### PR TITLE
[PW-2716] Update or create statedata for token

### DIFF
--- a/src/Service/PaymentStateDataService.php
+++ b/src/Service/PaymentStateDataService.php
@@ -83,17 +83,14 @@ class PaymentStateDataService
 
         if ($stateData) {
             $fields['id'] = $stateData->getId();
-            $this->paymentStateDataRepository->update(
-                [$fields],
-                \Shopware\Core\Framework\Context::createDefaultContext()
-            );
-        } else {
-            $this->paymentStateDataRepository->create(
-                [$fields],
-                \Shopware\Core\Framework\Context::createDefaultContext()
-            );
         }
+
+        $this->paymentStateDataRepository->upsert(
+            [$fields],
+            \Shopware\Core\Framework\Context::createDefaultContext()
+        );
     }
+
 
     /**
      * @param string $contextToken

--- a/src/Service/PaymentStateDataService.php
+++ b/src/Service/PaymentStateDataService.php
@@ -79,20 +79,28 @@ class PaymentStateDataService
 
         $fields['token'] = $contextToken;
         $fields['statedata'] = json_encode($stateDataArray);
+        $stateData = $this->getPaymentStateDataFromContextToken($contextToken);
 
-        $this->cleanTokenStateData($contextToken);
+        if ($stateData) {
+            $fields['id'] = $stateData->getId();
+            $this->paymentStateDataRepository->update(
+                [$fields],
+                \Shopware\Core\Framework\Context::createDefaultContext()
+            );
+        } else {
+            $this->paymentStateDataRepository->create(
+                [$fields],
+                \Shopware\Core\Framework\Context::createDefaultContext()
+            );
+        }
 
-        $this->paymentStateDataRepository->create(
-            [$fields],
-            \Shopware\Core\Framework\Context::createDefaultContext()
-        );
     }
 
     /**
      * @param string $contextToken
      * @return string
      */
-    public function getPaymentStateDataFromContextToken(string $contextToken): PaymentStateDataEntity
+    public function getPaymentStateDataFromContextToken(string $contextToken):? PaymentStateDataEntity
     {
         $stateDataRow = $this->paymentStateDataRepository->search(
             (new Criteria())->addFilter(new EqualsFilter('token', $contextToken)),
@@ -100,26 +108,5 @@ class PaymentStateDataService
         )->first();
 
         return $stateDataRow;
-    }
-
-    /**
-     * @param string $contextToken
-     */
-    private function cleanTokenStateData(string $contextToken)
-    {
-
-        $stateDataRows = $this->paymentStateDataRepository->searchIds(
-            (new Criteria())->addFilter(new EqualsFilter('token', $contextToken)),
-            Context::createDefaultContext()
-        );
-
-        $ids = $stateDataRows->getIds();
-        if ($ids) {
-            $idsToDelete = [];
-            foreach ($ids as $id) {
-                $idsToDelete[] = ['id' => $id];
-            }
-            $this->paymentStateDataRepository->delete($idsToDelete, Context::createDefaultContext());
-        }
     }
 }

--- a/src/Service/PaymentStateDataService.php
+++ b/src/Service/PaymentStateDataService.php
@@ -93,7 +93,6 @@ class PaymentStateDataService
                 \Shopware\Core\Framework\Context::createDefaultContext()
             );
         }
-
     }
 
     /**

--- a/src/Service/PaymentStateDataService.php
+++ b/src/Service/PaymentStateDataService.php
@@ -80,6 +80,8 @@ class PaymentStateDataService
         $fields['token'] = $contextToken;
         $fields['statedata'] = json_encode($stateDataArray);
 
+        $this->cleanTokenStateData($contextToken);
+
         $this->paymentStateDataRepository->create(
             [$fields],
             \Shopware\Core\Framework\Context::createDefaultContext()
@@ -98,5 +100,26 @@ class PaymentStateDataService
         )->first();
 
         return $stateDataRow;
+    }
+
+    /**
+     * @param string $contextToken
+     */
+    private function cleanTokenStateData(string $contextToken)
+    {
+
+        $stateDataRows = $this->paymentStateDataRepository->searchIds(
+            (new Criteria())->addFilter(new EqualsFilter('token', $contextToken)),
+            Context::createDefaultContext()
+        );
+
+        $ids = $stateDataRows->getIds();
+        if ($ids) {
+            $idsToDelete = [];
+            foreach ($ids as $id) {
+                $idsToDelete[] = ['id' => $id];
+            }
+            $this->paymentStateDataRepository->delete($idsToDelete, Context::createDefaultContext());
+        }
     }
 }


### PR DESCRIPTION
## Summary
This modification updates the state data record related to the context token in order to keep only one record.

## Tested scenarios
Generating a new statedata updates the PaymentStateData table for that token.
Generating a new statedata creates a new record if the token is not present.


**Fixed issue**:  PW-2716
