### PR TITLE
[PW-2741] Ajax payments call from checkout

### DIFF
--- a/src/Controller/SalesChannelApiController.php
+++ b/src/Controller/SalesChannelApiController.php
@@ -140,7 +140,7 @@ class SalesChannelApiController extends AbstractController
      * @param SalesChannelContext $context
      * @return JsonResponse
      */
-    public function payment(SalesChannelContext $context): JsonResponse
+    public function getPaymentStatus(SalesChannelContext $context): JsonResponse
     {
         return new JsonResponse(['aloha']);
     }

--- a/src/Controller/SalesChannelApiController.php
+++ b/src/Controller/SalesChannelApiController.php
@@ -128,4 +128,20 @@ class SalesChannelApiController extends AbstractController
     {
         return new JsonResponse($this->paymentDetailsService->doPaymentDetails($context));
     }
+
+    /**
+     * @RouteScope(scopes={"sales-channel-api"})
+     * @Route(
+     *     "/sales-channel-api/v1/adyen/payment",
+     *     name="sales-channel-api.action.adyen.payment",
+     *     methods={"POST"}
+     * )
+     *
+     * @param SalesChannelContext $context
+     * @return JsonResponse
+     */
+    public function payment(SalesChannelContext $context): JsonResponse
+    {
+        return new JsonResponse(['aloha']);
+    }
 }

--- a/src/Controller/SalesChannelApiController.php
+++ b/src/Controller/SalesChannelApiController.php
@@ -132,9 +132,9 @@ class SalesChannelApiController extends AbstractController
     /**
      * @RouteScope(scopes={"sales-channel-api"})
      * @Route(
-     *     "/sales-channel-api/v1/adyen/payment",
-     *     name="sales-channel-api.action.adyen.payment",
-     *     methods={"POST"}
+     *     "/sales-channel-api/v1/adyen/payment-status",
+     *     name="sales-channel-api.action.adyen.payment-status",
+     *     methods={"GET"}
      * )
      *
      * @param SalesChannelContext $context

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -115,7 +115,6 @@ class PaymentResponseHandler
             case 'IdentifyShopper':
             case 'ChallengeShopper':
                 // Store response for cart temporarily until the payment is done
-            $response;
                 $this->paymentResponseService->insertPaymentResponse(
                     $response,
                     $transaction->getOrder()->getOrderNumber(),

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -115,7 +115,12 @@ class PaymentResponseHandler
             case 'IdentifyShopper':
             case 'ChallengeShopper':
                 // Store response for cart temporarily until the payment is done
-                $this->paymentResponseService->insertPaymentResponse($response);
+            $response;
+                $this->paymentResponseService->insertPaymentResponse(
+                    $response,
+                    $transaction->getOrder()->getOrderNumber(),
+                    $salesChannelContext->getToken()
+                );
 
                 //TODO
                 return new RedirectResponse('');

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -120,9 +120,7 @@ class PaymentResponseHandler
                     $transaction->getOrder()->getOrderNumber(),
                     $salesChannelContext->getToken()
                 );
-
-                //TODO
-                return new RedirectResponse('');
+                return new RedirectResponse('responseUrl');
                 break;
             case 'Received':
             case 'PresentToShopper':

--- a/src/Migration/Migration1595336256AdyenPaymentResponse.php
+++ b/src/Migration/Migration1595336256AdyenPaymentResponse.php
@@ -22,6 +22,8 @@ class Migration1595336256AdyenPaymentResponse extends MigrationStep
                 `sales_channel_api_context_token` VARCHAR(255) NOT NULL,
                 `result_code` VARCHAR(255) NOT NULL,
                 `response` TEXT,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 SQL

--- a/src/Migration/Migration1595336256AdyenPaymentResponse.php
+++ b/src/Migration/Migration1595336256AdyenPaymentResponse.php
@@ -5,7 +5,7 @@ namespace Adyen\Shopware\Migration;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Migration\MigrationStep;
 
-class Migration1595336256PaymentResponse extends MigrationStep
+class Migration1595336256AdyenPaymentResponse extends MigrationStep
 {
     public function getCreationTimestamp(): int
     {

--- a/src/Resources/app/storefront/src/checkout/checkout.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/checkout.plugin.js
@@ -1,10 +1,10 @@
 import Plugin from 'src/plugin-system/plugin.class';
 
+/* global adyenCheckoutConfiguration, AdyenCheckout */
+/* eslint-disable no-unused-vars */
 export default class CheckoutPlugin extends Plugin {
 
     init() {
-        /* global adyenCheckoutConfiguration, AdyenCheckout */
-        /* eslint-disable no-unused-vars */
 
         const formattedHandlerIdentifier = 'handler_adyen_cardspaymentmethodhandler';
 

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -1,0 +1,55 @@
+import Plugin from 'src/plugin-system/plugin.class';
+import DomAccess from 'src/helper/dom-access.helper';
+import StoreApiClient from 'src/service/store-api-client.service';
+import FormSerializeUtil from 'src/utility/form/form-serialize.util';
+import ElementLoadingIndicatorUtil from 'src/utility/loading-indicator/element-loading-indicator.util';
+
+/* global adyenCheckoutOptions */
+export default class ConfirmOrderPlugin extends Plugin {
+
+    init() {
+        const confirmOrderForm = DomAccess.querySelector(document, '#confirmOrderForm');
+        confirmOrderForm.addEventListener('submit', this.confirmOrder.bind(this));
+    }
+
+    confirmOrder(event) {
+        event.preventDefault();
+        const form = event.target;
+        if (!form.checkValidity()) {
+            return;
+        }
+
+        this._client = new StoreApiClient();
+        const formData = FormSerializeUtil.serialize(form);
+
+        ElementLoadingIndicatorUtil.create(document.body);
+
+        const orderId = this.options.orderId;
+        const request = new XMLHttpRequest();
+        let callback = null;
+        if (orderId !== null) {
+            formData.set('orderId', orderId);
+            request.open('POST', '/sales-channel-api/v1/adyen/payment');
+            callback = this.afterSetPayment.bind(this);
+        } else {
+            request.open('POST', this.options.checkoutOrderUrl);
+            callback = this.afterCreateOrder.bind(this);
+        }
+        request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+        request.setRequestHeader('sw-language-id', adyenCheckoutOptions.languageId);
+        this._client._sendRequest(request, formData, callback);
+    }
+
+    afterCreateOrder(response) {
+
+    }
+
+    afterSetPayment(response) {
+
+    }
+
+    afterPayOrder(response) {
+
+    }
+
+}

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -14,7 +14,7 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     confirmOrder(event) {
-        if (!!adyenCheckoutOptions && !!adyenCheckoutOptions.paymentUrl && adyenCheckoutOptions.checkoutOrderUrl) {
+        if (!!adyenCheckoutOptions && !!adyenCheckoutOptions.paymentStatusUrl && adyenCheckoutOptions.checkoutOrderUrl) {
         event.preventDefault();
         const form = event.target;
         if (!form.checkValidity()) {
@@ -31,7 +31,7 @@ export default class ConfirmOrderPlugin extends Plugin {
         let callback = null;
         if (typeof(orderId) !== 'undefined' && orderId !== null) { //Only used if the order is being edited
             formData.set('orderId', orderId);
-            request.open('POST', adyenCheckoutOptions.paymentUrl);
+            request.open('POST', ''); //TODO define URL for order edit flow
             callback = this.afterSetPayment.bind(this);
         } else {
             request.open('POST', adyenCheckoutOptions.checkoutOrderUrl);
@@ -46,7 +46,7 @@ export default class ConfirmOrderPlugin extends Plugin {
     afterCreateOrder(response) {
         try {
             const order = JSON.parse(response);
-        } catch () {
+        } catch (error) {
             // Response is not a valid JSON
             // TODO error handling
             return;

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -5,6 +5,7 @@ import FormSerializeUtil from 'src/utility/form/form-serialize.util';
 import ElementLoadingIndicatorUtil from 'src/utility/loading-indicator/element-loading-indicator.util';
 
 /* global adyenCheckoutOptions */
+/* eslint-disable no-unused-vars */
 export default class ConfirmOrderPlugin extends Plugin {
 
     init() {

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -14,6 +14,7 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     confirmOrder(event) {
+        if (!!adyenCheckoutOptions && !!adyenCheckoutOptions.paymentUrl && adyenCheckoutOptions.checkoutOrderUrl) {
         event.preventDefault();
         const form = event.target;
         if (!form.checkValidity()) {

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -28,12 +28,12 @@ export default class ConfirmOrderPlugin extends Plugin {
         const orderId = this.options.orderId;
         const request = new XMLHttpRequest();
         let callback = null;
-        if (orderId !== null) {
+        if (typeof(orderId) !== 'undefined' && orderId !== null) { //Only used if the order is being edited
             formData.set('orderId', orderId);
-            request.open('POST', adyenCheckoutOptions.url);
+            request.open('POST', adyenCheckoutOptions.paymentUrl);
             callback = this.afterSetPayment.bind(this);
         } else {
-            request.open('POST', this.options.checkoutOrderUrl);
+            request.open('POST', adyenCheckoutOptions.checkoutOrderUrl);
             callback = this.afterCreateOrder.bind(this);
         }
         request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -42,7 +42,15 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     afterCreateOrder(response) {
+        const order = JSON.parse(response);
+        const orderId = order.data.id;
+        const params = {};
 
+        this._client.post(
+            `${adyenCheckoutOptions.checkoutOrderUrl}/${orderId}/pay`,
+            JSON.stringify(params),
+            this.afterPayOrder.bind(this)
+        );
     }
 
     afterSetPayment(response) {

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -40,6 +40,7 @@ export default class ConfirmOrderPlugin extends Plugin {
         request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
         request.setRequestHeader('sw-language-id', adyenCheckoutOptions.languageId);
         this._client._sendRequest(request, formData, callback);
+        }
     }
 
     afterCreateOrder(response) {

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -44,7 +44,13 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     afterCreateOrder(response) {
-        const order = JSON.parse(response);
+        try {
+            const order = JSON.parse(response);
+        } catch () {
+            // Response is not a valid JSON
+            // TODO error handling
+            return;
+        }
         const orderId = order.data.id;
         const params = {};
 

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -30,7 +30,7 @@ export default class ConfirmOrderPlugin extends Plugin {
         let callback = null;
         if (orderId !== null) {
             formData.set('orderId', orderId);
-            request.open('POST', '/sales-channel-api/v1/adyen/payment');
+            request.open('POST', adyenCheckoutOptions.url);
             callback = this.afterSetPayment.bind(this);
         } else {
             request.open('POST', this.options.checkoutOrderUrl);

--- a/src/Resources/app/storefront/src/main.js
+++ b/src/Resources/app/storefront/src/main.js
@@ -1,6 +1,8 @@
 // Import all necessary Storefront plugins and scss files
 import CheckoutPlugin from './checkout/checkout.plugin';
+import ConfirmOrderPlugin from './checkout/confirm-order.plugin';
 
 // Register them via the existing PluginManager
 const PluginManager = window.PluginManager;
 PluginManager.register('CheckoutPlugin', CheckoutPlugin, '[data-adyen-payment]');
+PluginManager.register('ConfirmOrderPlugin', ConfirmOrderPlugin, '[data-adyen-payment]');

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -100,7 +100,7 @@
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
         </service>
         <!--Event subscribers-->
-        <service id="Adyen\Shopware\Subscriber\SalesChannelContextSwitchEventSubscriber">
+        <service id="Adyen\Shopware\Subscriber\CheckoutSubscriber">
             <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -99,9 +99,11 @@
         <service id="Adyen\Shopware\Handlers\PaymentResponseHandler" autowire="true">
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
         </service>
+
         <!--Event subscribers-->
         <service id="Adyen\Shopware\Subscriber\CheckoutSubscriber">
             <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
+            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -9,8 +9,8 @@
              data-payment-url="{{ adyenFrontendData.paymentUrl }}"
              data-checkout-order-url="{{ adyenFrontendData.checkoutOrderUrl }}">
         </div>
+        <script>
+            var adyenCheckoutOptions = document.querySelector('#adyen-checkout-options').dataset;
+        </script>
     {% endif %}
-    <script>
-        var adyenCheckoutOptions = document.querySelector('#adyen-checkout-options').dataset;
-    </script>
 {% endblock %}

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -3,10 +3,11 @@
 {% block page_checkout_confirm_payment_inner %}
     {{ parent() }}
     {% set adyenFrontendData = page.extensions[constant('Adyen\\Shopware\\Subscriber\\CheckoutSubscriber::ADYEN_DATA_EXTENSION_ID')] %}
-    {% if adyenFrontendData and adyenFrontendData.Url %}
+    {% if adyenFrontendData and adyenFrontendData.paymentUrl %}
         <div id="adyen-checkout-options"
              data-language-id="{{ adyenFrontendData.languageId }}"
-             data-url="{{ adyenFrontendData.Url }}">
+             data-payment-url="{{ adyenFrontendData.paymentUrl }}"
+             data-checkout-order-url="{{ adyenFrontendData.checkoutOrderUrl }}">
         </div>
     {% endif %}
     <script>

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -5,7 +5,8 @@
     {% set adyenFrontendData = page.extensions[constant('Adyen\\Shopware\\Subscriber\\CheckoutSubscriber::ADYEN_DATA_EXTENSION_ID')] %}
     {% if adyenFrontendData and adyenFrontendData.Url %}
         <div id="adyen-checkout-options"
-             data-language-id="{{ adyenFrontendData.languageId }}">
+             data-language-id="{{ adyenFrontendData.languageId }}"
+             data-url="{{ adyenFrontendData.Url }}">
         </div>
     {% endif %}
     <script>

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -1,0 +1,14 @@
+{% sw_extends '@Storefront/storefront/page/checkout/confirm/confirm-payment.html.twig' %}
+
+{% block page_checkout_confirm_payment_inner %}
+    {{ parent() }}
+    {% set adyenFrontendData = page.extensions[constant('Adyen\\Shopware\\Subscriber\\CheckoutSubscriber::ADYEN_DATA_EXTENSION_ID')] %}
+    {% if adyenFrontendData and adyenFrontendData.Url %}
+        <div id="adyen-checkout-options"
+             data-language-id="{{ adyenFrontendData.languageId }}">
+        </div>
+    {% endif %}
+    <script>
+        var adyenCheckoutOptions = document.querySelector('#adyen-checkout-options').dataset;
+    </script>
+{% endblock %}

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -3,10 +3,10 @@
 {% block page_checkout_confirm_payment_inner %}
     {{ parent() }}
     {% set adyenFrontendData = page.extensions[constant('Adyen\\Shopware\\Subscriber\\CheckoutSubscriber::ADYEN_DATA_EXTENSION_ID')] %}
-    {% if adyenFrontendData and adyenFrontendData.paymentUrl %}
+    {% if adyenFrontendData and adyenFrontendData.paymentStatusUrl %}
         <div id="adyen-checkout-options"
              data-language-id="{{ adyenFrontendData.languageId }}"
-             data-payment-url="{{ adyenFrontendData.paymentUrl }}"
+             data-payment-status-url="{{ adyenFrontendData.paymentStatusUrl }}"
              data-checkout-order-url="{{ adyenFrontendData.checkoutOrderUrl }}">
         </div>
         <script>

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -50,14 +50,39 @@ class PaymentResponseService
         $this->orderRepository = $orderRepository;
     }
 
-    public function getWithOrderNumber(string $orderNumber) : PaymentResponseEntity
+    public function getWithOrderNumber(string $orderNumber):? PaymentResponseEntity
     {
         return $this->repository
             ->search(
                 (new Criteria())
-                    ->addFilter(new EqualsFilter('order_number', $orderNumber)),
+                    ->addFilter(new EqualsFilter('orderNumber', $orderNumber)),
                 Context::createDefaultContext()
             )
             ->first();
+    }
+
+    public function insertPaymentResponse(
+        array $paymentResponse,
+        string $orderNumber,
+        string $salesChannelContextToken
+    ): void {
+        if (empty($paymentResponse)) {
+            //TODO log error
+            exit;
+        }
+
+        $storedPaymentResponse = $this->getWithOrderNumber($orderNumber);
+        if ($storedPaymentResponse) {
+            $fields['id'] = $storedPaymentResponse->getId();
+        }
+
+        $fields['token'] = $salesChannelContextToken;
+        $fields['resultCode'] = $paymentResponse["resultCode"];
+        $fields['orderNumber'] = $orderNumber;
+
+        $this->repository->upsert(
+            [$fields],
+            Context::createDefaultContext()
+        );
     }
 }

--- a/src/Subscriber/CheckoutSubscriber.php
+++ b/src/Subscriber/CheckoutSubscriber.php
@@ -90,6 +90,7 @@ class CheckoutSubscriber implements EventSubscriberInterface
             self::ADYEN_DATA_EXTENSION_ID,
             new ArrayEntity(
                 [
+                    'Url' => '/sales-channel-api/v1/adyen/payment',
                     'languageId' => $salesChannelContext->getContext()->getLanguageId()
                 ]
             )

--- a/src/Subscriber/CheckoutSubscriber.php
+++ b/src/Subscriber/CheckoutSubscriber.php
@@ -98,8 +98,14 @@ class CheckoutSubscriber implements EventSubscriberInterface
             self::ADYEN_DATA_EXTENSION_ID,
             new ArrayEntity(
                 [
-                    'paymentUrl' => $this->router->generate('sales-channel-api.action.adyen.payment', ['version' => 2]),
-                    'checkoutOrderUrl' => $this->router->generate('sales-channel-api.checkout.order.create', ['version' => 2]),
+                    'paymentUrl' => $this->router->generate(
+                        'sales-channel-api.action.adyen.payment',
+                        ['version' => 2]
+                    ),
+                    'checkoutOrderUrl' => $this->router->generate(
+                        'sales-channel-api.checkout.order.create',
+                        ['version' => 2]
+                    ),
                     'languageId' => $salesChannelContext->getContext()->getLanguageId()
                 ]
             )

--- a/src/Subscriber/CheckoutSubscriber.php
+++ b/src/Subscriber/CheckoutSubscriber.php
@@ -98,7 +98,7 @@ class CheckoutSubscriber implements EventSubscriberInterface
             self::ADYEN_DATA_EXTENSION_ID,
             new ArrayEntity(
                 [
-                    'paymentUrl' => $this->router->generate(
+                    'paymentStatusUrl' => $this->router->generate(
                         'sales-channel-api.action.adyen.payment',
                         ['version' => 2]
                     ),

--- a/src/Subscriber/CheckoutSubscriber.php
+++ b/src/Subscriber/CheckoutSubscriber.php
@@ -86,7 +86,9 @@ class CheckoutSubscriber implements EventSubscriberInterface
     {
         $salesChannelContext = $event->getSalesChannelContext();
         $page = $event->getPage();
-        $page->addExtension(self::ADYEN_DATA_EXTENSION_ID, new ArrayEntity(
+        $page->addExtension(
+            self::ADYEN_DATA_EXTENSION_ID,
+            new ArrayEntity(
                 [
                     'languageId' => $salesChannelContext->getContext()->getLanguageId()
                 ]

--- a/src/Subscriber/CheckoutSubscriber.php
+++ b/src/Subscriber/CheckoutSubscriber.php
@@ -29,6 +29,7 @@ use Shopware\Core\System\SalesChannel\Event\SalesChannelContextSwitchEvent;
 use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoadedEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Adyen\Shopware\Service\PaymentStateDataService;
+use Symfony\Component\Routing\RouterInterface;
 
 class CheckoutSubscriber implements EventSubscriberInterface
 {
@@ -41,13 +42,20 @@ class CheckoutSubscriber implements EventSubscriberInterface
     private $paymentStateDataService;
 
     /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
      * CheckoutSubscriber constructor.
      * @param PaymentStateDataService $paymentStateDataService
      */
     public function __construct(
-        PaymentStateDataService $paymentStateDataService
+        PaymentStateDataService $paymentStateDataService,
+        RouterInterface $router
     ) {
         $this->paymentStateDataService = $paymentStateDataService;
+        $this->router = $router;
     }
 
     /**
@@ -90,7 +98,8 @@ class CheckoutSubscriber implements EventSubscriberInterface
             self::ADYEN_DATA_EXTENSION_ID,
             new ArrayEntity(
                 [
-                    'Url' => '/sales-channel-api/v1/adyen/payment',
+                    'paymentUrl' => $this->router->generate('sales-channel-api.action.adyen.payment', ['version' => 2]),
+                    'checkoutOrderUrl' => $this->router->generate('sales-channel-api.checkout.order.create', ['version' => 2]),
                     'languageId' => $salesChannelContext->getContext()->getLanguageId()
                 ]
             )

--- a/src/Subscriber/CheckoutSubscriber.php
+++ b/src/Subscriber/CheckoutSubscriber.php
@@ -99,7 +99,7 @@ class CheckoutSubscriber implements EventSubscriberInterface
             new ArrayEntity(
                 [
                     'paymentStatusUrl' => $this->router->generate(
-                        'sales-channel-api.action.adyen.payment',
+                        'sales-channel-api.action.adyen.payment-status',
                         ['version' => 2]
                     ),
                     'checkoutOrderUrl' => $this->router->generate(


### PR DESCRIPTION
## Summary
Payment API endpoint.
Confirm order JS plugin to make Ajax payment call to the backend.
Renamed migration class for consistency.
Renamed event subscriber class to be generic.

## Tested scenarios
NA

**Fixed issue**:  [PW-2741]
