### PR TITLE
[PW-2808] Tagging AdyenAccountOrderController for public access

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -165,6 +165,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Payment\SalesChannel\HandlePaymentMethodRoute"/>
             <argument type="service" id="event_dispatcher"/>
+            <tag name="controller.service_arguments"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
## Summary
The AdyenAccountOrderController decorator is a public controller and needed the `controller.service_arguments` tag.

## Tested scenarios
Retry of failed payment

**Fixed issue**:  PW-2808