### PR TITLE
[PW-2813] Payment status still in progress after wrong 3DS2 payment

### DIFF
--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -257,21 +257,14 @@ class CardsPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
         Request $request,
         SalesChannelContext $salesChannelContext
     ): void {
-        //TODO this one will only handle 3DS2 but for 3DS1 we need the processResult
-        $this->paymentResponseHandler->finalize(
-            $transaction,
-            $salesChannelContext
-        );
-        /*$context = $salesChannelContext->getContext();
-        $this->orderTransactionStateHandler->paid($transaction->getOrderTransaction()->getId(), $context);*/
-        /*try {
+        try {
             $this->resultHandler->processResult($transaction, $request, $salesChannelContext);
         } catch (PaymentException $exception) {
             throw new AsyncPaymentFinalizeException(
-        $transaction->getOrderTransaction()->getId(),
-        $exception->getMessage()
-        );
-        }*/
+                $transaction->getOrderTransaction()->getId(),
+                $exception->getMessage()
+            );
+        }
     }
 
     //TODO move to external object or outsource to lib

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -278,32 +278,4 @@ class PaymentResponseHandler
                     ];
         }
     }
-
-
-    /**
-     * @param AsyncPaymentTransactionStruct $transaction
-     * @param SalesChannelContext $salesChannelContext
-     */
-    public function finalize(
-        AsyncPaymentTransactionStruct $transaction,
-        SalesChannelContext $salesChannelContext
-    ): void {
-        $orderTransactionId = $transaction->getOrderTransaction()->getId();
-        $context = $salesChannelContext->getContext();
-
-        $this->logger->debug($transaction->getOrderTransaction()->getCustomFields());
-        $resultCode = '';
-
-        switch ($resultCode) {
-            case self::AUTHORISED:
-                $this->transactionStateHandler->paid($orderTransactionId, $context);
-                break;
-            case self::REFUSED:
-            case self::ERROR:
-                $this->transactionStateHandler->fail($orderTransactionId, $context);
-                break;
-            default:
-                //TODO log unhandled result code
-        }
-    }
 }

--- a/src/Handlers/PaymentResponseHandlerResult.php
+++ b/src/Handlers/PaymentResponseHandlerResult.php
@@ -2,12 +2,53 @@
 
 namespace Adyen\Shopware\Handlers;
 
+use Adyen\Shopware\Entity\PaymentResponse\PaymentResponseEntity;
+
 class PaymentResponseHandlerResult
 {
     private $resultCode;
     private $pspReference;
     private $action;
     private $additionalData;
+
+    /**
+     * @param PaymentResponseEntity $paymentResponse
+     */
+    public function createFromPaymentResponse($paymentResponse) {
+
+        // Set result code
+        $this->setResultCode($paymentResponse->getResultCode());
+
+        $response = $paymentResponse->getResponse();
+
+        // If response is empty return the result only with the result code
+        if (empty($response)) {
+            return $this;
+        }
+
+        $response = json_decode($response, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            //TODO error handling
+        }
+
+        // Set pspReference if exists
+        if (!empty($response['pspReference'])) {
+            $this->setPspReference($response['pspReference']);
+        }
+
+        // Set action if exists
+        if (!empty($response['action'])) {
+            $this->setAction($response['action']);
+        }
+
+        // Set additional data if exists
+        if (!empty($response['additionalData'])) {
+            $this->setAdditionalData($response['additionalData']);
+        }
+
+        return $this;
+    }
 
     /**
      * @return null|string

--- a/src/Handlers/PaymentResponseHandlerResult.php
+++ b/src/Handlers/PaymentResponseHandlerResult.php
@@ -14,8 +14,8 @@ class PaymentResponseHandlerResult
     /**
      * @param PaymentResponseEntity $paymentResponse
      */
-    public function createFromPaymentResponse($paymentResponse) {
-
+    public function createFromPaymentResponse($paymentResponse)
+    {
         // Set result code
         $this->setResultCode($paymentResponse->getResultCode());
 

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 /**
  *                       ######
  *                       ######
@@ -102,7 +103,6 @@ class ResultHandler
         Request $request,
         SalesChannelContext $salesChannelContext
     ) {
-
         // Retrieve paymentResponse and if it is
         $orderId = $transaction->getOrderTransaction()->getOrderId();
         $paymentResponse = $this->paymentResponseService->getWithOrderId($orderId, $salesChannelContext->getToken());
@@ -111,7 +111,6 @@ class ResultHandler
         $result = $this->paymentResponseHandlerResult->createFromPaymentResponse($paymentResponse);
 
         if ('RedirectShopper' === $result->getResultCode()) {
-
             // Validate 3DS1 Post parameters
             // Get MD and PaRes to be validated
             $md = $request->request->get('MD');


### PR DESCRIPTION
## Summary
Fix payment status still in progress after refused payment
 - Remove unused paymentResponseHandler->finalize()
 - Add PaymentResponseHandlerResult->createFromPaymentResponse() to create
result from payment response easier
 - Validate 3DS1 MD and PaRes when finalize transaction

## Tested scenarios
3DS1 success/refused
3DS2 success/refused
