### PR TITLE
[PW-2810] Hide PM contents by default

### DIFF
--- a/src/Resources/app/storefront/src/checkout/checkout.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/checkout.plugin.js
@@ -27,13 +27,12 @@ export default class CheckoutPlugin extends Plugin {
                         location.href = window.returnUrl;
                     }
 
-                    try{
+                    try {
                         window.adyenCheckout
                             .createFromAction(paymentActionResponse.action)
                             .mount('[data-adyen-payment-action-container]');
                         $('[data-adyen-payment-action-modal]').modal({show: true});
-                    }
-                    catch (e) {
+                    } catch (e) {
                         console.log(e);
                     }
                 }
@@ -72,12 +71,16 @@ export default class CheckoutPlugin extends Plugin {
                 return;
             }
 
+            //Show the payment method's contents if it's selected by default
+            if ($('[data-payment-method-id]').data('payment-method-id') == $('[name=paymentMethodId]:checked').val()) {
+                $('[data-payment-method-id]').show();
+            }
+
             //Hide other payment method's contents when selecting an option
             $('[name=paymentMethodId]').on("change", function () {
-                $('.payment-method-container-div').hide();
+                $('.adyen-payment-method-container-div').hide();
                 $('[data-payment-method-id="' + $(this).val() + '"]').show();
             });
-
 
             /*Use the storedPaymentMethod object and the custom onChange function as the configuration object together*/
             var configuration = Object.assign(paymentMethod, {

--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,0 +1,3 @@
+.adyen-payment-method-container-div{
+    display: none;
+}

--- a/src/Resources/views/storefront/component/payment/payment-fields.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-fields.html.twig
@@ -46,7 +46,7 @@
                                             {% endblock %}
                                         </label>
                                         {% if payment.formattedHandlerIdentifier == "handler_adyen_cardspaymentmethodhandler" %}
-                                            <div class="payment-method-container-div" data-payment-method-id="{{ payment.id }}" data-payment-method="handler_adyen_cardspaymentmethodhandler">
+                                            <div class="adyen-payment-method-container-div" data-payment-method-id="{{ payment.id }}" data-payment-method="handler_adyen_cardspaymentmethodhandler">
                                                 <div data-adyen-payment-container></div>
                                             </div>
                                         {% endif %}


### PR DESCRIPTION
## Summary
If an Adyen PM is not selected when opening the methods modal it's contents should be hidden until it is selected.

## Tested scenarios
Open PM modal when an Adyen and non-Adyen PM is selected.

**Fixed issue**:  PW-2810