### PR TITLE
[PW-2812] Hide PM contents when there's state.data already stored for it

### DIFF
--- a/src/Resources/app/storefront/src/checkout/checkout.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/checkout.plugin.js
@@ -13,6 +13,9 @@ export default class CheckoutPlugin extends Plugin {
             'scheme': formattedHandlerIdentifier
         };
 
+        //PMs that should show an 'Update Details' button if there's already a state.data for that PM stored for this context
+        const updatablePaymentMethods = ['scheme'];
+
         this.client = new StoreApiClient();
 
         let handleOnAdditionalDetails = function (state) {
@@ -106,6 +109,13 @@ export default class CheckoutPlugin extends Plugin {
                 console.log(err);
             }
 
+            //Hiding component contents if there's already state.data saved for this PM
+            if (updatablePaymentMethods.includes(paymentMethod.type) && adyenCheckoutOptions.statedataPaymentMethod === paymentMethod.type) {
+                console.log('includes');
+                $('[data-adyen-payment-container]').hide();
+                $('[data-adyen-update-payment-details]').show();
+            }
+
 
         });
 
@@ -114,6 +124,14 @@ export default class CheckoutPlugin extends Plugin {
          */
         function resetFields() {
             data = "";
+        }
+
+        /**
+         * Shows the payment method component in order to update the previously saved details
+         */
+        window.showPaymentMethodDetails = function () {
+            $('[data-adyen-payment-container]').show();
+            $('[data-adyen-update-payment-details]').hide();
         }
 
         /* eslint-enable no-unused-vars */

--- a/src/Resources/app/storefront/src/checkout/checkout.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/checkout.plugin.js
@@ -111,7 +111,6 @@ export default class CheckoutPlugin extends Plugin {
 
             //Hiding component contents if there's already state.data saved for this PM
             if (updatablePaymentMethods.includes(paymentMethod.type) && adyenCheckoutOptions.statedataPaymentMethod === paymentMethod.type) {
-                console.log('includes');
                 $('[data-adyen-payment-container]').hide();
                 $('[data-adyen-update-payment-details]').show();
             }

--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,3 +1,3 @@
-.adyen-payment-method-container-div{
+.adyen-payment-method-container-div, .adyen-update-payment-details{
     display: none;
 }

--- a/src/Resources/snippet/en_GB/messages.en-GB.json
+++ b/src/Resources/snippet/en_GB/messages.en-GB.json
@@ -1,0 +1,5 @@
+{
+  "adyen": {
+    "updateDetails": "Update payment details"
+  }
+}

--- a/src/Resources/views/storefront/component/payment/payment-fields.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-fields.html.twig
@@ -47,6 +47,9 @@
                                         </label>
                                         {% if payment.formattedHandlerIdentifier == "handler_adyen_cardspaymentmethodhandler" %}
                                             <div class="adyen-payment-method-container-div" data-payment-method-id="{{ payment.id }}" data-payment-method="handler_adyen_cardspaymentmethodhandler">
+                                                <div data-adyen-update-payment-details class="adyen-update-payment-details">
+                                                    <button type="button" class="btn btn-primary" onclick="window.showPaymentMethodDetails()">{{ "adyen.updateDetails"|trans }}</button>
+                                                </div>
                                                 <div data-adyen-payment-container></div>
                                             </div>
                                         {% endif %}

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -13,6 +13,7 @@
              data-payment-error-url="{{ adyenFrontendData.paymentErrorUrl }}"
              data-edit-payment-url="{{ adyenFrontendData.editPaymentUrl }}"
              data-order-id="{{ adyenFrontendData.orderId }}"
+             data-statedata-payment-method="{{ adyenFrontendData.stateDataPaymentMethod }}"
         >
         </div>
         <script>

--- a/src/Service/PaymentStateDataService.php
+++ b/src/Service/PaymentStateDataService.php
@@ -118,7 +118,7 @@ class PaymentStateDataService
         }
 
         $stateDataArray = json_decode($stateData->getStateData(), true);
-        if (!$stateDataArray['paymentMethod']['type']) {
+        if (empty($stateDataArray['paymentMethod']['type'])) {
             return null;
         }
 

--- a/src/Service/PaymentStateDataService.php
+++ b/src/Service/PaymentStateDataService.php
@@ -96,7 +96,7 @@ class PaymentStateDataService
      * @param string $contextToken
      * @return string
      */
-    public function getPaymentStateDataFromContextToken(string $contextToken):? PaymentStateDataEntity
+    public function getPaymentStateDataFromContextToken(string $contextToken): ?PaymentStateDataEntity
     {
         $stateDataRow = $this->paymentStateDataRepository->search(
             (new Criteria())->addFilter(new EqualsFilter('token', $contextToken)),
@@ -104,5 +104,24 @@ class PaymentStateDataService
         )->first();
 
         return $stateDataRow;
+    }
+
+    /**
+     * @param string $contextToken
+     * @return string|null
+     */
+    public function getPaymentMethodType(string $contextToken): ?string
+    {
+        $stateData = $this->getPaymentStateDataFromContextToken($contextToken);
+        if (!$stateData) {
+            return null;
+        }
+
+        $stateDataArray = json_decode($stateData->getStateData(), true);
+        if (!$stateDataArray['paymentMethod']['type']) {
+            return null;
+        }
+
+        return $stateDataArray['paymentMethod']['type'];
     }
 }

--- a/src/Service/PaymentStateDataService.php
+++ b/src/Service/PaymentStateDataService.php
@@ -113,7 +113,7 @@ class PaymentStateDataService
     public function getPaymentMethodType(string $contextToken): ?string
     {
         $stateData = $this->getPaymentStateDataFromContextToken($contextToken);
-        if (!$stateData) {
+        if (empty($stateData)) {
             return null;
         }
 

--- a/src/Service/PaymentStateDataService.php
+++ b/src/Service/PaymentStateDataService.php
@@ -122,6 +122,7 @@ class PaymentStateDataService
         }
 
         return $stateDataArray['paymentMethod']['type'];
+    }
 
     /**
      * @param PaymentStateDataEntity $stateData

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -140,6 +140,8 @@ class PaymentSubscriber implements EventSubscriberInterface
             $orderId = $page->getOrder()->getId();
         }
 
+        $stateDataPaymentMethod = $this->paymentStateDataService->getPaymentMethodType($salesChannelContext->getToken());
+
         $page->addExtension(
             self::ADYEN_DATA_EXTENSION_ID,
             new ArrayEntity(
@@ -180,7 +182,8 @@ class PaymentSubscriber implements EventSubscriberInterface
                     'paymentMethodsResponse' => json_encode(
                         $this->paymentMethodsService->getPaymentMethods($salesChannelContext)
                     ),
-                    'orderId' => $orderId
+                    'orderId' => $orderId,
+                    'stateDataPaymentMethod' => $stateDataPaymentMethod
                 ]
             )
         );

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -140,7 +140,9 @@ class PaymentSubscriber implements EventSubscriberInterface
             $orderId = $page->getOrder()->getId();
         }
 
-        $stateDataPaymentMethod = $this->paymentStateDataService->getPaymentMethodType($salesChannelContext->getToken());
+        $stateDataPaymentMethod = $this->paymentStateDataService->getPaymentMethodType(
+            $salesChannelContext->getToken()
+        );
 
         $page->addExtension(
             self::ADYEN_DATA_EXTENSION_ID,


### PR DESCRIPTION
## Summary
The payment methods modal can be opened after the state.data has been saved for a PM. If that PM is selected we want to provide feedback that the information can be updated instead of showing the form.

## Tested scenarios
Selecting Cards PM after a state.date has been saved

**Fixed issue**:  PW-2812
