### PR TITLE
[PW-2811] Add a loader state to the 3DS2 modal

### DIFF
--- a/src/Resources/app/storefront/src/scss/modal.scss
+++ b/src/Resources/app/storefront/src/scss/modal.scss
@@ -1,0 +1,43 @@
+/*!
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen plugin for Shopware 6
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ */
+
+#adyen-payment-action-modal .modal-dialog {
+  height: calc(100% - 3.5rem);
+
+  .modal-content {
+    height: 100%;
+  }
+}
+
+.adyen-payment-action-container.loader {
+  display: none;
+  left: 50%;
+  margin-left: -1rem;
+  margin-top: -1rem;
+  position: absolute;
+  top: 50%;
+
+  &:only-child {
+    display: block;
+  }
+}
+

--- a/src/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -2,11 +2,20 @@
 
 {% block base_footer %}
     {{ parent() }}
-    <div class="modal" tabindex="-1" role="dialog" data-adyen-payment-action-modal>
-        <div class="modal-dialog">
+    <div id="adyen-payment-action-modal"
+         class="modal"
+         tabindex="-1"
+         role="dialog"
+         data-adyen-payment-action-modal
+    >
+        <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-body">
-                    <div data-adyen-payment-action-container></div>
+                    <div data-adyen-payment-action-container>
+                        <div class="adyen-payment-action-container loader" role="status">
+                            <span class="sr-only">Loading...</span>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
After submitting the 3DS2 form, the modal was left there without any content and no status progress. Now it's pretty.

## Tested scenarios
<!-- Description of tested scenarios -->
Successful 3DS2 flow
