### PR TITLE
[PW-2820] Remove state.data after it has been used

### DIFF
--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -290,7 +290,6 @@ class CardsPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
         SalesChannelContext $salesChannelContext,
         AsyncPaymentTransactionStruct $transaction
     ) {
-
         //Get state.data using the context token
         $stateData = $this->paymentStateDataService->getPaymentStateDataFromContextToken(
             $salesChannelContext->getToken()

--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -290,13 +290,13 @@ class CardsPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
         SalesChannelContext $salesChannelContext,
         AsyncPaymentTransactionStruct $transaction
     ) {
-        //Get state.data using the context token
-        $request = json_decode(
-            $this->paymentStateDataService->getPaymentStateDataFromContextToken(
-                $salesChannelContext->getToken()
-            )->getStateData(),
-            true
+
+        $stateData = $this->paymentStateDataService->getPaymentStateDataFromContextToken(
+            $salesChannelContext->getToken()
         );
+
+        //Get state.data using the context token
+        $request = json_decode($stateData->getStateData(), true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new AsyncPaymentProcessException(
@@ -478,6 +478,9 @@ class CardsPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 
         // TODO add channel?
         $request['channel'] = 'web';
+
+        //Remove the used state.data
+        $this->paymentStateDataService->deletePaymentStateData($stateData);
 
         return $request;
     }

--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -291,11 +291,10 @@ class CardsPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
         AsyncPaymentTransactionStruct $transaction
     ) {
 
+        //Get state.data using the context token
         $stateData = $this->paymentStateDataService->getPaymentStateDataFromContextToken(
             $salesChannelContext->getToken()
         );
-
-        //Get state.data using the context token
         $request = json_decode($stateData->getStateData(), true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {

--- a/src/Service/PaymentStateDataService.php
+++ b/src/Service/PaymentStateDataService.php
@@ -105,4 +105,17 @@ class PaymentStateDataService
 
         return $stateDataRow;
     }
+
+    /**
+     * @param PaymentStateDataEntity $stateData
+     */
+    public function deletePaymentStateData(PaymentStateDataEntity $stateData): void
+    {
+        $this->paymentStateDataRepository->delete(
+            [
+                ['id' => $stateData->getId()],
+            ],
+            Context::createDefaultContext()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
After the payments request is built the plugin will delete the persisted state.data.

## Tested scenarios
Payment call removes the state.data after usage.

**Fixed issue**:  PW-2820
