### PR TITLE
Improve front-end reliability

### DIFF
--- a/src/Resources/app/storefront/src/checkout/checkout.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/checkout.plugin.js
@@ -62,7 +62,7 @@ export default class CheckoutPlugin extends Plugin {
         // Iterate through the payment methods list we got from the adyen checkout component
         paymentMethods.forEach(function (paymentMethod) {
             //  if the container doesn't exits don't try to render the component
-            var paymentMethodContainer = $('[data-payment-method="' + paymentMethodTypeHandlers[paymentMethod.type] + '"]');
+            var paymentMethodContainer = $('[data-adyen-payment-method="' + paymentMethodTypeHandlers[paymentMethod.type] + '"]');
 
             // container doesn't exist, something went wrong on the template side
             if (!paymentMethodContainer.length) {
@@ -75,14 +75,14 @@ export default class CheckoutPlugin extends Plugin {
             }
 
             //Show the payment method's contents if it's selected by default
-            if ($('[data-payment-method-id]').data('payment-method-id') == $('[name=paymentMethodId]:checked').val()) {
-                $('[data-payment-method-id]').show();
+            if ($('[data-adyen-payment-method-id]').data('adyen-payment-method-id') == $('[name=paymentMethodId]:checked').val()) {
+                $('[data-adyen-payment-method-id]').show();
             }
 
             //Hide other payment method's contents when selecting an option
             $('[name=paymentMethodId]').on("change", function () {
                 $('.adyen-payment-method-container-div').hide();
-                $('[data-payment-method-id="' + $(this).val() + '"]').show();
+                $('[data-adyen-payment-method-id="' + $(this).val() + '"]').show();
             });
 
             /*Use the storedPaymentMethod object and the custom onChange function as the configuration object together*/

--- a/src/Resources/views/storefront/component/payment/payment-fields.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-fields.html.twig
@@ -46,7 +46,10 @@
                                             {% endblock %}
                                         </label>
                                         {% if payment.formattedHandlerIdentifier == "handler_adyen_cardspaymentmethodhandler" %}
-                                            <div class="adyen-payment-method-container-div" data-payment-method-id="{{ payment.id }}" data-payment-method="handler_adyen_cardspaymentmethodhandler">
+                                            <div class="adyen-payment-method-container-div"
+                                                 data-adyen-payment-method-id="{{ payment.id }}"
+                                                 data-adyen-payment-method="handler_adyen_cardspaymentmethodhandler"
+                                            >
                                                 <div data-adyen-update-payment-details class="adyen-update-payment-details">
                                                     <button type="button" class="btn btn-primary" onclick="window.showPaymentMethodDetails()">{{ "adyen.updateDetails"|trans }}</button>
                                                 </div>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The plugin uses a generic data attribute to store essential information to work, like the payment method id. This can potentially conflict with other payment method providers, including native ones if they start looking for this attribute. This change includes a prefix for this with the name `adyen` so that conflicts are harder to happen.

## Tested scenarios
<!-- Description of tested scenarios -->
Successful 3DS2 payment

**Fixed issue**: PW-2826
