### PR TITLE
Fix 3DS2 modal in change order page

### DIFF
--- a/src/Resources/views/storefront/component/payment/payment-action-modal.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-action-modal.html.twig
@@ -1,0 +1,18 @@
+<div id="adyen-payment-action-modal"
+     class="modal"
+     tabindex="-1"
+     role="dialog"
+     data-adyen-payment-action-modal
+>
+    <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-body">
+                <div data-adyen-payment-action-container>
+                    <div class="adyen-payment-action-container loader" role="status">
+                        <span class="sr-only">{{ "adyen.loading"|trans }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Resources/views/storefront/page/account/order/index.html.twig
+++ b/src/Resources/views/storefront/page/account/order/index.html.twig
@@ -1,1 +1,6 @@
 {% sw_extends '@Storefront/storefront/page/account/order/index.html.twig' %}
+
+{% block base_footer %}
+    {{ parent() }}
+    {% include '@AdyenPayment/storefront/component/payment/payment-action-modal.html.twig' %}
+{% endblock %}

--- a/src/Resources/views/storefront/page/account/order/index.html.twig
+++ b/src/Resources/views/storefront/page/account/order/index.html.twig
@@ -1,16 +1,1 @@
 {% sw_extends '@Storefront/storefront/page/account/order/index.html.twig' %}
-
-{% block page_checkout_confirm_payment_inner %}
-    {{ parent() }}
-    {% set adyenFrontendData = page.extensions[constant('Adyen\\Shopware\\Subscriber\\PaymentSubscriber::ADYEN_DATA_EXTENSION_ID')] %}
-    {% if adyenFrontendData and adyenFrontendData.paymentStatusUrl %}
-        <div id="adyen-checkout-options"
-             data-language-id="{{ adyenFrontendData.languageId }}"
-             data-payment-status-url="{{ adyenFrontendData.paymentStatusUrl }}"
-             data-checkout-order-url="{{ adyenFrontendData.checkoutOrderUrl }}">
-        </div>
-        <script>
-            var adyenCheckoutOptions = document.querySelector('#adyen-checkout-options').dataset;
-        </script>
-    {% endif %}
-{% endblock %}

--- a/src/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -2,22 +2,5 @@
 
 {% block base_footer %}
     {{ parent() }}
-    <div id="adyen-payment-action-modal"
-         class="modal"
-         tabindex="-1"
-         role="dialog"
-         data-adyen-payment-action-modal
-    >
-        <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered">
-            <div class="modal-content">
-                <div class="modal-body">
-                    <div data-adyen-payment-action-container>
-                        <div class="adyen-payment-action-container loader" role="status">
-                            <span class="sr-only">{{ "adyen.loading"|trans }}</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+    {% include '@AdyenPayment/storefront/component/payment/payment-action-modal.html.twig' %}
 {% endblock %}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The 3DS2 modal is not appearing in the change order page because the HTML for the modal is missing. This Pull Request fixes that and also extracts the modal markup to a separate template file.

## Tested scenarios
<!-- Description of tested scenarios -->
- 3DS2 payments in both checkout and change order pages

**Fixed issue**: PW-2809
