### PR TITLE
Improve error messages in the plugin config test

### DIFF
--- a/src/Controller/ApiTestController.php
+++ b/src/Controller/ApiTestController.php
@@ -76,9 +76,14 @@ class ApiTestController
             );
             $result = $service->paymentMethods($params);
 
-            return new JsonResponse(['success' => isset($result['paymentMethods'])]);
+            $hasPaymentMethods = isset($result['paymentMethods']);
+            $response = ['success' => $hasPaymentMethods];
+            if (!$hasPaymentMethods) {
+                $response['message'] = 'adyen.paymentMethodsMissing';
+            }
+            return new JsonResponse($response);
         } catch (\Exception $exception) {
-            return new JsonResponse(['success' => false]);
+            return new JsonResponse(['success' => false, 'message' => $exception->getMessage()]);
         }
     }
 }

--- a/src/Resources/app/administration/src/component/adyen-config-check-button/index.js
+++ b/src/Resources/app/administration/src/component/adyen-config-check-button/index.js
@@ -63,7 +63,7 @@ Component.register('adyen-config-check-button', {
                 } else {
                     this.createNotificationError({
                         title: this.$tc('adyen.configTestTitle'),
-                        message: this.$tc('adyen.configTestFail')
+                        message: this.$tc(res.message ? res.message : 'adyen.configTestFail')
                     });
                 }
 

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -106,7 +106,7 @@ export default class ConfirmOrderPlugin extends Plugin {
                 .createFromAction(paymentActionResponse.action)
                 .mount('[data-adyen-payment-action-container]');
         } catch (e) {
-            console.log('error');
+            console.log(e);
         }
 
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Improves the messages from checking the configuration values.

## Tested scenarios
<!-- Description of tested scenarios -->
Clicking the button in the plugin config screen

