### PR TITLE
[PW-2788] Add payment methods to the plugin and adjust card payment handler

### DIFF
--- a/src/AdyenPaymentShopware6.php
+++ b/src/AdyenPaymentShopware6.php
@@ -59,28 +59,20 @@ class AdyenPaymentShopware6 extends Plugin
 
     public function deactivate(DeactivateContext $deactivateContext): void
     {
-        $this->setPaymentMethodIsActive(false, $deactivateContext->getContext());
+        foreach (PaymentMethods::PAYMENT_METHODS as $paymentMethod) {
+            $this->setPaymentMethodIsActive(false, $deactivateContext->getContext(), $paymentMethod);
+        }
         parent::deactivate($deactivateContext);
     }
 
     public function uninstall(UninstallContext $uninstallContext): void
     {
-        $this->setPaymentMethodIsActive(false, $uninstallContext->getContext());
-    }
+        foreach (PaymentMethods::PAYMENT_METHODS as $paymentMethod) {
+            $this->setPaymentMethodIsActive(false, $uninstallContext->getContext(), $paymentMethod);
+        }    }
 
     private function addPaymentMethod(PaymentMethodInterface $paymentMethod, Context $context): void
     {
-        if (true && true) {
-            if (true) {
-            }
-
-            // for pending payment that redirect we store this under adyenPaymentData
-            // we need to refactor the code in the plugin that all paymentData is stored in paymentData and not in adyenPaymentData
-            if (true) {
-
-            }
-        }
-
         $paymentMethodExists = $this->getPaymentMethodId($paymentMethod->getPaymentHandler());
 
         // Payment method exists already, no need to continue here

--- a/src/AdyenPaymentShopware6.php
+++ b/src/AdyenPaymentShopware6.php
@@ -51,7 +51,9 @@ class AdyenPaymentShopware6 extends Plugin
 
     public function activate(ActivateContext $activateContext): void
     {
-        $this->setPaymentMethodIsActive(true, $activateContext->getContext());
+        foreach (PaymentMethods::PAYMENT_METHODS as $paymentMethod) {
+            $this->setPaymentMethodIsActive(true, $activateContext->getContext(), $paymentMethod);
+        }
         parent::activate($activateContext);
     }
 
@@ -68,7 +70,18 @@ class AdyenPaymentShopware6 extends Plugin
 
     private function addPaymentMethod(PaymentMethodInterface $paymentMethod, Context $context): void
     {
-        $paymentMethodExists = $this->getPaymentMethodId();
+        if (true && true) {
+            if (true) {
+            }
+
+            // for pending payment that redirect we store this under adyenPaymentData
+            // we need to refactor the code in the plugin that all paymentData is stored in paymentData and not in adyenPaymentData
+            if (true) {
+
+            }
+        }
+
+        $paymentMethodExists = $this->getPaymentMethodId($paymentMethod->getPaymentHandler());
 
         // Payment method exists already, no need to continue here
         if ($paymentMethodExists) {
@@ -92,7 +105,7 @@ class AdyenPaymentShopware6 extends Plugin
         $paymentRepository->create([$paymentData], $context);
     }
 
-    private function getPaymentMethodId(): ?string
+    private function getPaymentMethodId(string $paymentMethodHandler): ?string
     {
         /** @var EntityRepositoryInterface $paymentRepository */
         $paymentRepository = $this->container->get('payment_method.repository');
@@ -101,7 +114,7 @@ class AdyenPaymentShopware6 extends Plugin
 
         $paymentCriteria = (new Criteria())->addFilter(new EqualsFilter(
             'handlerIdentifier',
-            CardsPaymentMethodHandler::class
+            $paymentMethodHandler
         ));
 
         $paymentIds = $paymentRepository->searchIds($paymentCriteria, Context::createDefaultContext());
@@ -113,12 +126,12 @@ class AdyenPaymentShopware6 extends Plugin
         return $paymentIds->getIds()[0];
     }
 
-    private function setPaymentMethodIsActive(bool $active, Context $context): void
+    private function setPaymentMethodIsActive(bool $active, Context $context, string $paymentMethodHandler): void
     {
         /** @var EntityRepositoryInterface $paymentRepository */
         $paymentRepository = $this->container->get('payment_method.repository');
 
-        $paymentMethodId = $this->getPaymentMethodId();
+        $paymentMethodId = $this->getPaymentMethodId($paymentMethodHandler);
 
         // Payment does not even exist, so nothing to (de-)activate here
         if (!$paymentMethodId) {

--- a/src/AdyenPaymentShopware6.php
+++ b/src/AdyenPaymentShopware6.php
@@ -69,7 +69,8 @@ class AdyenPaymentShopware6 extends Plugin
     {
         foreach (PaymentMethods::PAYMENT_METHODS as $paymentMethod) {
             $this->setPaymentMethodIsActive(false, $uninstallContext->getContext(), $paymentMethod);
-        }    }
+        }
+    }
 
     private function addPaymentMethod(PaymentMethodInterface $paymentMethod, Context $context): void
     {

--- a/src/Controller/SalesChannelApiController.php
+++ b/src/Controller/SalesChannelApiController.php
@@ -156,7 +156,7 @@ class SalesChannelApiController extends AbstractController
     /**
      * @RouteScope(scopes={"sales-channel-api"})
      * @Route(
-     *     "/sales-channel-api/v1/adyen/payment-details",
+     *     "/sales-channel-api/v2/adyen/payment-details",
      *     name="sales-channel-api.action.adyen.payment-details",
      *     methods={"POST"}
      * )
@@ -203,7 +203,7 @@ class SalesChannelApiController extends AbstractController
     /**
      * @RouteScope(scopes={"sales-channel-api"})
      * @Route(
-     *     "/sales-channel-api/v1/adyen/payment-status",
+     *     "/sales-channel-api/v2/adyen/payment-status",
      *     name="sales-channel-api.action.adyen.payment-status",
      *     methods={"POST"}
      * )

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -1,0 +1,527 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+
+namespace Adyen\Shopware\Handlers;
+
+
+use Adyen\AdyenException;
+use Adyen\Service\Builder\Address;
+use Adyen\Service\Builder\Browser;
+use Adyen\Service\Builder\Customer;
+use Adyen\Service\Builder\Payment;
+use Adyen\Service\Validator\CheckoutStateDataValidator;
+use Adyen\Shopware\Exception\PaymentException;
+use Adyen\Shopware\Service\CheckoutService;
+use Adyen\Shopware\Service\ConfigurationService;
+use Adyen\Shopware\Service\PaymentStateDataService;
+use Adyen\Shopware\Service\Repository\SalesChannelRepository;
+use Adyen\Shopware\Storefront\Controller\RedirectResultController;
+use Adyen\Util\Currency;
+use Exception;
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
+use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
+use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentFinalizeException;
+use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentProcessException;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class AbstractPaymentMethodHandler
+{
+
+    /**
+     * @var CheckoutService
+     */
+    protected $checkoutService;
+
+    /**
+     * @var Browser
+     */
+    protected $browserBuilder;
+
+    /**
+     * @var Address
+     */
+    protected $addressBuilder;
+
+    /**
+     * @var Payment
+     */
+    protected $paymentBuilder;
+
+    /**
+     * @var Currency
+     */
+    protected $currency;
+
+    /**
+     * @var ConfigurationService
+     */
+    protected $configurationService;
+
+    /**
+     * @var Customer
+     */
+    protected $customerBuilder;
+
+    /**
+     * @var CheckoutStateDataValidator
+     */
+    protected $checkoutStateDataValidator;
+
+    /**
+     * @var PaymentStateDataService
+     */
+    protected $paymentStateDataService;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var SalesChannelRepository
+     */
+    protected $salesChannelRepository;
+
+    /**
+     * @var PaymentResponseHandler
+     */
+    protected $paymentResponseHandler;
+
+    /**
+     * @var ResultHandler
+     */
+    protected $resultHandler;
+
+    /**
+     * @var OrderTransactionStateHandler
+     */
+    protected $orderTransactionStateHandler;
+
+    /**
+     * @var RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @var CsrfTokenManagerInterface
+     */
+    protected $csrfTokenManager;
+
+    /**
+     * CardsPaymentMethodHandler constructor.
+     *
+     * @param ConfigurationService $configurationService
+     * @param CheckoutService $checkoutService
+     * @param Browser $browserBuilder
+     * @param Address $addressBuilder
+     * @param Payment $paymentBuilder
+     * @param Currency $currency
+     * @param Customer $customerBuilder
+     * @param CheckoutStateDataValidator $checkoutStateDataValidator
+     * @param PaymentStateDataService $paymentStateDataService
+     * @param SalesChannelRepository $salesChannelRepository
+     * @param PaymentResponseHandler $paymentResponseHandler
+     * @param ResultHandler $resultHandler
+     * @param OrderTransactionStateHandler $orderTransactionStateHandler
+     * @param RouterInterface $router
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ConfigurationService $configurationService,
+        CheckoutService $checkoutService,
+        Browser $browserBuilder,
+        Address $addressBuilder,
+        Payment $paymentBuilder,
+        Currency $currency,
+        Customer $customerBuilder,
+        CheckoutStateDataValidator $checkoutStateDataValidator,
+        PaymentStateDataService $paymentStateDataService,
+        SalesChannelRepository $salesChannelRepository,
+        PaymentResponseHandler $paymentResponseHandler,
+        ResultHandler $resultHandler,
+        OrderTransactionStateHandler $orderTransactionStateHandler,
+        RouterInterface $router,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        LoggerInterface $logger
+    ) {
+        $this->checkoutService = $checkoutService;
+        $this->browserBuilder = $browserBuilder;
+        $this->addressBuilder = $addressBuilder;
+        $this->currency = $currency;
+        $this->configurationService = $configurationService;
+        $this->customerBuilder = $customerBuilder;
+        $this->paymentBuilder = $paymentBuilder;
+        $this->checkoutStateDataValidator = $checkoutStateDataValidator;
+        $this->paymentStateDataService = $paymentStateDataService;
+        $this->salesChannelRepository = $salesChannelRepository;
+        $this->paymentResponseHandler = $paymentResponseHandler;
+        $this->resultHandler = $resultHandler;
+        $this->logger = $logger;
+        $this->orderTransactionStateHandler = $orderTransactionStateHandler;
+        $this->router = $router;
+        $this->csrfTokenManager = $csrfTokenManager;
+    }
+
+    /**
+     * @param AsyncPaymentTransactionStruct $transaction
+     * @param RequestDataBag $dataBag
+     * @param SalesChannelContext $salesChannelContext
+     * @return RedirectResponse
+     */
+    public function pay(
+        AsyncPaymentTransactionStruct $transaction,
+        RequestDataBag $dataBag,
+        SalesChannelContext $salesChannelContext
+    ): RedirectResponse {
+        try {
+            $request = $this->preparePaymentsRequest($salesChannelContext, $transaction);
+        } catch (Exception $exception) {
+            $message = sprintf(
+                "There was an error with the payment method. Order number: %s Missing data: %s",
+                $transaction->getOrder()->getOrderNumber(),
+                $exception->getMessage()
+            );
+            $this->logger->error($message);
+            throw new AsyncPaymentProcessException(
+                $transaction->getOrderTransaction()->getId(),
+                $message
+            );
+        }
+
+        try {
+            $response = $this->checkoutService->payments($request);
+        } catch (AdyenException $exception) {
+            $message = sprintf(
+                "There was an error with the /payments request. Order number %s: %s",
+                $transaction->getOrder()->getOrderNumber(),
+                $exception->getMessage()
+            );
+
+            $this->logger->error($message);
+
+            throw new AsyncPaymentProcessException(
+                $transaction->getOrderTransaction()->getId(),
+                $message
+            );
+        }
+
+        $orderNumber = $transaction->getOrder()->getOrderNumber();
+
+        if (empty($orderNumber)) {
+            $message = 'Order number is missing';
+            throw new AsyncPaymentProcessException(
+                $transaction->getOrderTransaction()->getId(),
+                $message
+            );
+        }
+
+        $result = $this->paymentResponseHandler->handlePaymentResponse($response, $orderNumber, $salesChannelContext);
+
+        try {
+            $this->paymentResponseHandler->handleShopwareApis($transaction, $salesChannelContext, $result);
+        } catch (PaymentException $exception) {
+            // Cancel payment in shopware
+            throw new AsyncPaymentProcessException(
+                $transaction->getOrderTransaction()->getId(),
+                $exception->getMessage()
+            );
+        }
+
+        // Payment had no error, continue the process
+        return new RedirectResponse($this->getAdyenReturnUrl($transaction->getReturnUrl()));
+    }
+
+    /**
+     * @param AsyncPaymentTransactionStruct $transaction
+     * @param Request $request
+     * @param SalesChannelContext $salesChannelContext
+     */
+    public function finalize(
+        AsyncPaymentTransactionStruct $transaction,
+        Request $request,
+        SalesChannelContext $salesChannelContext
+    ): void {
+        try {
+            $this->resultHandler->processResult($transaction, $request, $salesChannelContext);
+        } catch (PaymentException $exception) {
+            throw new AsyncPaymentFinalizeException(
+                $transaction->getOrderTransaction()->getId(),
+                $exception->getMessage()
+            );
+        }
+    }
+
+    /**
+     * @param string $address
+     * @return array
+     */
+    public function splitStreetAddressHouseNumber(string $address): array
+    {
+        return [
+            'street' => $address,
+            'houseNumber' => 'N/A'
+        ];
+    }
+
+    /**
+     * @param SalesChannelContext $salesChannelContext
+     * @param AsyncPaymentTransactionStruct $transaction
+     * @return array
+     */
+    public function preparePaymentsRequest(
+        SalesChannelContext $salesChannelContext,
+        AsyncPaymentTransactionStruct $transaction
+    ) {
+        //Get state.data using the context token
+        $stateData = $this->paymentStateDataService->getPaymentStateDataFromContextToken(
+            $salesChannelContext->getToken()
+        );
+        $request = json_decode($stateData->getStateData(), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new AsyncPaymentProcessException(
+                $transaction->getOrderTransaction()->getId(),
+                'Invalid payment state data.'
+            );
+        }
+
+        if (!empty($request['additionalData'])) {
+            $stateDataAdditionalData = $request['additionalData'];
+        }
+
+        //Validate state.data for payment and build request object
+        $request = $this->checkoutStateDataValidator->getValidatedAdditionalData($request);
+
+        //Setting browser info if not present in statedata
+        if (empty($request['browserInfo']['acceptHeader'])) {
+            $acceptHeader = $_SERVER['HTTP_ACCEPT'];
+        } else {
+            $acceptHeader = $request['browserInfo']['acceptHeader'];
+        }
+        if (empty($request['browserInfo']['userAgent'])) {
+            $userAgent = $_SERVER['HTTP_USER_AGENT'];
+        } else {
+            $userAgent = $request['browserInfo']['userAgent'];
+        }
+
+        //Setting delivery address info if not present in statedata
+        if (empty($request['deliveryAddress'])) {
+            if ($salesChannelContext->getShippingLocation()->getAddress()->getCountryState()) {
+                $shippingState = $salesChannelContext->getShippingLocation()
+                    ->getAddress()->getCountryState()->getShortCode();
+            } else {
+                $shippingState = '';
+            }
+
+            $shippingStreetAddress = $this->splitStreetAddressHouseNumber(
+                $salesChannelContext->getShippingLocation()->getAddress()->getStreet()
+            );
+            $request = $this->addressBuilder->buildDeliveryAddress(
+                $shippingStreetAddress['street'],
+                $shippingStreetAddress['houseNumber'],
+                $salesChannelContext->getShippingLocation()->getAddress()->getZipcode(),
+                $salesChannelContext->getShippingLocation()->getAddress()->getCity(),
+                $shippingState,
+                $salesChannelContext->getShippingLocation()->getAddress()->getCountry()->getIso(),
+                $request
+            );
+        }
+
+        //Setting billing address info if not present in statedata
+        if (empty($request['billingAddress'])) {
+            if ($salesChannelContext->getCustomer()->getActiveBillingAddress()->getCountryState()) {
+                $billingState = $salesChannelContext->getCustomer()
+                    ->getActiveBillingAddress()->getCountryState()->getShortCode();
+            } else {
+                $billingState = '';
+            }
+
+            $billingStreetAddress = $this->splitStreetAddressHouseNumber(
+                $salesChannelContext->getCustomer()->getActiveBillingAddress()->getStreet()
+            );
+            $request = $this->addressBuilder->buildBillingAddress(
+                $billingStreetAddress['street'],
+                $billingStreetAddress['houseNumber'],
+                $salesChannelContext->getCustomer()->getActiveBillingAddress()->getZipcode(),
+                $salesChannelContext->getCustomer()->getActiveBillingAddress()->getCity(),
+                $billingState,
+                $salesChannelContext->getCustomer()->getActiveBillingAddress()->getCountry()->getIso(),
+                $request
+            );
+        }
+
+        //Setting customer data if not present in statedata
+        if (empty($request['shopperName'])) {
+            $shopperFirstName = $salesChannelContext->getCustomer()->getFirstName();
+            $shopperLastName = $salesChannelContext->getCustomer()->getFirstName();
+        } else {
+            $shopperFirstName = $request['shopperName']['firstName'];
+            $shopperLastName = $request['shopperName']['lastName'];
+        }
+
+        if (empty($request['shopperEmail'])) {
+            $shopperEmail = $salesChannelContext->getCustomer()->getEmail();
+        } else {
+            $shopperEmail = $request['shopperEmail'];
+        }
+
+        if (empty($request['paymentMethod']['personalDetails']['telephoneNumber'])) {
+            $shopperPhone = $salesChannelContext->getShippingLocation()->getAddress()->getPhoneNumber();
+        } else {
+            $shopperPhone = $request['paymentMethod']['personalDetails']['telephoneNumber'];
+        }
+
+        if (empty($request['paymentMethod']['personalDetails']['dateOfBirth'])) {
+            if ($salesChannelContext->getCustomer()->getBirthday()) {
+                $shopperDob = $salesChannelContext->getCustomer()->getBirthday()->format('dd-mm-yyyy');
+            } else {
+                $shopperDob = '';
+            }
+        } else {
+            $shopperDob = $request['paymentMethod']['personalDetails']['dateOfBirth'];
+        }
+
+        if (empty($request['shopperLocale'])) {
+            $shopperLocale = $this->salesChannelRepository->getSalesChannelAssocLocale($salesChannelContext)
+                ->getLanguage()->getLocale()->getCode();
+        } else {
+            $shopperLocale = $request['shopperLocale'];
+        }
+
+        if (empty($request['shopperIP'])) {
+            $shopperIp = $salesChannelContext->getCustomer()->getRemoteAddress();
+        } else {
+            $shopperIp = $request['shopperIP'];
+        }
+
+        if (empty($request['shopperReference'])) {
+            $shopperReference = $salesChannelContext->getCustomer()->getId();
+        } else {
+            $shopperReference = $request['shopperReference'];
+        }
+
+        if (empty($request['countryCode'])) {
+            $countryCode = $salesChannelContext->getCustomer()->getActiveBillingAddress()->getCountry()->getIso();
+        } else {
+            $countryCode = $request['countryCode'];
+        }
+
+        $request = $this->browserBuilder->buildBrowserData(
+            $userAgent,
+            $acceptHeader,
+            $request['browserInfo']['screenWidth'],
+            $request['browserInfo']['screenHeight'],
+            $request['browserInfo']['colorDepth'],
+            $request['browserInfo']['timeZoneOffset'],
+            $request['browserInfo']['language'],
+            $request['browserInfo']['javaEnabled'],
+            $request
+        );
+
+        $request = $this->customerBuilder->buildCustomerData(
+            false,
+            $shopperEmail,
+            $shopperPhone,
+            '',
+            $shopperDob,
+            $shopperFirstName,
+            $shopperLastName,
+            $countryCode,
+            $shopperLocale,
+            $shopperIp,
+            $shopperReference,
+            $request
+        );
+
+        //Building payment data
+        $request = $this->paymentBuilder->buildPaymentData(
+            $salesChannelContext->getCurrency()->getIsoCode(),
+            $this->currency->sanitize(
+                $transaction->getOrder()->getPrice()->getTotalPrice(),
+                $salesChannelContext->getCurrency()->getIsoCode()
+            ),
+            $transaction->getOrder()->getOrderNumber(),
+            $this->configurationService->getMerchantAccount(),
+            $this->getAdyenReturnUrl($transaction->getReturnUrl()),
+            $request
+        );
+
+        //Setting info from statedata additionalData if present
+        if (!empty($stateDataAdditionalData['origin'])) {
+            $request['origin'] = $stateDataAdditionalData['origin'];
+        } else {
+            $request['origin'] = $this->salesChannelRepository->getSalesChannelUrl($salesChannelContext);
+        }
+
+        $request['additionalData']['allow3DS2'] = true;
+
+        $request['channel'] = 'web';
+
+        //Remove the used state.data
+        $this->paymentStateDataService->deletePaymentStateData($stateData);
+
+        return $request;
+    }
+
+    /**
+     * Creates the Adyen Redirect Result URL with the same query as the original return URL
+     * Fixes the CSRF validation bug: https://issues.shopware.com/issues/NEXT-6356
+     *
+     * @param $returnUrl
+     * @return string
+     * @throws PaymentException
+     */
+    protected function getAdyenReturnUrl($returnUrl)
+    {
+        // Parse the original return URL to retrieve the query parameters
+        $returnUrlQuery = parse_url($returnUrl, PHP_URL_QUERY);
+
+        // In case the URL is malformed it cannot be parsed
+        if (false === $returnUrlQuery) {
+            throw new PaymentException('Return URL is malformed');
+        }
+
+        // Generate the custom Adyen endpoint to receive the redirect from the issuer page
+        $adyenReturnUrl = $this->router->generate(
+            'adyen_redirect_result',
+            [
+                RedirectResultController::CSRF_TOKEN => $this->csrfTokenManager->getToken(
+                    'payment.finalize.transaction'
+                )->getValue()
+            ],
+            RouterInterface::ABSOLUTE_URL
+        );
+
+        // Create the adyen redirect result URL with the same query as the original return URL
+        return $adyenReturnUrl . '&' . $returnUrlQuery;
+    }
+}

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -23,9 +23,7 @@
  * Author: Adyen <shopware@adyen.com>
  */
 
-
 namespace Adyen\Shopware\Handlers;
-
 
 use Adyen\AdyenException;
 use Adyen\Service\Builder\Address;
@@ -191,7 +189,7 @@ abstract class AbstractPaymentMethodHandler
         $this->csrfTokenManager = $csrfTokenManager;
     }
 
-    abstract static function getPaymentMethodCode();
+    public abstract static function getPaymentMethodCode();
 
     /**
      * @param AsyncPaymentTransactionStruct $transaction

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -189,7 +189,7 @@ abstract class AbstractPaymentMethodHandler
         $this->csrfTokenManager = $csrfTokenManager;
     }
 
-    public abstract static function getPaymentMethodCode();
+    abstract public static function getPaymentMethodCode();
 
     /**
      * @param AsyncPaymentTransactionStruct $transaction

--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -35,7 +35,8 @@ use Symfony\Component\HttpFoundation\Request;
 class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
-    static function getPaymentMethodCode(){
+    public static function getPaymentMethodCode()
+    {
         return 'scheme';
     }
 
@@ -54,5 +55,4 @@ class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements 
     ): void {
         parent::finalize($transaction, $request, $salesChannelContext);
     }
-
 }

--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -39,20 +39,4 @@ class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements 
     {
         return 'scheme';
     }
-
-    public function pay(
-        AsyncPaymentTransactionStruct $transaction,
-        RequestDataBag $dataBag,
-        SalesChannelContext $salesChannelContext
-    ): RedirectResponse {
-        return parent::pay($transaction, $dataBag, $salesChannelContext);
-    }
-
-    public function finalize(
-        AsyncPaymentTransactionStruct $transaction,
-        Request $request,
-        SalesChannelContext $salesChannelContext
-    ): void {
-        parent::finalize($transaction, $request, $salesChannelContext);
-    }
 }

--- a/src/Handlers/IdealPaymentMethodHandler.php
+++ b/src/Handlers/IdealPaymentMethodHandler.php
@@ -39,20 +39,4 @@ class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler implements 
     {
         return 'ideal';
     }
-
-    public function pay(
-        AsyncPaymentTransactionStruct $transaction,
-        RequestDataBag $dataBag,
-        SalesChannelContext $salesChannelContext
-    ): RedirectResponse {
-        return parent::pay($transaction, $dataBag, $salesChannelContext);
-    }
-
-    public function finalize(
-        AsyncPaymentTransactionStruct $transaction,
-        Request $request,
-        SalesChannelContext $salesChannelContext
-    ): void {
-        parent::finalize($transaction, $request, $salesChannelContext);
-    }
 }

--- a/src/Handlers/IdealPaymentMethodHandler.php
+++ b/src/Handlers/IdealPaymentMethodHandler.php
@@ -32,7 +32,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
     public function pay(

--- a/src/Handlers/IdealPaymentMethodHandler.php
+++ b/src/Handlers/IdealPaymentMethodHandler.php
@@ -35,6 +35,10 @@ use Symfony\Component\HttpFoundation\Request;
 class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
+    static function getPaymentMethodCode(){
+        return 'ideal';
+    }
+
     public function pay(
         AsyncPaymentTransactionStruct $transaction,
         RequestDataBag $dataBag,

--- a/src/Handlers/IdealPaymentMethodHandler.php
+++ b/src/Handlers/IdealPaymentMethodHandler.php
@@ -35,7 +35,8 @@ use Symfony\Component\HttpFoundation\Request;
 class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
-    static function getPaymentMethodCode(){
+    public static function getPaymentMethodCode()
+    {
         return 'ideal';
     }
 
@@ -54,5 +55,4 @@ class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler implements 
     ): void {
         parent::finalize($transaction, $request, $salesChannelContext);
     }
-
 }

--- a/src/Handlers/KlarnaPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPaymentMethodHandler.php
@@ -39,20 +39,4 @@ class KlarnaPaymentMethodHandler extends AbstractPaymentMethodHandler implements
     {
         return 'klarna';
     }
-
-    public function pay(
-        AsyncPaymentTransactionStruct $transaction,
-        RequestDataBag $dataBag,
-        SalesChannelContext $salesChannelContext
-    ): RedirectResponse {
-        return parent::pay($transaction, $dataBag, $salesChannelContext);
-    }
-
-    public function finalize(
-        AsyncPaymentTransactionStruct $transaction,
-        Request $request,
-        SalesChannelContext $salesChannelContext
-    ): void {
-        parent::finalize($transaction, $request, $salesChannelContext);
-    }
 }

--- a/src/Handlers/KlarnaPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPaymentMethodHandler.php
@@ -35,7 +35,8 @@ use Symfony\Component\HttpFoundation\Request;
 class KlarnaPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
-    static function getPaymentMethodCode(){
+    public static function getPaymentMethodCode()
+    {
         return 'klarna';
     }
 
@@ -54,5 +55,4 @@ class KlarnaPaymentMethodHandler extends AbstractPaymentMethodHandler implements
     ): void {
         parent::finalize($transaction, $request, $salesChannelContext);
     }
-
 }

--- a/src/Handlers/KlarnaPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPaymentMethodHandler.php
@@ -32,11 +32,11 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class KlarnaPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
     static function getPaymentMethodCode(){
-        return 'scheme';
+        return 'klarna';
     }
 
     public function pay(

--- a/src/Handlers/SepaPaymentMethodHandler.php
+++ b/src/Handlers/SepaPaymentMethodHandler.php
@@ -32,11 +32,11 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class SepaPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
     static function getPaymentMethodCode(){
-        return 'scheme';
+        return 'sepadirectdebit';
     }
 
     public function pay(

--- a/src/Handlers/SepaPaymentMethodHandler.php
+++ b/src/Handlers/SepaPaymentMethodHandler.php
@@ -35,7 +35,8 @@ use Symfony\Component\HttpFoundation\Request;
 class SepaPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
-    static function getPaymentMethodCode(){
+    public static function getPaymentMethodCode()
+    {
         return 'sepadirectdebit';
     }
 
@@ -54,5 +55,4 @@ class SepaPaymentMethodHandler extends AbstractPaymentMethodHandler implements A
     ): void {
         parent::finalize($transaction, $request, $salesChannelContext);
     }
-
 }

--- a/src/Handlers/SepaPaymentMethodHandler.php
+++ b/src/Handlers/SepaPaymentMethodHandler.php
@@ -39,20 +39,4 @@ class SepaPaymentMethodHandler extends AbstractPaymentMethodHandler implements A
     {
         return 'sepadirectdebit';
     }
-
-    public function pay(
-        AsyncPaymentTransactionStruct $transaction,
-        RequestDataBag $dataBag,
-        SalesChannelContext $salesChannelContext
-    ): RedirectResponse {
-        return parent::pay($transaction, $dataBag, $salesChannelContext);
-    }
-
-    public function finalize(
-        AsyncPaymentTransactionStruct $transaction,
-        Request $request,
-        SalesChannelContext $salesChannelContext
-    ): void {
-        parent::finalize($transaction, $request, $salesChannelContext);
-    }
 }

--- a/src/Handlers/SofortPaymentMethodHandler.php
+++ b/src/Handlers/SofortPaymentMethodHandler.php
@@ -39,20 +39,4 @@ class SofortPaymentMethodHandler extends AbstractPaymentMethodHandler implements
     {
         return 'directEbanking';
     }
-
-    public function pay(
-        AsyncPaymentTransactionStruct $transaction,
-        RequestDataBag $dataBag,
-        SalesChannelContext $salesChannelContext
-    ): RedirectResponse {
-        return parent::pay($transaction, $dataBag, $salesChannelContext);
-    }
-
-    public function finalize(
-        AsyncPaymentTransactionStruct $transaction,
-        Request $request,
-        SalesChannelContext $salesChannelContext
-    ): void {
-        parent::finalize($transaction, $request, $salesChannelContext);
-    }
 }

--- a/src/Handlers/SofortPaymentMethodHandler.php
+++ b/src/Handlers/SofortPaymentMethodHandler.php
@@ -32,11 +32,11 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class SofortPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
     static function getPaymentMethodCode(){
-        return 'scheme';
+        return 'directEbanking';
     }
 
     public function pay(

--- a/src/Handlers/SofortPaymentMethodHandler.php
+++ b/src/Handlers/SofortPaymentMethodHandler.php
@@ -35,7 +35,8 @@ use Symfony\Component\HttpFoundation\Request;
 class SofortPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
-    static function getPaymentMethodCode(){
+    public static function getPaymentMethodCode()
+    {
         return 'directEbanking';
     }
 
@@ -54,5 +55,4 @@ class SofortPaymentMethodHandler extends AbstractPaymentMethodHandler implements
     ): void {
         parent::finalize($transaction, $request, $salesChannelContext);
     }
-
 }

--- a/src/PaymentMethods/IdealPaymentMethod.php
+++ b/src/PaymentMethods/IdealPaymentMethod.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\IdealPaymentMethodHandler;
+
+class IdealPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'iDeal';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'The most popular payment method in the Netherlands,' .
+            'iDEAL is an inter-bank system covered by all major Dutch consumer banks.';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return IdealPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_IDEAL';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/ideal.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/KlarnaPaymentMethod.php
+++ b/src/PaymentMethods/KlarnaPaymentMethod.php
@@ -24,9 +24,9 @@
 
 namespace Adyen\Shopware\PaymentMethods;
 
-use Adyen\Shopware\Handlers\IdealPaymentMethodHandler;
+use Adyen\Shopware\Handlers\KlarnaPaymentMethodHandler;
 
-class IdealPaymentMethod implements PaymentMethodInterface
+class KlarnaPaymentMethod implements PaymentMethodInterface
 {
     /**
      * {@inheritDoc}
@@ -35,7 +35,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getName(): string
     {
-        return 'iDeal';
+        return 'Klarna Pay Later';
     }
 
     /**
@@ -55,7 +55,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getPaymentHandler(): string
     {
-        return IdealPaymentMethodHandler::class;
+        return KlarnaPaymentMethodHandler::class;
     }
 
     /**
@@ -65,7 +65,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getGatewayCode(): string
     {
-        return 'ADYEN_IDEAL';
+        return 'ADYEN_KLARNA';
     }
 
     /**
@@ -85,7 +85,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/ideal.png';
+        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/klarna.png';
     }
 
     /**

--- a/src/PaymentMethods/PaymentMethods.php
+++ b/src/PaymentMethods/PaymentMethods.php
@@ -27,6 +27,7 @@ namespace Adyen\Shopware\PaymentMethods;
 class PaymentMethods
 {
     const PAYMENT_METHODS = [
-        CardsPaymentMethod::class
+        CardsPaymentMethod::class,
+        IdealPaymentMethod::class
     ];
 }

--- a/src/PaymentMethods/PaymentMethods.php
+++ b/src/PaymentMethods/PaymentMethods.php
@@ -28,6 +28,9 @@ class PaymentMethods
 {
     const PAYMENT_METHODS = [
         CardsPaymentMethod::class,
-        IdealPaymentMethod::class
+        IdealPaymentMethod::class,
+        KlarnaPaymentMethod::class,
+        SepaPaymentMethod::class,
+        SofortPaymentMethod::class
     ];
 }

--- a/src/PaymentMethods/SepaPaymentMethod.php
+++ b/src/PaymentMethods/SepaPaymentMethod.php
@@ -24,9 +24,9 @@
 
 namespace Adyen\Shopware\PaymentMethods;
 
-use Adyen\Shopware\Handlers\IdealPaymentMethodHandler;
+use Adyen\Shopware\Handlers\SepaPaymentMethodHandler;
 
-class IdealPaymentMethod implements PaymentMethodInterface
+class SepaPaymentMethod implements PaymentMethodInterface
 {
     /**
      * {@inheritDoc}
@@ -35,7 +35,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getName(): string
     {
-        return 'iDeal';
+        return 'SEPA direct debit';
     }
 
     /**
@@ -55,7 +55,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getPaymentHandler(): string
     {
-        return IdealPaymentMethodHandler::class;
+        return SepaPaymentMethodHandler::class;
     }
 
     /**
@@ -65,7 +65,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getGatewayCode(): string
     {
-        return 'ADYEN_IDEAL';
+        return 'ADYEN_SEPA';
     }
 
     /**
@@ -85,7 +85,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/ideal.png';
+        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/sepa.png';
     }
 
     /**

--- a/src/PaymentMethods/SofortPaymentMethod.php
+++ b/src/PaymentMethods/SofortPaymentMethod.php
@@ -24,9 +24,9 @@
 
 namespace Adyen\Shopware\PaymentMethods;
 
-use Adyen\Shopware\Handlers\IdealPaymentMethodHandler;
+use Adyen\Shopware\Handlers\SofortPaymentMethodHandler;
 
-class IdealPaymentMethod implements PaymentMethodInterface
+class SofortPaymentMethod implements PaymentMethodInterface
 {
     /**
      * {@inheritDoc}
@@ -35,7 +35,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getName(): string
     {
-        return 'iDeal';
+        return 'Sofort';
     }
 
     /**
@@ -55,7 +55,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getPaymentHandler(): string
     {
-        return IdealPaymentMethodHandler::class;
+        return SofortPaymentMethodHandler::class;
     }
 
     /**
@@ -65,7 +65,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getGatewayCode(): string
     {
-        return 'ADYEN_IDEAL';
+        return 'ADYEN_SOFORT';
     }
 
     /**
@@ -85,7 +85,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/ideal.png';
+        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/sofort.png';
     }
 
     /**

--- a/src/Resources/app/storefront/src/checkout/checkout.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/checkout.plugin.js
@@ -35,14 +35,22 @@ export default class CheckoutPlugin extends Plugin {
         const confirmPaymentForm = DomAccess.querySelector(document, '#confirmPaymentForm');
         confirmPaymentForm.addEventListener('submit', this.onConfirmPayment.bind(this));
 
-        const formattedHandlerIdentifier = 'handler_adyen_cardspaymentmethodhandler';
+        const cardsFormattedHandlerIdentifier = 'handler_adyen_cardspaymentmethodhandler';
+        const idealFormattedHandlerIdentifier = 'handler_adyen_idealpaymentmethodhandler';
+        const klarnaFormattedHandlerIdentifier = 'handler_adyen_klarnapaymentmethodhandler';
+        const sepaFormattedHandlerIdentifier = 'handler_adyen_sepapaymentmethodhandler';
+        const sofortFormattedHandlerIdentifier = 'handler_adyen_sofortpaymentmethodhandler';
 
         this.paymentMethodTypeHandlers = {
-            'scheme': formattedHandlerIdentifier
+            'scheme': cardsFormattedHandlerIdentifier,
+            'ideal': idealFormattedHandlerIdentifier,
+            'klarna': klarnaFormattedHandlerIdentifier,
+            'sepadirectdebit': sepaFormattedHandlerIdentifier,
+            'sofort': sofortFormattedHandlerIdentifier
         };
 
         //PMs that should show an 'Update Details' button if there's already a state.data for that PM stored for this context
-        this.updatablePaymentMethods = ['scheme'];
+        this.updatablePaymentMethods = ['scheme', 'ideal', 'sepadirectdebit'];
 
         this.client = new StoreApiClient();
 
@@ -158,7 +166,8 @@ export default class CheckoutPlugin extends Plugin {
     }
 
     onConfirmPayment (event) {
-        if (!this.cardFormValidator.validateForm()) {
+        //TODO Implement validation for multiple PMs
+        if (!this.cardFormValidator.validateForm() && false) {
             event.preventDefault();
         }
     }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -96,6 +96,7 @@
             <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
             <tag name="shopware.payment.method.async"/>
         </service>
+        <service id="Adyen\Shopware\Handlers\IdealPaymentMethodHandler" />
         <service id="Adyen\Service\Builder\Browser"/>
         <service id="Adyen\Service\Builder\Address"/>
         <service id="Adyen\Service\Builder\Payment"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -96,7 +96,86 @@
             <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
             <tag name="shopware.payment.method.async"/>
         </service>
-        <service id="Adyen\Shopware\Handlers\IdealPaymentMethodHandler" />
+        <service id="Adyen\Shopware\Handlers\IdealPaymentMethodHandler">
+            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
+            <argument type="service" id="Adyen\Shopware\Service\CheckoutService"/>
+            <argument type="service" id="Adyen\Service\Builder\Browser"/>
+            <argument type="service" id="Adyen\Service\Builder\Address"/>
+            <argument type="service" id="Adyen\Service\Builder\Payment"/>
+            <argument type="service" id="Adyen\Util\Currency"/>
+            <argument type="service" id="Adyen\Service\Builder\Customer"/>
+            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
+            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\ResultHandler"/>
+            <argument type="service"
+                      id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
+            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
+            <argument type="service" id="security.csrf.token_manager"/>
+            <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\KlarnaPaymentMethodHandler">
+            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
+            <argument type="service" id="Adyen\Shopware\Service\CheckoutService"/>
+            <argument type="service" id="Adyen\Service\Builder\Browser"/>
+            <argument type="service" id="Adyen\Service\Builder\Address"/>
+            <argument type="service" id="Adyen\Service\Builder\Payment"/>
+            <argument type="service" id="Adyen\Util\Currency"/>
+            <argument type="service" id="Adyen\Service\Builder\Customer"/>
+            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
+            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\ResultHandler"/>
+            <argument type="service"
+                      id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
+            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
+            <argument type="service" id="security.csrf.token_manager"/>
+            <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\SepaPaymentMethodHandler">
+            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
+            <argument type="service" id="Adyen\Shopware\Service\CheckoutService"/>
+            <argument type="service" id="Adyen\Service\Builder\Browser"/>
+            <argument type="service" id="Adyen\Service\Builder\Address"/>
+            <argument type="service" id="Adyen\Service\Builder\Payment"/>
+            <argument type="service" id="Adyen\Util\Currency"/>
+            <argument type="service" id="Adyen\Service\Builder\Customer"/>
+            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
+            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\ResultHandler"/>
+            <argument type="service"
+                      id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
+            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
+            <argument type="service" id="security.csrf.token_manager"/>
+            <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\SofortPaymentMethodHandler">
+            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
+            <argument type="service" id="Adyen\Shopware\Service\CheckoutService"/>
+            <argument type="service" id="Adyen\Service\Builder\Browser"/>
+            <argument type="service" id="Adyen\Service\Builder\Address"/>
+            <argument type="service" id="Adyen\Service\Builder\Payment"/>
+            <argument type="service" id="Adyen\Util\Currency"/>
+            <argument type="service" id="Adyen\Service\Builder\Customer"/>
+            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
+            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\ResultHandler"/>
+            <argument type="service"
+                      id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
+            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
+            <argument type="service" id="security.csrf.token_manager"/>
+            <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
+            <tag name="shopware.payment.method.async"/>
+        </service>
         <service id="Adyen\Service\Builder\Browser"/>
         <service id="Adyen\Service\Builder\Address"/>
         <service id="Adyen\Service\Builder\Payment"/>

--- a/src/Resources/views/storefront/component/payment/payment-fields.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-fields.html.twig
@@ -45,10 +45,10 @@
                                                 </div>
                                             {% endblock %}
                                         </label>
-                                        {% if payment.formattedHandlerIdentifier == "handler_adyen_cardspaymentmethodhandler" %}
+                                        {% if "adyen" in payment.formattedHandlerIdentifier %}
                                             <div class="adyen-payment-method-container-div"
                                                  data-adyen-payment-method-id="{{ payment.id }}"
-                                                 data-adyen-payment-method="handler_adyen_cardspaymentmethodhandler"
+                                                 data-adyen-payment-method="{{ payment.formattedHandlerIdentifier }}"
                                             >
                                                 <div data-adyen-update-payment-details class="adyen-update-payment-details">
                                                     <button type="button" class="btn btn-primary" onclick="window.showPaymentMethodDetails()">{{ "adyen.updateDetails"|trans }}</button>

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -223,7 +223,7 @@ class PaymentSubscriber implements EventSubscriberInterface
 
             //If this is an Adyen PM installed it will only be enabled if it's present in the /paymentMethods response
             if (strpos($paymentMethodEntity->getFormattedHandlerIdentifier(), 'adyen') !== false) {
-                $pmCode = 'scheme'; //TODO get from payment method handler instead of hardcoding PM type
+                $pmCode = $pmHandlerIdentifier::getPaymentMethodCode();
                 // In case the paymentMethods response has no payment methods, remove it from the list
                 if (empty($adyenPaymentMethods)) {
                     $originalPaymentMethods->remove($paymentMethodEntity->getId());


### PR DESCRIPTION
## Summary
New payment methods have been added to be installed and picked up by the generic component in the checkout page. In order to outsource the payment handler logic an abstract class was created along with a static function to fetch the PM code in the Payment Subscriber using the handler.

All the payment methods have been added to services.xml with all the classes' dependencies, maybe there's a way to simplify those declarations.

New frontend validation must be implemented to accommodate all the payment methods.

Some API endpoints were moved from v2 to v3 since that version was removed from S6.3.

## Tested scenarios
New payment methods are installed and rendered in the frontend.

**Fixed issue**:  PW-2788