### PR TITLE
Adding redirect data to /payments call

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -257,7 +257,7 @@ abstract class AbstractPaymentMethodHandler
         }
 
         // Payment had no error, continue the process
-        return new RedirectResponse($this->getAdyenReturnUrl($transaction->getReturnUrl()));
+        return new RedirectResponse($transaction->getReturnUrl());
     }
 
     /**
@@ -307,7 +307,7 @@ abstract class AbstractPaymentMethodHandler
         );
 
         //Generate returnUrl
-        $returnUrl = $this->getAdyenReturnUrl($transaction->getReturnUrl());
+        $returnUrl = $transaction->getReturnUrl();
 
         if ($stateData) {
             $request = json_decode($stateData->getStateData(), true);
@@ -514,6 +514,9 @@ abstract class AbstractPaymentMethodHandler
      * @param $returnUrl
      * @return string
      * @throws PaymentException
+     * @deprecated using redirectToIssuerMethod and redirectFromIssuerMethod in the
+     * /payments call is not necessary to modify the CSRF token
+     *
      */
     protected function getAdyenReturnUrl($returnUrl)
     {

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -306,6 +306,9 @@ abstract class AbstractPaymentMethodHandler
             $salesChannelContext->getToken()
         );
 
+        //Generate returnUrl
+        $returnUrl = $this->getAdyenReturnUrl($transaction->getReturnUrl());
+
         if ($stateData) {
             $request = json_decode($stateData->getStateData(), true);
         } else {
@@ -440,6 +443,11 @@ abstract class AbstractPaymentMethodHandler
             $countryCode = $request['countryCode'];
         }
 
+        //Redirect parameters for 3DS1 payments
+        $request['redirectFromIssuerMethod'] = 'GET';
+        $request['redirectToIssuerMethod'] = 'POST';
+        $request['returnUrl'] = $returnUrl;
+
         $request = $this->browserBuilder->buildBrowserData(
             $userAgent,
             $acceptHeader,
@@ -476,7 +484,7 @@ abstract class AbstractPaymentMethodHandler
             ),
             $transaction->getOrder()->getOrderNumber(),
             $this->configurationService->getMerchantAccount(),
-            $this->getAdyenReturnUrl($transaction->getReturnUrl()),
+            $returnUrl,
             $request
         );
 

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -113,8 +113,8 @@ class ResultHandler
         if ('RedirectShopper' === $result->getResultCode()) {
             // Validate 3DS1 Post parameters
             // Get MD and PaRes to be validated
-            $md = $request->request->get('MD');
-            $paRes = $request->request->get('PaRes');
+            $md = $request->query->get('MD');
+            $paRes = $request->query->get('PaRes');
 
             if (empty($md) || empty($paRes)) {
                 throw new PaymentException('MD and/or PaRes parameter is missing from the redirect request');

--- a/src/Storefront/Controller/RedirectResultController.php
+++ b/src/Storefront/Controller/RedirectResultController.php
@@ -35,7 +35,6 @@ use Symfony\Component\Routing\Annotation\Route;
 use Shopware\Core\Checkout\Payment\Controller\PaymentController;
 
 /**
- * also legal
  * @deprecated using redirectToIssuerMethod and redirectFromIssuerMethod in the
  * /payments call is not necessary to process the redirect separately
  */

--- a/src/Storefront/Controller/RedirectResultController.php
+++ b/src/Storefront/Controller/RedirectResultController.php
@@ -34,6 +34,11 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Shopware\Core\Checkout\Payment\Controller\PaymentController;
 
+/**
+ * also legal
+ * @deprecated using redirectToIssuerMethod and redirectFromIssuerMethod in the
+ * /payments call is not necessary to process the redirect separately
+ */
 class RedirectResultController extends StorefrontController
 {
     const CSRF_TOKEN = '_csrf_token';


### PR DESCRIPTION
## Summary
This new redirect data adds `redirectFromIssuerMethod`, `redirectToIssuerMethod` and `returnUrl` to the /payments request. The sales channel API context token is the same after the payment and the order can be finished.

The redirect response from issuers page is now GET and not POST. The session is maintained without ignoring the SameSite cookie security.

## Tested scenarios
/payments request contains new redirect data
Redirect payments are handled via GET

**Fixed issue**:  PW-2822
