### PR TITLE
[PW-2786] OpenInvoice lines support and Klarna PMs

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -54,6 +54,8 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 abstract class AbstractPaymentMethodHandler
 {
 
+    static protected $isOpenInvoice = false;
+
     /**
      * @var CheckoutService
      */

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -30,6 +30,7 @@ use Adyen\Service\Builder\Address;
 use Adyen\Service\Builder\Browser;
 use Adyen\Service\Builder\Customer;
 use Adyen\Service\Builder\Payment;
+use Adyen\Service\Builder\OpenInvoice;
 use Adyen\Service\Validator\CheckoutStateDataValidator;
 use Adyen\Shopware\Exception\PaymentException;
 use Adyen\Shopware\Service\CheckoutService;
@@ -44,7 +45,16 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStat
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentFinalizeException;
 use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentProcessException;
+use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\Currency\CurrencyCollection;
+use Shopware\Core\System\Currency\CurrencyEntity;
+use Swag\PayPal\Payment\Exception\CurrencyNotFoundException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -75,6 +85,11 @@ abstract class AbstractPaymentMethodHandler
      * @var Payment
      */
     protected $paymentBuilder;
+
+    /**
+     * @var OpenInvoice
+     */
+    protected $openInvoiceBuilder;
 
     /**
      * @var Currency
@@ -137,6 +152,16 @@ abstract class AbstractPaymentMethodHandler
     protected $csrfTokenManager;
 
     /**
+     * @var EntityRepositoryInterface
+     */
+    protected $currencyRepository;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    protected $productRepository;
+
+    /**
      * CardsPaymentMethodHandler constructor.
      *
      * @param ConfigurationService $configurationService
@@ -144,6 +169,7 @@ abstract class AbstractPaymentMethodHandler
      * @param Browser $browserBuilder
      * @param Address $addressBuilder
      * @param Payment $paymentBuilder
+     * @param OpenInvoice $openInvoiceBuilder
      * @param Currency $currency
      * @param Customer $customerBuilder
      * @param CheckoutStateDataValidator $checkoutStateDataValidator
@@ -153,7 +179,9 @@ abstract class AbstractPaymentMethodHandler
      * @param ResultHandler $resultHandler
      * @param OrderTransactionStateHandler $orderTransactionStateHandler
      * @param RouterInterface $router
+     * @param CsrfTokenManagerInterface $csrfTokenManager
      * @param LoggerInterface $logger
+     * @param EntityRepositoryInterface $currencyRepository
      */
     public function __construct(
         ConfigurationService $configurationService,
@@ -161,6 +189,7 @@ abstract class AbstractPaymentMethodHandler
         Browser $browserBuilder,
         Address $addressBuilder,
         Payment $paymentBuilder,
+        OpenInvoice $openInvoiceBuilder,
         Currency $currency,
         Customer $customerBuilder,
         CheckoutStateDataValidator $checkoutStateDataValidator,
@@ -171,11 +200,14 @@ abstract class AbstractPaymentMethodHandler
         OrderTransactionStateHandler $orderTransactionStateHandler,
         RouterInterface $router,
         CsrfTokenManagerInterface $csrfTokenManager,
+        EntityRepositoryInterface $currencyRepository,
+        EntityRepositoryInterface $productRepository,
         LoggerInterface $logger
     ) {
         $this->checkoutService = $checkoutService;
         $this->browserBuilder = $browserBuilder;
         $this->addressBuilder = $addressBuilder;
+        $this->openInvoiceBuilder = $openInvoiceBuilder;
         $this->currency = $currency;
         $this->configurationService = $configurationService;
         $this->customerBuilder = $customerBuilder;
@@ -189,6 +221,8 @@ abstract class AbstractPaymentMethodHandler
         $this->orderTransactionStateHandler = $orderTransactionStateHandler;
         $this->router = $router;
         $this->csrfTokenManager = $csrfTokenManager;
+        $this->currencyRepository = $currencyRepository;
+        $this->productRepository = $productRepository;
     }
 
     abstract public static function getPaymentMethodCode();
@@ -330,6 +364,13 @@ abstract class AbstractPaymentMethodHandler
 
         //Validate state.data for payment and build request object
         $request = $this->checkoutStateDataValidator->getValidatedAdditionalData($request);
+
+        //Setting payment method type if not present in statedata
+        if (empty($request['paymentMethod']['type'])) {
+            $paymentMethodType = static::getPaymentMethodCode();
+        } else {
+            $paymentMethodType = $request['paymentMethod']['type'];
+        }
 
         //Setting browser info if not present in statedata
         if (empty($request['browserInfo']['acceptHeader'])) {
@@ -490,6 +531,50 @@ abstract class AbstractPaymentMethodHandler
             $request
         );
 
+        $request = $this->paymentBuilder->buildAlternativePaymentMethodData(
+            $paymentMethodType,
+            '',
+            $request
+        );
+
+        if (static::$isOpenInvoice) {
+            $orderLines = $transaction->getOrder()->getLineItems();
+            $lineItems = [];
+            foreach ($orderLines->getElements() as $orderLine) {
+                $price = $orderLine->getPrice();
+                $taxRate = $price->getCalculatedTaxes()->first();
+                $lineTax = $price->getCalculatedTaxes()->getAmount() / $orderLine->getQuantity();
+
+                $product = $this->getProduct($orderLine->getProductId(), $salesChannelContext->getContext());
+
+                if (!empty($taxRate)) {
+                    $taxRate = $taxRate->getTaxRate();
+                } else {
+                    $taxRate = 0;
+                }
+                $lineItems[] = $this->openInvoiceBuilder->buildOpenInvoiceLineItem(
+                    $product->getName(),
+                    $this->currency->sanitize(
+                        $price->getUnitPrice() - $lineTax,
+                        $this->getCurrency(
+                            $transaction->getOrder()->getCurrencyId(), $salesChannelContext->getContext()
+                        )
+                    ),
+                    $this->currency->sanitize($lineTax,
+                        $this->getCurrency(
+                            $transaction->getOrder()->getCurrencyId(), $salesChannelContext->getContext()
+                        )
+                    ),
+                    $taxRate * 100,
+                    $orderLine->getQuantity(),
+                    '',
+                    $product->getProductNumber()
+                );
+            }
+
+            $request['lineItems'] = $lineItems;
+        }
+
         //Setting info from statedata additionalData if present
         if (!empty($stateDataAdditionalData['origin'])) {
             $request['origin'] = $stateDataAdditionalData['origin'];
@@ -543,5 +628,45 @@ abstract class AbstractPaymentMethodHandler
 
         // Create the adyen redirect result URL with the same query as the original return URL
         return $adyenReturnUrl . '&' . $returnUrlQuery;
+    }
+
+    /**
+     * @param string $currencyId
+     * @param Context $context
+     * @return CurrencyEntity
+     */
+    private function getCurrency(string $currencyId, Context $context): CurrencyEntity
+    {
+        $criteria = new Criteria([$currencyId]);
+
+        /** @var CurrencyCollection $currencyCollection */
+        $currencyCollection = $this->currencyRepository->search($criteria, $context);
+
+        $currency = $currencyCollection->get($currencyId);
+        if ($currency === null) {
+            throw new CurrencyNotFoundException($currencyId);
+        }
+
+        return $currency;
+    }
+
+    /**
+     * @param string $productId
+     * @param Context $context
+     * @return ProductEntity
+     */
+    private function getProduct(string $productId, Context $context): ProductEntity
+    {
+        $criteria = new Criteria([$productId]);
+
+        /** @var ProductCollection $productCollection */
+        $productCollection = $this->productRepository->search($criteria, $context);
+
+        $product = $productCollection->get($productId);
+        if ($product === null) {
+            throw new ProductNotFoundException($productId);
+        }
+
+        return $product;
     }
 }

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -64,7 +64,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 abstract class AbstractPaymentMethodHandler
 {
 
-    static protected $isOpenInvoice = false;
+    protected static $isOpenInvoice = false;
 
     /**
      * @var CheckoutService
@@ -557,12 +557,15 @@ abstract class AbstractPaymentMethodHandler
                     $this->currency->sanitize(
                         $price->getUnitPrice() - $lineTax,
                         $this->getCurrency(
-                            $transaction->getOrder()->getCurrencyId(), $salesChannelContext->getContext()
+                            $transaction->getOrder()->getCurrencyId(),
+                            $salesChannelContext->getContext()
                         )
                     ),
-                    $this->currency->sanitize($lineTax,
+                    $this->currency->sanitize(
+                        $lineTax,
                         $this->getCurrency(
-                            $transaction->getOrder()->getCurrencyId(), $salesChannelContext->getContext()
+                            $transaction->getOrder()->getCurrencyId(),
+                            $salesChannelContext->getContext()
                         )
                     ),
                     $taxRate * 100,

--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {

--- a/src/Handlers/IdealPaymentMethodHandler.php
+++ b/src/Handlers/IdealPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {

--- a/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
@@ -27,7 +27,8 @@ namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
 
-class KlarnaPayLaterPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class KlarnaPayLaterPaymentMethodHandler extends AbstractPaymentMethodHandler
+    implements AsynchronousPaymentHandlerInterface
 {
 
     protected static $isOpenInvoice = true;

--- a/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  *                       ######
  *                       ######
@@ -22,16 +23,17 @@
  * Author: Adyen <shopware@adyen.com>
  */
 
-namespace Adyen\Shopware\PaymentMethods;
+namespace Adyen\Shopware\Handlers;
 
-class PaymentMethods
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+
+class KlarnaPayLaterPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
-    const PAYMENT_METHODS = [
-        CardsPaymentMethod::class,
-        IdealPaymentMethod::class,
-        KlarnaPayNowPaymentMethod::class,
-        KlarnaPayLaterPaymentMethod::class,
-        SepaPaymentMethod::class,
-        SofortPaymentMethod::class
-    ];
+
+    protected static $isOpenInvoice = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'klarna';
+    }
 }

--- a/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
@@ -27,8 +27,8 @@ namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
 
-class KlarnaPayLaterPaymentMethodHandler extends AbstractPaymentMethodHandler
-    implements AsynchronousPaymentHandlerInterface
+// phpcs:ignore Generic.Files.LineLength.TooLong
+class KlarnaPayLaterPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
     protected static $isOpenInvoice = true;

--- a/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
@@ -27,8 +27,8 @@ namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
 
-class KlarnaPayNowPaymentMethodHandler extends AbstractPaymentMethodHandler
-    implements AsynchronousPaymentHandlerInterface
+// phpcs:ignore Generic.Files.LineLength.TooLong
+class KlarnaPayNowPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
 
     protected static $isOpenInvoice = true;

--- a/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
@@ -27,7 +27,8 @@ namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
 
-class KlarnaPayNowPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class KlarnaPayNowPaymentMethodHandler extends AbstractPaymentMethodHandler
+    implements AsynchronousPaymentHandlerInterface
 {
 
     protected static $isOpenInvoice = true;

--- a/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
@@ -25,18 +25,15 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
-class KlarnaPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class KlarnaPayNowPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
+
+    protected static $isOpenInvoice = true;
 
     public static function getPaymentMethodCode()
     {
-        return 'klarna';
+        return 'klarna_paynow';
     }
 }

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -36,6 +36,11 @@ use Psr\Log\LoggerInterface;
 
 class ResultHandler
 {
+
+    const PA_RES = 'PaRes';
+    const MD = 'MD';
+    const REDIRECT_RESULT = 'redirectResult';
+
     /**
      * @var CheckoutService
      */
@@ -113,16 +118,20 @@ class ResultHandler
         if ('RedirectShopper' === $result->getResultCode()) {
             // Validate 3DS1 Post parameters
             // Get MD and PaRes to be validated
-            $md = $request->query->get('MD');
-            $paRes = $request->query->get('PaRes');
-            $redirectResult = $request->query->get('redirectResult');
+            $md = $request->query->get(self::MD);
+            $paRes = $request->query->get(self::PA_RES);
+            $redirectResult = $request->query->get(self::REDIRECT_RESULT);
 
             // Construct the details object for the paymentDetails request
-            $details = [
-                'MD' => $md,
-                'PaRes' => $paRes,
-                'redirectResult' => $redirectResult
-            ];
+            if (!empty($md)) {
+                $details[self::MD] = $md;
+            }
+            if (!empty($paRes)) {
+                $details[self::PA_RES] = $paRes;
+            }
+            if (!empty($redirectResult)) {
+                $details[self::REDIRECT_RESULT] = $redirectResult;
+            }
 
             // Validate the return
             $result = $this->paymentDetailsService->doPaymentDetails(

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -115,15 +115,13 @@ class ResultHandler
             // Get MD and PaRes to be validated
             $md = $request->query->get('MD');
             $paRes = $request->query->get('PaRes');
-
-            if (empty($md) || empty($paRes)) {
-                throw new PaymentException('MD and/or PaRes parameter is missing from the redirect request');
-            }
+            $redirectResult = $request->query->get('redirectResult');
 
             // Construct the details object for the paymentDetails request
             $details = [
                 'MD' => $md,
-                'PaRes' => $paRes
+                'PaRes' => $paRes,
+                'redirectResult' => $redirectResult
             ];
 
             // Validate the return

--- a/src/Handlers/SepaPaymentMethodHandler.php
+++ b/src/Handlers/SepaPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 class SepaPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {

--- a/src/Handlers/SofortPaymentMethodHandler.php
+++ b/src/Handlers/SofortPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 class SofortPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {

--- a/src/PaymentMethods/KlarnaPayLaterPaymentMethod.php
+++ b/src/PaymentMethods/KlarnaPayLaterPaymentMethod.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\KlarnaPayLaterPaymentMethodHandler;
+
+class KlarnaPayLaterPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Klarna Pay Later';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return ''; //TODO
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return KlarnaPayLaterPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_KLARNAPAYLATER';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/klarna.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/KlarnaPayNowPaymentMethod.php
+++ b/src/PaymentMethods/KlarnaPayNowPaymentMethod.php
@@ -24,9 +24,9 @@
 
 namespace Adyen\Shopware\PaymentMethods;
 
-use Adyen\Shopware\Handlers\KlarnaPaymentMethodHandler;
+use Adyen\Shopware\Handlers\KlarnaPayNowPaymentMethodHandler;
 
-class KlarnaPaymentMethod implements PaymentMethodInterface
+class KlarnaPayNowPaymentMethod implements PaymentMethodInterface
 {
     /**
      * {@inheritDoc}
@@ -35,7 +35,7 @@ class KlarnaPaymentMethod implements PaymentMethodInterface
      */
     public function getName(): string
     {
-        return 'Klarna Pay Later';
+        return 'Klarna Pay Now';
     }
 
     /**
@@ -55,7 +55,7 @@ class KlarnaPaymentMethod implements PaymentMethodInterface
      */
     public function getPaymentHandler(): string
     {
-        return KlarnaPaymentMethodHandler::class;
+        return KlarnaPayNowPaymentMethodHandler::class;
     }
 
     /**
@@ -65,7 +65,7 @@ class KlarnaPaymentMethod implements PaymentMethodInterface
      */
     public function getGatewayCode(): string
     {
-        return 'ADYEN_KLARNA';
+        return 'ADYEN_KLARNAPAYNOW';
     }
 
     /**

--- a/src/Resources/app/storefront/src/checkout/checkout.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/checkout.plugin.js
@@ -37,14 +37,16 @@ export default class CheckoutPlugin extends Plugin {
 
         const cardsFormattedHandlerIdentifier = 'handler_adyen_cardspaymentmethodhandler';
         const idealFormattedHandlerIdentifier = 'handler_adyen_idealpaymentmethodhandler';
-        const klarnaFormattedHandlerIdentifier = 'handler_adyen_klarnapaymentmethodhandler';
+        const klarnaPayNowFormattedHandlerIdentifier = 'handler_adyen_klarnapaynowpaymentmethodhandler';
+        const klarnaPayLaterFormattedHandlerIdentifier = 'handler_adyen_klarnapaylaterpaynowpaymentmethodhandler';
         const sepaFormattedHandlerIdentifier = 'handler_adyen_sepapaymentmethodhandler';
         const sofortFormattedHandlerIdentifier = 'handler_adyen_sofortpaymentmethodhandler';
 
         this.paymentMethodTypeHandlers = {
             'scheme': cardsFormattedHandlerIdentifier,
             'ideal': idealFormattedHandlerIdentifier,
-            'klarna': klarnaFormattedHandlerIdentifier,
+            'klarna': klarnaPayLaterFormattedHandlerIdentifier,
+            'klarna_paynow': klarnaPayNowFormattedHandlerIdentifier,
             'sepadirectdebit': sepaFormattedHandlerIdentifier,
             'sofort': sofortFormattedHandlerIdentifier
         };

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -76,7 +76,7 @@
             <argument type="service" id="adyen_payment_state_data.repository"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
         </service>
-        <service id="Adyen\Shopware\Handlers\CardsPaymentMethodHandler">
+        <service id="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler" abstract="true">
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="Adyen\Shopware\Service\CheckoutService"/>
             <argument type="service" id="Adyen\Service\Builder\Browser"/>
@@ -94,86 +94,29 @@
             <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
             <argument type="service" id="security.csrf.token_manager"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\CardsPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
         </service>
-        <service id="Adyen\Shopware\Handlers\IdealPaymentMethodHandler">
-            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
-            <argument type="service" id="Adyen\Shopware\Service\CheckoutService"/>
-            <argument type="service" id="Adyen\Service\Builder\Browser"/>
-            <argument type="service" id="Adyen\Service\Builder\Address"/>
-            <argument type="service" id="Adyen\Service\Builder\Payment"/>
-            <argument type="service" id="Adyen\Util\Currency"/>
-            <argument type="service" id="Adyen\Service\Builder\Customer"/>
-            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
-            <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
-            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
-            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
-            <argument type="service" id="Adyen\Shopware\Handlers\ResultHandler"/>
-            <argument type="service"
-                      id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
-            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
-            <argument type="service" id="security.csrf.token_manager"/>
-            <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
+        <service id="Adyen\Shopware\Handlers\IdealPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
         </service>
-        <service id="Adyen\Shopware\Handlers\KlarnaPaymentMethodHandler">
-            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
-            <argument type="service" id="Adyen\Shopware\Service\CheckoutService"/>
-            <argument type="service" id="Adyen\Service\Builder\Browser"/>
-            <argument type="service" id="Adyen\Service\Builder\Address"/>
-            <argument type="service" id="Adyen\Service\Builder\Payment"/>
-            <argument type="service" id="Adyen\Util\Currency"/>
-            <argument type="service" id="Adyen\Service\Builder\Customer"/>
-            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
-            <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
-            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
-            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
-            <argument type="service" id="Adyen\Shopware\Handlers\ResultHandler"/>
-            <argument type="service"
-                      id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
-            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
-            <argument type="service" id="security.csrf.token_manager"/>
-            <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
+        <service id="Adyen\Shopware\Handlers\KlarnaPayNowPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
         </service>
-        <service id="Adyen\Shopware\Handlers\SepaPaymentMethodHandler">
-            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
-            <argument type="service" id="Adyen\Shopware\Service\CheckoutService"/>
-            <argument type="service" id="Adyen\Service\Builder\Browser"/>
-            <argument type="service" id="Adyen\Service\Builder\Address"/>
-            <argument type="service" id="Adyen\Service\Builder\Payment"/>
-            <argument type="service" id="Adyen\Util\Currency"/>
-            <argument type="service" id="Adyen\Service\Builder\Customer"/>
-            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
-            <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
-            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
-            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
-            <argument type="service" id="Adyen\Shopware\Handlers\ResultHandler"/>
-            <argument type="service"
-                      id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
-            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
-            <argument type="service" id="security.csrf.token_manager"/>
-            <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
+        <service id="Adyen\Shopware\Handlers\KlarnaPayLaterPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
         </service>
-        <service id="Adyen\Shopware\Handlers\SofortPaymentMethodHandler">
-            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
-            <argument type="service" id="Adyen\Shopware\Service\CheckoutService"/>
-            <argument type="service" id="Adyen\Service\Builder\Browser"/>
-            <argument type="service" id="Adyen\Service\Builder\Address"/>
-            <argument type="service" id="Adyen\Service\Builder\Payment"/>
-            <argument type="service" id="Adyen\Util\Currency"/>
-            <argument type="service" id="Adyen\Service\Builder\Customer"/>
-            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
-            <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
-            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
-            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
-            <argument type="service" id="Adyen\Shopware\Handlers\ResultHandler"/>
-            <argument type="service"
-                      id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
-            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
-            <argument type="service" id="security.csrf.token_manager"/>
-            <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
+        <service id="Adyen\Shopware\Handlers\SepaPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\SofortPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
         </service>
         <service id="Adyen\Service\Builder\Browser"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -82,6 +82,7 @@
             <argument type="service" id="Adyen\Service\Builder\Browser"/>
             <argument type="service" id="Adyen\Service\Builder\Address"/>
             <argument type="service" id="Adyen\Service\Builder\Payment"/>
+            <argument type="service" id="Adyen\Service\Builder\OpenInvoice"/>
             <argument type="service" id="Adyen\Util\Currency"/>
             <argument type="service" id="Adyen\Service\Builder\Customer"/>
             <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
@@ -123,6 +124,7 @@
         <service id="Adyen\Service\Builder\Address"/>
         <service id="Adyen\Service\Builder\Payment"/>
         <service id="Adyen\Service\Builder\Customer"/>
+        <service id="Adyen\Service\Builder\OpenInvoice"/>
         <service id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
         <service id="Adyen\Shopware\Handlers\ResultHandler" autowire="true">
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -94,6 +94,8 @@
                       id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
             <argument type="service" id="security.csrf.token_manager"/>
+            <argument type="service" id="currency.repository"/>
+            <argument type="service" id="product.repository"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
         </service>
         <service id="Adyen\Shopware\Handlers\CardsPaymentMethodHandler"


### PR DESCRIPTION
## Summary
This PR adds order item lines to the payments request in order to support open invoice PMs. It also includes Klarna Pay Later and Pay Now.

The services.xml abstract payment method handler declaration now is parent to the concrete handlers and some old use statements were removed.

## Tested scenarios
Payments with Klarna Pay Later and Pay Now.
Payments with 3DS and non 3DS cards.

**Fixed issue**:  PW-2786
