### PR TITLE
[PW-2838] Investigate if payment response needs to be stored for ERROR payment result code

### DIFF
--- a/src/Resources/app/storefront/src/checkout/checkout.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/checkout.plugin.js
@@ -86,6 +86,7 @@ export default class CheckoutPlugin extends Plugin {
             originKey,
             environment,
             showPayButton: false,
+            hasHolderName: true,
             paymentMethodsResponse: JSON.parse(paymentMethodsResponse),
             onAdditionalDetails: handleOnAdditionalDetails.bind(this)
         };


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The /payments response needs to be stored even for ERROR results otherwise the payment status will fail 

## Tested scenarios
Authorised payment
Refused payment
Error payment
