### PR TITLE
Fixing invalid entity definitions

### DIFF
--- a/src/Entity/Notification/NotificationEntity.php
+++ b/src/Entity/Notification/NotificationEntity.php
@@ -97,6 +97,16 @@ class NotificationEntity extends Entity
     protected $processing;
 
     /**
+     * @var int
+     */
+    protected $errorCount;
+
+    /**
+     * @var string
+     */
+    protected $errorMessage;
+
+    /**
      * @return string
      */
     public function getPspReference(): string
@@ -302,5 +312,37 @@ class NotificationEntity extends Entity
     public function setProcessing(string $processing): void
     {
         $this->processing = $processing;
+    }
+
+    /**
+     * @return int
+     */
+    public function getErrorCount(): int
+    {
+        return $this->errorCount;
+    }
+
+    /**
+     * @param string $errorCount
+     */
+    public function setErrorCount(string $errorCount): void
+    {
+        $this->errorCount = $errorCount;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorMessage(): string
+    {
+        return $this->errorMessage;
+    }
+
+    /**
+     * @param string $errorMessage
+     */
+    public function setErrorMessage(string $errorMessage): void
+    {
+        $this->errorMessage = $errorMessage;
     }
 }

--- a/src/Entity/PaymentResponse/PaymentResponseEntity.php
+++ b/src/Entity/PaymentResponse/PaymentResponseEntity.php
@@ -38,7 +38,7 @@ class PaymentResponseEntity extends Entity
     /**
      * @var string
      */
-    protected $salesChannelApiContextToken;
+    protected $token;
 
     /**
      * @var string
@@ -85,17 +85,17 @@ class PaymentResponseEntity extends Entity
     /**
      * @return string
      */
-    public function getSalesChannelApiContextToken(): string
+    public function getToken(): string
     {
-        return $this->salesChannelApiContextToken;
+        return $this->token;
     }
 
     /**
-     * @param string $salesChannelApiContextToken
+     * @param string $token
      */
-    public function setSalesChannelApiContextToken(string $salesChannelApiContextToken): void
+    public function setToken(string $token): void
     {
-        $this->salesChannelApiContextToken = $salesChannelApiContextToken;
+        $this->token = $token;
     }
 
     /**


### PR DESCRIPTION
## Summary
The Notifications and Payment Response entities had invalid definitions.

**Fixed issue**:  Fixes #50 
