### PR TITLE
[PW-2937] Make plugin compatible with different payment methods

### DIFF
--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -14,6 +14,10 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     confirmOrder(event) {
+        if (!$('#confirmPaymentForm').find('input[name="paymentMethodId"]:checked').hasClass('adyen-payment-method-input-radio')) {
+            return true;
+        }
+
         if (!!adyenCheckoutOptions && !!adyenCheckoutOptions.paymentStatusUrl && adyenCheckoutOptions.checkoutOrderUrl) {
             event.preventDefault();
             const form = event.target;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -153,6 +153,7 @@
             <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentMethodsService"/>
+            <argument type="service" id="Shopware\Core\Framework\Plugin\Util\PluginIdProvider"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/src/Resources/views/storefront/component/payment/adyencheckout.html.twig
+++ b/src/Resources/views/storefront/component/payment/adyencheckout.html.twig
@@ -1,5 +1,5 @@
 {% set adyenFrontendData = page.extensions[constant('Adyen\\Shopware\\Subscriber\\PaymentSubscriber::ADYEN_DATA_EXTENSION_ID')] %}
-{% if adyenFrontendData and adyenFrontendData.locale %}
+{% if adyenFrontendData and adyenFrontendData.locale and adyenFrontendData.originKey and adyenFrontendData.environment and adyenFrontendData.paymentMethodsResponse %}
     <div id="adyen-checkout-configuration"
          data-locale="{{ adyenFrontendData.locale }}"
          data-origin-key="{{ adyenFrontendData.originKey }}"

--- a/src/Resources/views/storefront/component/payment/payment-fields.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-fields.html.twig
@@ -1,4 +1,5 @@
 {% sw_extends '@Storefront/storefront/component/payment/payment-fields.html.twig' %}
+{% set adyenFrontendData = page.extensions[constant('Adyen\\Shopware\\Subscriber\\PaymentSubscriber::ADYEN_DATA_EXTENSION_ID')] %}
 {% block component_payment_methods %}
     <div class="payment-methods">
         <template data-adyen-payment></template>
@@ -16,7 +17,7 @@
                                                name="paymentMethodId"
                                                value="{{ payment.id }}"
                                                {% if payment.id is same as(defaultPaymentMethodId) %}checked="checked"{% endif %}
-                                               class="custom-control-input payment-method-input">
+                                               class="custom-control-input payment-method-input {% if payment.pluginId is same as(adyenFrontendData.pluginId) %}adyen-payment-method-input-radio{% endif %}">
                                     {% endblock %}
                                     {% block component_payment_method_label %}
                                         <label class="custom-control-label payment-method-label"


### PR DESCRIPTION
## Summary
Don't change the behaviour of non adyen payment methods.
Check the pluginId of the payment method and if it's not from adyen do not interfere with the default process.

