### PR TITLE
[PW-2975] Adding support for multiple sales channels configurations

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -240,6 +240,7 @@ abstract class AbstractPaymentMethodHandler
         RequestDataBag $dataBag,
         SalesChannelContext $salesChannelContext
     ): RedirectResponse {
+        $this->checkoutService->startClient($salesChannelContext->getSalesChannel()->getId());
         try {
             $request = $this->preparePaymentsRequest($salesChannelContext, $transaction);
         } catch (Exception $exception) {
@@ -308,6 +309,7 @@ abstract class AbstractPaymentMethodHandler
         Request $request,
         SalesChannelContext $salesChannelContext
     ): void {
+        $this->checkoutService->startClient($salesChannelContext->getSalesChannel()->getId());
         try {
             $this->resultHandler->processResult($transaction, $request, $salesChannelContext);
         } catch (PaymentException $exception) {
@@ -528,7 +530,7 @@ abstract class AbstractPaymentMethodHandler
                 $salesChannelContext->getCurrency()->getIsoCode()
             ),
             $transaction->getOrder()->getOrderNumber(),
-            $this->configurationService->getMerchantAccount(),
+            $this->configurationService->getMerchantAccount($salesChannelContext->getSalesChannel()->getId()),
             $returnUrl,
             $request
         );

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -30,7 +30,6 @@ use Adyen\Shopware\Service\PaymentDetailsService;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
-use Adyen\Shopware\Service\CheckoutService;
 use Adyen\Shopware\Service\PaymentResponseService;
 use Psr\Log\LoggerInterface;
 
@@ -41,10 +40,6 @@ class ResultHandler
     const MD = 'MD';
     const REDIRECT_RESULT = 'redirectResult';
 
-    /**
-     * @var CheckoutService
-     */
-    private $checkoutService;
 
     /**
      * @var PaymentResponseService
@@ -74,7 +69,6 @@ class ResultHandler
     /**
      * ResultHandler constructor.
      *
-     * @param CheckoutService $checkoutService
      * @param PaymentResponseService $paymentResponseService
      * @param LoggerInterface $logger
      * @param PaymentResponseHandler $paymentResponseHandler
@@ -82,14 +76,12 @@ class ResultHandler
      * @param PaymentResponseHandlerResult $paymentResponseHandlerResult
      */
     public function __construct(
-        CheckoutService $checkoutService,
         PaymentResponseService $paymentResponseService,
         LoggerInterface $logger,
         PaymentResponseHandler $paymentResponseHandler,
         PaymentDetailsService $paymentDetailsService,
         PaymentResponseHandlerResult $paymentResponseHandlerResult
     ) {
-        $this->checkoutService = $checkoutService;
         $this->paymentResponseService = $paymentResponseService;
         $this->logger = $logger;
         $this->paymentResponseHandler = $paymentResponseHandler;
@@ -116,7 +108,7 @@ class ResultHandler
         $result = $this->paymentResponseHandlerResult->createFromPaymentResponse($paymentResponse);
 
         if ('RedirectShopper' === $result->getResultCode()) {
-            // Validate 3DS1 Post parameters
+            // Validate 3DS1 parameters
             // Get MD and PaRes to be validated
             $md = $request->query->get(self::MD);
             $paRes = $request->query->get(self::PA_RES);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -28,7 +28,9 @@
         <service id="Adyen\Shopware\Service\OriginKeyService" autowire="true">
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
         </service>
-        <service id="Adyen\Shopware\Service\CheckoutUtilityService" autowire="true"/>
+        <service id="Adyen\Shopware\Service\CheckoutUtilityService" autowire="true">
+            <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
+        </service>
         <service id="Adyen\Shopware\Service\ClientService" autowire="true">
             <argument key="$genericLogger" type="service" id="monolog.logger.adyen_generic"/>
             <argument key="$apiLogger" type="service" id="monolog.logger.adyen_api"/>
@@ -40,7 +42,9 @@
         <service id="Adyen\Shopware\Service\PaymentDetailsService" autowire="true">
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
         </service>
-        <service id="Adyen\Shopware\Service\CheckoutService" autowire="true"/>
+        <service id="Adyen\Shopware\Service\CheckoutService" autowire="true">
+            <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
+        </service>
         <service id="Adyen\Util\Currency" autowire="true"/>
         <service id="Adyen\Util\HmacSignature" autowire="true"/>
         <service id="Adyen\Shopware\Service\ConfigurationService" autowire="true">

--- a/src/Service/CheckoutService.php
+++ b/src/Service/CheckoutService.php
@@ -23,12 +23,36 @@
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\AdyenException;
 use Adyen\Service\Checkout;
+use Psr\Log\LoggerInterface;
 
 class CheckoutService extends Checkout
 {
-    public function __construct(ClientService $client)
+    /**
+     * @var ClientService
+     */
+    private $client;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        ClientService $client,
+        LoggerInterface $logger
+    ) {
+        $this->client = $client;
+        $this->logger = $logger;
+    }
+
+    public function startClient($salesChannelId)
     {
-        parent::__construct($client);
+        try {
+            parent::__construct($this->client->getClient($salesChannelId));
+        } catch (AdyenException $e) {
+            $this->logger->error($e->getMessage());
+        }
     }
 }

--- a/src/Service/CheckoutUtilityService.php
+++ b/src/Service/CheckoutUtilityService.php
@@ -24,10 +24,37 @@
 
 namespace Adyen\Shopware\Service;
 
-class CheckoutUtilityService extends \Adyen\Service\CheckoutUtility
+use Adyen\AdyenException;
+use Adyen\Service\CheckoutUtility;
+use Psr\Log\LoggerInterface;
+
+class CheckoutUtilityService extends CheckoutUtility
 {
-    public function __construct(ClientService $client)
+    /**
+     * @var ClientService
+     */
+    private $client;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        ClientService $client,
+        LoggerInterface $logger
+    ) {
+        $this->client = $client;
+        $this->logger = $logger;
+    }
+
+    public function startClient($salesChannelId)
     {
-        parent::__construct($client);
+        try {
+            $client = $this->client->getClient($salesChannelId);
+            return new parent($client);
+        } catch (AdyenException $e) {
+            $this->logger->error($e->getMessage());
+        }
     }
 }

--- a/src/Service/CheckoutUtilityService.php
+++ b/src/Service/CheckoutUtilityService.php
@@ -48,7 +48,7 @@ class CheckoutUtilityService extends CheckoutUtility
         $this->logger = $logger;
     }
 
-    public function startClient($salesChannelId)
+    public function getClientBySalesChannelId($salesChannelId)
     {
         try {
             $client = $this->client->getClient($salesChannelId);

--- a/src/Service/ConfigurationService.php
+++ b/src/Service/ConfigurationService.php
@@ -48,100 +48,120 @@ class ConfigurationService
     }
 
     /**
+     * @param string|null $salesChannelId
      * @return array|mixed|null
      */
-    public function getMerchantAccount()
+    public function getMerchantAccount(?string $salesChannelId)
     {
-        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.merchantAccount');
+        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.merchantAccount', $salesChannelId);
     }
 
     /**
+     * @param string $salesChannelId
      * @return array|mixed|null
      */
-    public function getApiKeyTest()
+    public function getApiKeyTest(string $salesChannelId)
     {
-        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.apiKeyTest');
+        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.apiKeyTest', $salesChannelId);
     }
 
     /**
+     * @param string $salesChannelId
      * @return array|mixed|null
      */
-    public function getApiKeyLive()
+    public function getApiKeyLive(string $salesChannelId)
     {
-        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.apiKeyLive');
+        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.apiKeyLive', $salesChannelId);
     }
 
     /**
+     * @param string $salesChannelId
      * @return array|mixed|null
      */
-    public function getEnvironment()
+    public function getEnvironment(?string $salesChannelId)
     {
-        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.environment') ?
+        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.environment', $salesChannelId) ?
             Environment::LIVE : Environment::TEST;
     }
 
     /**
+     * @param string $salesChannelId
      * @return array|mixed|null
      */
-    public function getLiveEndpointUrlPrefix()
+    public function getLiveEndpointUrlPrefix(string $salesChannelId)
     {
-        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.liveEndpointUrlPrefix');
+        return $this->systemConfigService->get(
+            self::BUNDLE_NAME . '.config.liveEndpointUrlPrefix',
+            $salesChannelId
+        );
     }
 
     /**
+     * @param string|null $salesChannelId
      * @return array|mixed|null
      */
-    public function getNotificationUsername()
+    public function getNotificationUsername(?string $salesChannelId)
     {
-        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.notificationUsername');
+        return $this->systemConfigService->get(
+            self::BUNDLE_NAME . '.config.notificationUsername',
+            $salesChannelId
+        );
     }
 
     /**
+     * @param string|null $salesChannelId
      * @return array|mixed|null
      */
-    public function getNotificationPassword()
+    public function getNotificationPassword(?string $salesChannelId)
     {
-        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.notificationPassword');
+        return $this->systemConfigService->get(
+            self::BUNDLE_NAME . '.config.notificationPassword',
+            $salesChannelId
+        );
     }
 
     /**
+     * @param string $salesChannelId
      * @return array|mixed|null
      */
-    public function getHmacTest()
+    public function getHmacTest(string $salesChannelId)
     {
-        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.hmacTest');
+        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.hmacTest', $salesChannelId);
     }
 
     /**
+     * @param string $salesChannelId
      * @return array|mixed|null
      */
-    public function getHmacLive()
+    public function getHmacLive(string $salesChannelId)
     {
-        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.hmacLive');
+        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.hmacLive', $salesChannelId);
     }
 
     /**
      * Returns HMAC Key based on the configured environment
+     * @param string|null $salesChannelId
      * @return array|mixed|null
      */
-    public function getHmacKey()
+    public function getHmacKey(?string $salesChannelId)
     {
-        if ($this->getEnvironment() === Environment::LIVE) {
-            return $this->getHmacLive();
+        if ($this->getEnvironment($salesChannelId) === Environment::LIVE) {
+            return $this->getHmacLive($salesChannelId);
         }
 
-        return $this->getHmacTest();
+        return $this->getHmacTest($salesChannelId);
     }
 
     /**
+     * @param string $salesChannelId
      * @return array|mixed|null
      */
-    public function getApiKey()
+    public function getApiKey(string $salesChannelId)
     {
-        if ($this->getEnvironment() === Environment::LIVE) {
-            return $this->getApiKeyLive();
+        if ($this->getEnvironment($salesChannelId) === Environment::LIVE) {
+            return $this->getApiKeyLive($salesChannelId);
         }
 
-        return $this->getApiKeyTest();
+        return $this->getApiKeyTest($salesChannelId);
     }
 }

--- a/src/Service/NotificationReceiverService.php
+++ b/src/Service/NotificationReceiverService.php
@@ -114,7 +114,7 @@ class NotificationReceiverService
         }
 
         // Is the plugin configured to live environment
-        $pluginMode = $this->configurationService->getEnvironment();
+        $pluginMode = $this->configurationService->getEnvironment(null);
 
         // Validate notification and process the notification items
         if (!empty($request['live']) && $this->validateNotificationMode($request['live'], $pluginMode)) {
@@ -205,8 +205,8 @@ class NotificationReceiverService
     private function isAuthorized($isTestNotification, $requestUser, $requestPassword)
     {
         // Retrieve username and password from config
-        $userName = $this->configurationService->getNotificationUsername();
-        $password = $this->configurationService->getNotificationPassword();
+        $userName = $this->configurationService->getNotificationUsername(null);
+        $password = $this->configurationService->getNotificationPassword(null);
 
         // Validate if username and password is sent
         if ((is_null($requestUser) || is_null($requestPassword))) {
@@ -257,8 +257,8 @@ class NotificationReceiverService
      */
     protected function processNotificationItem($notificationItem)
     {
-        $merchantAccount = $this->configurationService->getMerchantAccount();
-        $hmacKey = $this->configurationService->getHmacKey();
+        $merchantAccount = $this->configurationService->getMerchantAccount(null);
+        $hmacKey = $this->configurationService->getHmacKey(null);
 
         // validate the notification
         if ($this->isValidated($notificationItem, $merchantAccount, $hmacKey)) {

--- a/src/Service/OriginKeyService.php
+++ b/src/Service/OriginKeyService.php
@@ -70,7 +70,7 @@ class OriginKeyService
      */
     public function getOriginKeyForOrigin(string $host, string $salesChannelId): OriginKeyModel
     {
-        $client=$this->adyenCheckoutUtilityService->startClient($salesChannelId);
+        $client = $this->adyenCheckoutUtilityService->getClientBySalesChannelId($salesChannelId);
         $params = array("originDomains" => array($host));
         try {
             $response = $client->originKeys($params);

--- a/src/Service/OriginKeyService.php
+++ b/src/Service/OriginKeyService.php
@@ -65,14 +65,15 @@ class OriginKeyService
     /**
      * Get origin key for a specific origin using the adyen api library client
      * @param string $host
+     * @param string $salesChannelId
      * @return OriginKeyModel
      */
-    public function getOriginKeyForOrigin(string $host): OriginKeyModel
+    public function getOriginKeyForOrigin(string $host, string $salesChannelId): OriginKeyModel
     {
+        $client=$this->adyenCheckoutUtilityService->startClient($salesChannelId);
         $params = array("originDomains" => array($host));
-        $response = [];
         try {
-            $response = $this->adyenCheckoutUtilityService->originKeys($params);
+            $response = $client->originKeys($params);
         } catch (AdyenException $e) {
             $this->logger->error($e->getMessage());
             return $this->originKeyModel->setOriginKey('');

--- a/src/Service/PaymentDetailsService.php
+++ b/src/Service/PaymentDetailsService.php
@@ -138,6 +138,7 @@ class PaymentDetailsService
         ];
 
         try {
+            $this->checkoutService->startClient($context->getSalesChannel()->getId());
             $response = $this->checkoutService->paymentsDetails($request);
             return $this->paymentResponseHandler->handlePaymentResponse($response, $orderNumber, $context);
         } catch (AdyenException $exception) {

--- a/src/Service/PaymentMethodsService.php
+++ b/src/Service/PaymentMethodsService.php
@@ -97,6 +97,7 @@ class PaymentMethodsService
         try {
             $requestData = $this->buildPaymentMethodsRequestData($context);
             if (!empty($requestData)) {
+                $this->checkoutService->startClient($context->getSalesChannel()->getId());
                 $responseData = $this->checkoutService->paymentMethods($requestData);
             }
         } catch (AdyenException $e) {
@@ -116,7 +117,7 @@ class PaymentMethodsService
         }
 
         $cart = $this->cartService->getCart($context->getToken(), $context);
-        $merchantAccount = $this->configurationService->getMerchantAccount();
+        $merchantAccount = $this->configurationService->getMerchantAccount($context->getSalesChannel()->getId());
 
         if (!$merchantAccount) {
             $this->logger->error('No Merchant Account has been configured. ' .

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -206,12 +206,15 @@ class PaymentSubscriber implements EventSubscriberInterface
                     ),
                     'languageId' => $salesChannelContext->getContext()->getLanguageId(),
                     'originKey' => $this->originKeyService->getOriginKeyForOrigin(
-                        $this->salesChannelRepository->getSalesChannelUrl($salesChannelContext)
+                        $this->salesChannelRepository->getSalesChannelUrl($salesChannelContext),
+                        $salesChannelContext->getSalesChannel()->getId()
                     )->getOriginKey(),
                     'locale' => $this->salesChannelRepository->getSalesChannelAssocLocale($salesChannelContext)
                         ->getLanguage()->getLocale()->getCode(),
 
-                    'environment' => $this->configurationService->getEnvironment(),
+                    'environment' => $this->configurationService->getEnvironment(
+                        $event->getSalesChannelContext()->getSalesChannel()->getId()
+                    ),
                     'paymentMethodsResponse' => json_encode(
                         $this->paymentMethodsService->getPaymentMethods($salesChannelContext)
                     ),


### PR DESCRIPTION
## Summary
The plugin used to fetch the default configuration for all sales channels for all operations. With this PR the API calls make use of the current sales channel configuration values.

The redirect of 3DS1 payments on non-default sales channels fails because Shopware generates a finishUrl for the default sales channel and not for the current one.

## Tested scenarios
3DS and non-3DS payments in default and non default sales channels (3DS1 fails when using a non-default sales channel with no default configuration).
Klarna Pay Now and Klarna Pay Later in default and non default sales channels.

**Fixed issue**:  PW-2975 fixes #46 
