### PR TITLE
[PW-2787] New paypal integration

### DIFF
--- a/src/Exception/PaymentCancelledException.php
+++ b/src/Exception/PaymentCancelledException.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Exception;
+
+class PaymentCancelledException extends PaymentException
+{
+
+}

--- a/src/Exception/PaymentFailedException.php
+++ b/src/Exception/PaymentFailedException.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Exception;
+
+class PaymentFailedException extends PaymentException
+{
+
+}

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -693,7 +693,6 @@ abstract class AbstractPaymentMethodHandler
 
         switch ($exceptionType) {
             case PaymentCancelledException::class:
-                $this->logger->debug('ATTILA CANCELLED DEBUG');
                 throw new CustomerCanceledAsyncPaymentException(
                     $transactionId,
                     $exception->getMessage()

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -698,11 +698,8 @@ abstract class AbstractPaymentMethodHandler
                     $transactionId,
                     $exception->getMessage()
                 );
+                break;
             case PaymentFailedException::class:
-                throw new AsyncPaymentFinalizeException(
-                    $transactionId,
-                    $exception->getMessage()
-                );
             default:
                 throw new AsyncPaymentFinalizeException(
                     $transactionId,

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -687,7 +687,8 @@ abstract class AbstractPaymentMethodHandler
      * @param PaymentException $exception
      * @param $transactionId
      */
-    private function handlePaymentException(PaymentException $exception, $transactionId) {
+    private function handlePaymentException(PaymentException $exception, $transactionId)
+    {
 
         $exceptionType = get_class($exception);
 

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -169,6 +169,13 @@ class PaymentResponseHandler
         return $this->paymentResponseHandlerResult;
     }
 
+    /**
+     * @param AsyncPaymentTransactionStruct $transaction
+     * @param SalesChannelContext $salesChannelContext
+     * @param PaymentResponseHandlerResult $paymentResponseHandlerResult
+     * @throws PaymentCancelledException
+     * @throws PaymentFailedException
+     */
     public function handleShopwareApis(
         AsyncPaymentTransactionStruct $transaction,
         SalesChannelContext $salesChannelContext,

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -26,7 +26,9 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Handlers;
 
+use Adyen\Shopware\Exception\PaymentCancelledException;
 use Adyen\Shopware\Exception\PaymentException;
+use Adyen\Shopware\Exception\PaymentFailedException;
 use Psr\Log\LoggerInterface;
 use Adyen\Shopware\Service\PaymentResponseService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
@@ -46,7 +48,7 @@ class PaymentResponseHandler
     const PENDING = 'Pending';
     const PRESENT_TO_SHOPPER = 'PresentToShopper';
     const ERROR = 'Error';
-    const CANCELED = 'Canceled';
+    const CANCELLED = 'Cancelled';
 
     const PSP_REFERENCE = 'pspReference';
     const ORIGINAL_PSP_REFERENCE = 'originalPspReference';
@@ -138,6 +140,7 @@ class PaymentResponseHandler
                 );
 
                 break;
+            case self::CANCELLED:
             case self::AUTHORISED:
             case self::REDIRECT_SHOPPER:
             case self::IDENTIFY_SHOPPER:
@@ -220,10 +223,18 @@ class PaymentResponseHandler
                 break;
             case self::REFUSED:
                 //Sync response, do nothing, wait for finalize()
-                $this->transactionStateHandler->fail($orderTransactionId, $context);
+                //$this->transactionStateHandler->fail($orderTransactionId, $context);
                 // Cancel the order
-                throw new PaymentException(
+                throw new PaymentFailedException(
                     'The payment was refused'
+                );
+                break;
+            case self::CANCELLED:
+                //Sync response, do nothing, wait for finalize()
+                //$this->transactionStateHandler->fail($orderTransactionId, $context);
+                // Cancel the order
+                throw new PaymentCancelledException(
+                    'The payment was cancelled'
                 );
                 break;
             case self::REDIRECT_SHOPPER:
@@ -237,7 +248,7 @@ class PaymentResponseHandler
             case self::ERROR:
             default:
                 // Cancel the order
-                throw new PaymentException(
+                throw new PaymentFailedException(
                     'The payment had an error or an unhandled result code'
                 );
         }
@@ -307,7 +318,7 @@ class PaymentResponseHandler
                     return true;
                 }
                 break;
-            case self::CANCELED:
+            case self::CANCELLED:
                 if ($transactionStateTechnicalName === OrderTransactionStates::STATE_CANCELLED) {
                     return true;
                 }

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -43,6 +43,7 @@ class PaymentResponseHandler
     const IDENTIFY_SHOPPER = 'IdentifyShopper';
     const CHALLENGE_SHOPPER = 'ChallengeShopper';
     const RECEIVED = 'Received';
+    const PENDING = 'Pending';
     const PRESENT_TO_SHOPPER = 'PresentToShopper';
     const ERROR = 'Error';
     const CANCELED = 'Canceled';
@@ -143,6 +144,7 @@ class PaymentResponseHandler
             case self::CHALLENGE_SHOPPER:
             case self::RECEIVED:
             case self::PRESENT_TO_SHOPPER:
+            case self::PENDING:
                 // Do nothing here
                 break;
             case self::ERROR:
@@ -258,6 +260,7 @@ class PaymentResponseHandler
             case self::IDENTIFY_SHOPPER:
             case self::CHALLENGE_SHOPPER:
             case self::PRESENT_TO_SHOPPER:
+            case self::PENDING:
                 return [
                     "isFinal" => false,
                     "resultCode" => $this->paymentResponseHandlerResult->getResultCode(),

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -222,16 +222,12 @@ class PaymentResponseHandler
                 $this->transactionStateHandler->paid($orderTransactionId, $context);
                 break;
             case self::REFUSED:
-                //Sync response, do nothing, wait for finalize()
-                //$this->transactionStateHandler->fail($orderTransactionId, $context);
                 // Cancel the order
                 throw new PaymentFailedException(
                     'The payment was refused'
                 );
                 break;
             case self::CANCELLED:
-                //Sync response, do nothing, wait for finalize()
-                //$this->transactionStateHandler->fail($orderTransactionId, $context);
                 // Cancel the order
                 throw new PaymentCancelledException(
                     'The payment was cancelled'

--- a/src/Handlers/PaypalPaymentMethodHandler.php
+++ b/src/Handlers/PaypalPaymentMethodHandler.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  *                       ######
  *                       ######
@@ -22,17 +23,18 @@
  * Author: Adyen <shopware@adyen.com>
  */
 
-namespace Adyen\Shopware\PaymentMethods;
+namespace Adyen\Shopware\Handlers;
 
-class PaymentMethods
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+
+// phpcs:ignore Generic.Files.LineLength.TooLong
+class PaypalPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
 {
-    const PAYMENT_METHODS = [
-        CardsPaymentMethod::class,
-        IdealPaymentMethod::class,
-        KlarnaPayNowPaymentMethod::class,
-        KlarnaPayLaterPaymentMethod::class,
-        SepaPaymentMethod::class,
-        SofortPaymentMethod::class,
-        PaypalPaymentMethod::class
-    ];
+
+    protected static $isOpenInvoice = false;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'paypal';
+    }
 }

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -40,6 +40,7 @@ class ResultHandler
     const PA_RES = 'PaRes';
     const MD = 'MD';
     const REDIRECT_RESULT = 'redirectResult';
+    const PAYLOAD = 'payload';
 
     /**
      * @var CheckoutService
@@ -121,16 +122,25 @@ class ResultHandler
             $md = $request->query->get(self::MD);
             $paRes = $request->query->get(self::PA_RES);
             $redirectResult = $request->query->get(self::REDIRECT_RESULT);
+            $payload = $request->query->get(self::PAYLOAD);
+
+            $details = [];
 
             // Construct the details object for the paymentDetails request
             if (!empty($md)) {
                 $details[self::MD] = $md;
             }
+
             if (!empty($paRes)) {
                 $details[self::PA_RES] = $paRes;
             }
+
             if (!empty($redirectResult)) {
                 $details[self::REDIRECT_RESULT] = $redirectResult;
+            }
+
+            if (!empty($payload)) {
+                $details[self::PAYLOAD] = $payload;
             }
 
             // Validate the return

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -25,7 +25,8 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Handlers;
 
-use Adyen\Shopware\Exception\PaymentException;
+use Adyen\Shopware\Exception\PaymentCancelledException;
+use Adyen\Shopware\Exception\PaymentFailedException;
 use Adyen\Shopware\Service\PaymentDetailsService;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -102,7 +103,8 @@ class ResultHandler
      * @param AsyncPaymentTransactionStruct $transaction
      * @param Request $request
      * @param SalesChannelContext $salesChannelContext
-     * @throws PaymentException
+     * @throws PaymentCancelledException
+     * @throws PaymentFailedException
      */
     public function processResult(
         AsyncPaymentTransactionStruct $transaction,

--- a/src/PaymentMethods/PaypalPaymentMethod.php
+++ b/src/PaymentMethods/PaypalPaymentMethod.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\PaypalPaymentMethodHandler;
+
+class PaypalPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'PayPal';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return ''; //TODO
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return PaypalPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_PAYPAL';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/paypal.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/Resources/app/storefront/src/checkout/checkout.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/checkout.plugin.js
@@ -41,6 +41,7 @@ export default class CheckoutPlugin extends Plugin {
         const klarnaPayLaterFormattedHandlerIdentifier = 'handler_adyen_klarnapaylaterpaynowpaymentmethodhandler';
         const sepaFormattedHandlerIdentifier = 'handler_adyen_sepapaymentmethodhandler';
         const sofortFormattedHandlerIdentifier = 'handler_adyen_sofortpaymentmethodhandler';
+        const paypalFormattedHandlerIdentifier = 'handler_adyen_paypalpaymentmethodhandler';
 
         this.paymentMethodTypeHandlers = {
             'scheme': cardsFormattedHandlerIdentifier,
@@ -48,7 +49,8 @@ export default class CheckoutPlugin extends Plugin {
             'klarna': klarnaPayLaterFormattedHandlerIdentifier,
             'klarna_paynow': klarnaPayNowFormattedHandlerIdentifier,
             'sepadirectdebit': sepaFormattedHandlerIdentifier,
-            'sofort': sofortFormattedHandlerIdentifier
+            'sofort': sofortFormattedHandlerIdentifier,
+            'paypal': paypalFormattedHandlerIdentifier
         };
 
         //PMs that should show an 'Update Details' button if there's already a state.data for that PM stored for this context

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -122,6 +122,10 @@
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
         </service>
+        <service id="Adyen\Shopware\Handlers\PaypalPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
         <service id="Adyen\Service\Builder\Browser"/>
         <service id="Adyen\Service\Builder\Address"/>
         <service id="Adyen\Service\Builder\Payment"/>


### PR DESCRIPTION
## Summary
Add paypal support in checkout without using the adyen checkout components

Known issue, will be fixed by shopware in the core: https://issues.shopware.com/issues/NEXT-8636
When the customer cancels the payment the payment status will be failed in the admin and the customer will see a message related to failed payment and not cancelled payment.

## Tested scenarios
paypal successful payment
paypal cancelled payment