### PR TITLE
[PW-3004] Fix payment when attempt without state.data stored but requested from db

### DIFF
--- a/src/Controller/SalesChannelApiController.php
+++ b/src/Controller/SalesChannelApiController.php
@@ -218,11 +218,18 @@ class SalesChannelApiController extends AbstractController
             return new JsonResponse('Order ID not provided');
         }
 
-        return new JsonResponse(
-            $this->paymentStatusService->getPaymentStatusWithOrderId(
-                $request->get('orderId'),
-                $context
-            )
-        );
+        try {
+            return new JsonResponse(
+                $this->paymentStatusService->getPaymentStatusWithOrderId(
+                    $request->get('orderId'),
+                    $context
+                )
+            );
+        } catch (\Exception $exception) {
+
+            // TODO log error message
+
+            return new JsonResponse(["isFinal" => true]);
+        }
     }
 }

--- a/src/Controller/SalesChannelApiController.php
+++ b/src/Controller/SalesChannelApiController.php
@@ -31,6 +31,7 @@ use Adyen\Shopware\Service\PaymentDetailsService;
 use Adyen\Shopware\Service\PaymentMethodsService;
 use Adyen\Shopware\Service\PaymentResponseService;
 use Adyen\Shopware\Service\PaymentStatusService;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -84,6 +85,11 @@ class SalesChannelApiController extends AbstractController
     private $paymentResponseHandler;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * SalesChannelApiController constructor.
      *
      * @param OriginKeyService $originKeyService
@@ -94,6 +100,7 @@ class SalesChannelApiController extends AbstractController
      * @param PaymentStatusService $paymentStatusService
      * @param PaymentResponseHandler $paymentResponseHandler
      * @param PaymentResponseService $paymentResponseService
+     * @param LoggerInterface $logger
      */
     public function __construct(
         OriginKeyService $originKeyService,
@@ -103,7 +110,8 @@ class SalesChannelApiController extends AbstractController
         CheckoutStateDataValidator $checkoutStateDataValidator,
         PaymentStatusService $paymentStatusService,
         PaymentResponseHandler $paymentResponseHandler,
-        PaymentResponseService $paymentResponseService
+        PaymentResponseService $paymentResponseService,
+        LoggerInterface $logger
     ) {
         $this->originKeyService = $originKeyService;
         $this->paymentMethodsService = $paymentMethodsService;
@@ -113,6 +121,7 @@ class SalesChannelApiController extends AbstractController
         $this->paymentStatusService = $paymentStatusService;
         $this->paymentResponseHandler = $paymentResponseHandler;
         $this->paymentResponseService = $paymentResponseService;
+        $this->logger = $logger;
     }
 
     /**
@@ -226,9 +235,7 @@ class SalesChannelApiController extends AbstractController
                 )
             );
         } catch (\Exception $exception) {
-
-            // TODO log error message
-
+            $this->logger->error($exception->getMessage());
             return new JsonResponse(["isFinal" => true]);
         }
     }

--- a/src/Resources/app/storefront/src/validator/FormValidatorWithComponent.js
+++ b/src/Resources/app/storefront/src/validator/FormValidatorWithComponent.js
@@ -20,13 +20,17 @@
  *
  */
 
-export default class CardFormValidator {
-    constructor(cardInstance) {
-        this.cardInstance = cardInstance;
+export default class FormValidatorWithComponent {
+    constructor(component) {
+        this.component = component;
     }
 
     validateForm() {
-        this.cardInstance.showValidation();
-        return this.cardInstance.isValid;
+        if (!this.component.isValid) {
+            this.component.showValidation();
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -23,6 +23,7 @@
             <argument type="service" id="Adyen\Shopware\Service\PaymentStatusService"/>
             <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentResponseService"/>
+            <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="Adyen\Shopware\Service\OriginKeyService" autowire="true">

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -102,7 +102,7 @@ class PaymentResponseService
     public function getWithSalesChannelApiContextTokenAndOrderNumber(
         string $salesChannelApiContextToken,
         string $orderNumber
-    ): PaymentResponseEntity {
+    ): ?PaymentResponseEntity {
         return $this->repository
             ->search(
                 (new Criteria())

--- a/src/Service/PaymentStatusService.php
+++ b/src/Service/PaymentStatusService.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\Exception\MissingDataException;
 use Adyen\Shopware\Handlers\PaymentResponseHandler;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -51,16 +52,23 @@ class PaymentStatusService
     public function getPaymentStatusWithOrderId(string $orderId, SalesChannelContext $context): array
     {
         $paymentResponse = $this->paymentResponseService->getWithOrderId($orderId, $context->getToken());
-        $responseData = json_decode($paymentResponse->getResponse(), true);
-        
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            //TODO error handling
+
+        if (empty($paymentResponse)) {
+            throw new MissingDataException('Payment response cannot be found!');
         }
+
+        $responseData = json_decode($paymentResponse->getResponse(), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \JsonException('Payment response is an invalid JSON');
+        }
+
         $result = $this->paymentResponseHandler->handlePaymentResponse(
             $responseData,
             $paymentResponse->getOrderNumber(),
             $context
         );
+
         return $this->paymentResponseHandler->handleAdyenApis($result);
     }
 }

--- a/src/Service/PaymentStatusService.php
+++ b/src/Service/PaymentStatusService.php
@@ -54,13 +54,13 @@ class PaymentStatusService
         $paymentResponse = $this->paymentResponseService->getWithOrderId($orderId, $context->getToken());
 
         if (empty($paymentResponse)) {
-            throw new MissingDataException('Payment response cannot be found!');
+            throw new MissingDataException('Payment response cannot be found for order id: ' . $orderId . '!');
         }
 
         $responseData = json_decode($paymentResponse->getResponse(), true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \JsonException('Payment response is an invalid JSON');
+            throw new \JsonException('Payment response is an invalid JSON for order id: ' . $orderId . '');
         }
 
         $result = $this->paymentResponseHandler->handlePaymentResponse(


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
A 500 error can occur 
 - when the customer doesn't complete the component before saving the payment method configuration therefore the state.data is missing from the /payments request because of the missing frontend validation
 - when the customer arrives to the payment methods list page while their preferred payment method is already selected therefore they don't change and store it but places the order right away

## Tested scenarios
<!-- Description of tested scenarios -->
Wrong details filled in the checkout component - validation won't let the customer to save the changes anymore
Payment method change is not saved but order is placed - redirects the user to the finalize page and shows an error message while the payment is failed in the admin page
