### PR TITLE
[PW-3042] Fix account order construct incompatibility with 6.3.*

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -175,11 +175,8 @@
         <!--Service decorators-->
         <service id="Adyen\Shopware\Storefront\Controller\AdyenAccountOrderController"
                  decorates="Shopware\Storefront\Controller\AccountOrderController">
-            <argument type="service"
-                      id="Adyen\Shopware\Storefront\Controller\AdyenAccountOrderController.inner"/>
             <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountOrderPageLoader"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\OrderRoute"/>
-            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder"/>
             <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountEditOrderPageLoader"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\CancelOrderRoute"/>

--- a/src/Storefront/Controller/AdyenAccountOrderController.php
+++ b/src/Storefront/Controller/AdyenAccountOrderController.php
@@ -6,7 +6,6 @@ use Shopware\Core\Checkout\Order\SalesChannel\AbstractCancelOrderRoute;
 use Shopware\Core\Checkout\Order\SalesChannel\AbstractOrderRoute;
 use Shopware\Core\Checkout\Order\SalesChannel\AbstractSetPaymentOrderRoute;
 use Shopware\Core\Checkout\Payment\SalesChannel\AbstractHandlePaymentMethodRoute;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute;
@@ -29,10 +28,8 @@ class AdyenAccountOrderController extends AccountOrderController
     private $contextSwitchRoute;
 
     public function __construct(
-        AccountOrderController $accountOrderController,
         AccountOrderPageLoader $orderPageLoader,
         AbstractOrderRoute $orderRoute,
-        RequestCriteriaBuilder $requestCriteriaBuilder,
         AccountEditOrderPageLoader $accountEditOrderPageLoader,
         ContextSwitchRoute $contextSwitchRoute,
         AbstractCancelOrderRoute $cancelOrderRoute,
@@ -44,7 +41,6 @@ class AdyenAccountOrderController extends AccountOrderController
         parent::__construct(
             $orderPageLoader,
             $orderRoute,
-            $requestCriteriaBuilder,
             $accountEditOrderPageLoader,
             $contextSwitchRoute,
             $cancelOrderRoute,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adjust constructor to shopware 6.3 in AdyenAccountOrderController
Drop support for shopware 6.2.*

## Tested scenarios
After failed payment a new payment can be initiated in the account orders page