### PR TITLE
Make API version in routes dynamic

### DIFF
--- a/src/Controller/SalesChannelApiController.php
+++ b/src/Controller/SalesChannelApiController.php
@@ -127,7 +127,7 @@ class SalesChannelApiController extends AbstractController
     /**
      * @RouteScope(scopes={"sales-channel-api"})
      * @Route(
-     *     "/sales-channel-api/v1/adyen/origin-key",
+     *     "/sales-channel-api/v{version}/adyen/origin-key",
      *     name="sales-channel-api.action.adyen.origin-key",
      *     methods={"GET"}
      * )
@@ -149,7 +149,7 @@ class SalesChannelApiController extends AbstractController
     /**
      * @RouteScope(scopes={"sales-channel-api"})
      * @Route(
-     *     "/sales-channel-api/v1/adyen/payment-methods",
+     *     "/sales-channel-api/v{version}/adyen/payment-methods",
      *     name="sales-channel-api.action.adyen.payment-methods",
      *     methods={"GET"}
      * )
@@ -165,7 +165,7 @@ class SalesChannelApiController extends AbstractController
     /**
      * @RouteScope(scopes={"sales-channel-api"})
      * @Route(
-     *     "/sales-channel-api/v2/adyen/payment-details",
+     *     "/sales-channel-api/v{version}/adyen/payment-details",
      *     name="sales-channel-api.action.adyen.payment-details",
      *     methods={"POST"}
      * )
@@ -212,7 +212,7 @@ class SalesChannelApiController extends AbstractController
     /**
      * @RouteScope(scopes={"sales-channel-api"})
      * @Route(
-     *     "/sales-channel-api/v2/adyen/payment-status",
+     *     "/sales-channel-api/v{version}/adyen/payment-status",
      *     name="sales-channel-api.action.adyen.payment-status",
      *     methods={"POST"}
      * )


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Shopware deprecates API versions constantly, these can be made dynamic and should be tested in 6.3 versions of the platform.

## Tested scenarios
<!-- Description of tested scenarios -->
Payment with cards
