### PR TITLE
[PW-3190] Moving AdyenAccountOrderController from a decorated service to a controller

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -153,6 +153,10 @@
         <service id="Adyen\Shopware\Service\ContainerParametersService" autowire="true">
         </service>
         <service id="Adyen\Shopware\Handlers\PaymentResponseHandlerResult" autowire="true"/>
+        <service id="Adyen\Shopware\Storefront\Controller\AdyenAccountOrderController">
+            <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
+            <tag name="controller.service_arguments"/>
+        </service>
 
         <!--Event subscribers-->
         <service id="Adyen\Shopware\Subscriber\PaymentSubscriber">
@@ -173,18 +177,6 @@
         </service>
 
         <!--Service decorators-->
-        <service id="Adyen\Shopware\Storefront\Controller\AdyenAccountOrderController"
-                 decorates="Shopware\Storefront\Controller\AccountOrderController">
-            <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountOrderPageLoader"/>
-            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\OrderRoute"/>
-            <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountEditOrderPageLoader"/>
-            <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
-            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\CancelOrderRoute"/>
-            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRoute"/>
-            <argument type="service" id="Shopware\Core\Checkout\Payment\SalesChannel\HandlePaymentMethodRoute"/>
-            <argument type="service" id="event_dispatcher"/>
-            <tag name="controller.service_arguments"/>
-        </service>
         <service id="Adyen\Shopware\Framework\Cookie\AdyenCookieProvider"
                  decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">
             <argument type="service"

--- a/src/Storefront/Controller/AdyenAccountOrderController.php
+++ b/src/Storefront/Controller/AdyenAccountOrderController.php
@@ -2,18 +2,11 @@
 
 namespace Adyen\Shopware\Storefront\Controller;
 
-use Shopware\Core\Checkout\Order\SalesChannel\AbstractCancelOrderRoute;
-use Shopware\Core\Checkout\Order\SalesChannel\AbstractOrderRoute;
-use Shopware\Core\Checkout\Order\SalesChannel\AbstractSetPaymentOrderRoute;
-use Shopware\Core\Checkout\Payment\SalesChannel\AbstractHandlePaymentMethodRoute;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Storefront\Controller\AccountOrderController;
-use Shopware\Storefront\Page\Account\Order\AccountEditOrderPageLoader;
-use Shopware\Storefront\Page\Account\Order\AccountOrderPageLoader;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
@@ -22,32 +15,15 @@ use Symfony\Component\Routing\Annotation\Route;
 /**
  * @RouteScope(scopes={"storefront"})
  */
-class AdyenAccountOrderController extends AccountOrderController
+class AdyenAccountOrderController extends StorefrontController
 {
 
     private $contextSwitchRoute;
 
     public function __construct(
-        AccountOrderPageLoader $orderPageLoader,
-        AbstractOrderRoute $orderRoute,
-        AccountEditOrderPageLoader $accountEditOrderPageLoader,
-        ContextSwitchRoute $contextSwitchRoute,
-        AbstractCancelOrderRoute $cancelOrderRoute,
-        AbstractSetPaymentOrderRoute $setPaymentOrderRoute,
-        AbstractHandlePaymentMethodRoute $handlePaymentMethodRoute,
-        EventDispatcherInterface $eventDispatcher
+        ContextSwitchRoute $contextSwitchRoute
     ) {
         $this->contextSwitchRoute = $contextSwitchRoute;
-        parent::__construct(
-            $orderPageLoader,
-            $orderRoute,
-            $accountEditOrderPageLoader,
-            $contextSwitchRoute,
-            $cancelOrderRoute,
-            $setPaymentOrderRoute,
-            $handlePaymentMethodRoute,
-            $eventDispatcher
-        );
     }
 
     /**


### PR DESCRIPTION
## Summary
`AdyenAccountOrderController` was a service decorating and extending `AccountOrderController`, this broke implementations on Shopware versions that changed the constructor’s signature.

We're moving that logic into a storefront controller accessible through an overridden route. The controller then adds the extra parameters to the RequestBag.

## Tested scenarios
Shopware 6.3.2.0
Editing the order's payment methods.


**Fixed issue**:  PW-3190 Fixes #71
