### PR TITLE
[PW-2842] Getting module version from plugin entity

### DIFF
--- a/src/AdyenPaymentShopware6.php
+++ b/src/AdyenPaymentShopware6.php
@@ -140,4 +140,6 @@ class AdyenPaymentShopware6 extends Plugin
     }
 }
 
-require_once __DIR__ . '/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -33,6 +33,7 @@
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
         </service>
         <service id="Adyen\Shopware\Service\ClientService" autowire="true">
+            <argument type="service" id="plugin.repository"/>
             <argument key="$genericLogger" type="service" id="monolog.logger.adyen_generic"/>
             <argument key="$apiLogger" type="service" id="monolog.logger.adyen_api"/>
         </service>

--- a/src/Service/ClientService.php
+++ b/src/Service/ClientService.php
@@ -130,7 +130,8 @@ class ClientService extends Client
     }
 
     /**
-     * Get adyen module's version from PluginEntity
+     * Get adyen module's version from cache if exists or from PluginEntity
+     * Stores the module version in the cache when empty
      *
      * @return string
      */

--- a/src/Service/ClientService.php
+++ b/src/Service/ClientService.php
@@ -26,12 +26,19 @@ namespace Adyen\Shopware\Service;
 
 use Adyen\Client;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Store\Services\StoreService;
+use Psr\Cache\CacheItemPoolInterface;
 
 class ClientService extends Client
 {
     const MERCHANT_APPLICATION_NAME = 'adyen-shopware6';
     const EXTERNAL_PLATFORM_NAME = 'Shopware';
+    const MODULE_VERSION_CACHE_TAG = 'adyen_module_version';
 
     /**
      * @var ConfigurationService
@@ -59,27 +66,42 @@ class ClientService extends Client
     private $storeService;
 
     /**
+     * @var EntityRepositoryInterface
+     */
+    private $pluginRepository;
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
      * Client constructor.
      *
+     * @param EntityRepositoryInterface $pluginRepository
      * @param LoggerInterface $genericLogger
      * @param LoggerInterface $apiLogger
      * @param ConfigurationService $configurationService
      * @param ContainerParametersService $containerParametersService
      * @param StoreService $storeService
-     * @throws \Adyen\AdyenException
+     * @param CacheItemPoolInterface $cache
      */
     public function __construct(
+        EntityRepositoryInterface $pluginRepository,
         LoggerInterface $genericLogger,
         LoggerInterface $apiLogger,
         ConfigurationService $configurationService,
         ContainerParametersService $containerParametersService,
-        StoreService $storeService
+        StoreService $storeService,
+        CacheItemPoolInterface $cache
     ) {
+        $this->pluginRepository = $pluginRepository;
         $this->configurationService = $configurationService;
         $this->genericLogger = $genericLogger;
         $this->apiLogger = $apiLogger;
         $this->containerParametersService = $containerParametersService;
         $this->storeService = $storeService;
+        $this->cache = $cache;
     }
 
     public function getClient($salesChannelId)
@@ -108,33 +130,37 @@ class ClientService extends Client
     }
 
     /**
-     * Get adyen module's version from composer.json
-     * TODO: switch to a shopware service to retrieve the module version instead of composer
+     * Get adyen module's version from PluginEntity
      *
      * @return string
      */
     public function getModuleVersion()
     {
-        $rootDir = $this->containerParametersService->getApplicationRootDir();
+        try {
+            $moduleVersionCacheItem = $this->cache->getItem(self::MODULE_VERSION_CACHE_TAG);
+        } catch (\Psr\Cache\InvalidArgumentException $e) {
+            $this->genericLogger->error($e->getMessage());
+        }
 
-        $composerJson = file_get_contents($rootDir . '/custom/plugins/adyen-shopware6/composer.json');
+        //Prefer the cached module version
+        if (!$moduleVersionCacheItem->isHit() || !$moduleVersionCacheItem->get()) {
+            /** @var PluginEntity $pluginEntity */
+            $pluginEntity = $this->pluginRepository->search(
+                (new Criteria())->addFilter(new EqualsFilter('name', ConfigurationService::BUNDLE_NAME)),
+                Context::createDefaultContext()
+            )->first();
+            $pluginVersion = $pluginEntity->getVersion();
+            $moduleVersionCacheItem->set($pluginVersion);
+            $this->cache->save($moduleVersionCacheItem);
+        } else {
+            $pluginVersion = $moduleVersionCacheItem->get();
+        }
 
-        if (false === $composerJson) {
-            $this->genericLogger->error('composer.json is not available in the Adyen plugin folder');
+        if (empty($pluginVersion)) {
+            $this->genericLogger->error('Adyen plugin version is not available');
             return "NA";
         }
 
-        $composerJson = json_decode($composerJson, true);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            $this->genericLogger->error('composer.json is not a valid JSON in the Adyen plugin folder');
-            return "NA";
-        }
-
-        if (empty($composerJson['version'])) {
-            $this->genericLogger->error('Adyen plugin version is not available in composer.json');
-            return "NA";
-        }
-
-        return $composerJson['version'];
+        return $pluginVersion;
     }
 }


### PR DESCRIPTION
## Summary
The plugin used to get the module version from the composer file and this caused problems with the directory structure. We're switching to the plugin entity to fetch this value now, leveraging the cache system.

## Tested scenarios
Shopware 6.3.2.0
`getModuleVersion()` queries the plugin entity to get the installed version. In production mode this value is then saved in cache for future use.

**Fixed issue**:  PW-2842 Fixes #49 
