### PR TITLE
[PW-2839] Removing plugin data on uninstall

### DIFF
--- a/src/AdyenPaymentShopware6.php
+++ b/src/AdyenPaymentShopware6.php
@@ -118,8 +118,11 @@ class AdyenPaymentShopware6 extends Plugin
         return $paymentIds->getIds()[0];
     }
 
-    private function setPaymentMethodIsActive(bool $active, Context $context, PaymentMethodInterface $paymentMethod): void
-    {
+    private function setPaymentMethodIsActive(
+        bool $active,
+        Context $context,
+        PaymentMethodInterface $paymentMethod
+    ): void {
         /** @var EntityRepositoryInterface $paymentRepository */
         $paymentRepository = $this->container->get('payment_method.repository');
 

--- a/src/AdyenPaymentShopware6.php
+++ b/src/AdyenPaymentShopware6.php
@@ -100,10 +100,15 @@ class AdyenPaymentShopware6 extends Plugin
         $systemConfigRepository->delete($ids, Context::createDefaultContext());
 
         //Dropping database tables
+        $tables = [
+            NotificationEntityDefinition::ENTITY_NAME,
+            PaymentStateDataEntityDefinition::ENTITY_NAME,
+            PaymentResponseEntityDefinition::ENTITY_NAME
+        ];
         $connection = $this->container->get(Connection::class);
-        $connection->executeUpdate('DROP TABLE IF EXISTS `'.NotificationEntityDefinition::ENTITY_NAME.'`');
-        $connection->executeUpdate('DROP TABLE IF EXISTS `'.PaymentResponseEntityDefinition::ENTITY_NAME.'`');
-        $connection->executeUpdate('DROP TABLE IF EXISTS `'.PaymentStateDataEntityDefinition::ENTITY_NAME.'`');
+        foreach ($tables as $table) {
+            $connection->executeUpdate(\sprintf('DROP TABLE IF EXISTS `%s`', $table));
+        }
     }
 
     private function addPaymentMethod(PaymentMethodInterface $paymentMethod, Context $context): void

--- a/src/AdyenPaymentShopware6.php
+++ b/src/AdyenPaymentShopware6.php
@@ -79,7 +79,7 @@ class AdyenPaymentShopware6 extends Plugin
             $this->setPaymentMethodIsActive(false, $uninstallContext->getContext(), new $paymentMethod());
         }
 
-        //Call parent function and exit if the user prefers to keep the plugin's data
+        //Exit here if the user prefers to keep the plugin's data
         if ($uninstallContext->keepUserData()) {
             return;
         }


### PR DESCRIPTION
## Summary
If during uninstallation the user selects "Remove all plugin data permanently" the configuration keys used by the bundle are deleted and the plugin's tables are dropped.

Payment methods are not removed as the IDs could still be referenced from order_transaction.

## Tested scenarios
Shopware 6.3.2.0
Uninstall with "Remove all plugin data permanently" checked: Deactivates all payment methods, deletes configuration keys and drops adyen tables.
Uninstall with "Remove all plugin data permanently" unchecked: Deactivates all payment methods.

**Fixed issue**:  PW-2839
