### PR TITLE
Changing twig if statement to check if payment method handler contains 'handler_adyen_'

### DIFF
--- a/src/Resources/views/storefront/component/payment/payment-fields.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-fields.html.twig
@@ -17,7 +17,7 @@
                                                name="paymentMethodId"
                                                value="{{ payment.id }}"
                                                {% if payment.id is same as(defaultPaymentMethodId) %}checked="checked"{% endif %}
-                                               class="custom-control-input payment-method-input {% if payment.pluginId is same as(adyenFrontendData.pluginId) %}adyen-payment-method-input-radio{% endif %}">
+                                               class="custom-control-input payment-method-input {% if 'handler_adyen_' in payment.formattedHandlerIdentifier %}adyen-payment-method-input-radio{% endif %}">
                                     {% endblock %}
                                     {% block component_payment_method_label %}
                                         <label class="custom-control-label payment-method-label"


### PR DESCRIPTION
## Summary
In Shopware 6.3.2.1 the `payment` entity in `payment-fields.html.twig` doesn't include `pluginId`. We're checking for the formatted payment method handler identifier to apply the Adyen class instead.

## Tested scenarios
Shopware 6.3.2.1
Adyen payment methods include the Adyen class in the frontend used for order form interception.