### PR TITLE
Checking if order is 'in_progress' before doing do_pay transition

### DIFF
--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -245,8 +245,11 @@ class PaymentResponseHandler
             case self::CHALLENGE_SHOPPER:
             case self::RECEIVED:
             case self::PRESENT_TO_SHOPPER:
-                // Return to the frontend without throwing an exception
-                $this->transactionStateHandler->process($orderTransactionId, $context);
+                //The payment is in progress, transition order to do_pay if it's not already there
+                if ($stateTechnicalName !== 'in_progress') {
+                    // Return to the frontend without throwing an exception
+                    $this->transactionStateHandler->process($orderTransactionId, $context);
+                }
                 break;
             case self::ERROR:
             default:


### PR DESCRIPTION
## Summary
The plugin attempted to move the order with do_pay more than once for some payments.

e.g. SEPA might return 'Received', then both the `pay()` and `finalize()` functions tried to process it. `finalize()` doesn't need to move the order because the response was sync.

## Tested scenarios
Shopware 6.3.2.1
'Received' payments move the oder to in_progress on `pay()` sync response only.