### PR TITLE
[PW-2789 ] Enable save card details

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -369,6 +369,11 @@ abstract class AbstractPaymentMethodHandler
             $paymentMethodType = $request['paymentMethod']['type'];
         }
 
+        if ($request['storePaymentMethod'] === true) {
+            $request['recurringProcessingModel'] = 'CardOnFile';
+            $request['shopperInteraction'] = 'Ecommerce';
+        }
+
         //Setting browser info if not present in statedata
         if (empty($request['browserInfo']['acceptHeader'])) {
             $acceptHeader = $_SERVER['HTTP_ACCEPT'];

--- a/src/Resources/app/storefront/src/checkout/checkout.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/checkout.plugin.js
@@ -144,6 +144,10 @@ export default class CheckoutPlugin extends Plugin {
             onChange: this.onPaymentMethodChange.bind(this)
         });
 
+        if (paymentMethod.type === 'scheme') {
+            configuration.enableStoreDetails = true;
+        }
+
         try {
             const paymentMethodInstance = window.adyenCheckout
                 .create(paymentMethod.type, configuration);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This adds support for saving card details. A future pull request will enable paying with stored credit cards.

The data is stored in Adyen servers securely, and only a token is shared between the plugin and Adyen.

## Tested scenarios
<!-- Description of tested scenarios -->
Payment with credit cards, asking to save the card details or not.

**Fixed issue**:  <!-- #-prefixed issue number -->
