### PR TITLE
[PW-3301] /paymentMethods call in order edit is not using the order data

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,6 +14,10 @@
             <argument type="service" id="sales_channel_domain.repository"/>
             <argument type="service" id="sales_channel.repository"/>
         </service>
+        <service id="Adyen\Shopware\Service\Repository\OrderRepository" autowire="true">
+            <argument type="service" id="order.repository"/>
+            <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
+        </service>
         <service id="Adyen\Shopware\Controller\SalesChannelApiController">
             <argument type="service" id="Adyen\Shopware\Service\OriginKeyService"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentMethodsService"/>

--- a/src/Service/Repository/OrderRepository.php
+++ b/src/Service/Repository/OrderRepository.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Adyen\Shopware\Service\Repository;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+
+class OrderRepository
+{
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * OrderRepository constructor.
+     *
+     * @param EntityRepositoryInterface $orderRepository
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        EntityRepositoryInterface $orderRepository,
+        LoggerInterface $logger
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param string $orderId
+     * @param Context $context
+     * @return OrderEntity|null
+     */
+    public function getOrder(string $orderId, Context $context) : ?OrderEntity
+    {
+        $order = null;
+
+        try {
+            $criteria = new Criteria();
+            $criteria->addFilter(new EqualsFilter('id', $orderId));
+            $criteria->addAssociation('currency');
+
+            /** @var OrderEntity $order */
+            $order = $this->orderRepository->search($criteria, $context)->first();
+        } catch (Exception $e) {
+            $this->logger->error($e->getMessage(), [$e]);
+        }
+
+        return $order;
+    }
+}

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -173,7 +173,7 @@ class PaymentSubscriber implements EventSubscriberInterface
             $salesChannelContext->getContext()
         );
 
-        $paymentMethodsResponse = $this->paymentMethodsService->getPaymentMethods($salesChannelContext);
+        $paymentMethodsResponse = $this->paymentMethodsService->getPaymentMethods($salesChannelContext, $orderId);
 
         $page->addExtension(
             self::ADYEN_DATA_EXTENSION_ID,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Use the order currency and order total amount for the paymentMethods request in case the order is already created (edit order)
Use the cart currency and cart total amount when the payment happens in the checkout

## Tested scenarios
paymentMethods request in order edit
paymentMethods request in checkout
