### PR TITLE
Add minutely scheduled tasks for notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cyattilakiss @acampos1916 @msilvagarcia @rikterbeek
+* @cyattilakiss @acampos1916 @msilvagarcia @rikterbeek @peterojo

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -178,7 +178,7 @@
             <argument type="service" id="scheduled_task.repository" />
             <tag name="messenger.message_handler" />
             <call method="setLogger">
-                <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
+                <argument key="$logger" type="service" id="monolog.logger.adyen_notification"/>
             </call>
         </service>
         <service id="Adyen\Shopware\ScheduledTask\ScheduleNotifications">
@@ -188,7 +188,7 @@
             <argument type="service" id="scheduled_task.repository" />
             <tag name="messenger.message_handler" />
             <call method="setLogger">
-                <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
+                <argument key="$logger" type="service" id="monolog.logger.adyen_notification"/>
             </call>
         </service>
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -177,6 +177,9 @@
         <service id="Adyen\Shopware\ScheduledTask\ProcessNotificationsHandler">
             <argument type="service" id="scheduled_task.repository" />
             <tag name="messenger.message_handler" />
+            <call method="setLogger">
+                <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
+            </call>
         </service>
         <service id="Adyen\Shopware\ScheduledTask\ScheduleNotifications">
             <tag name="shopware.scheduled.task" />
@@ -184,6 +187,9 @@
         <service id="Adyen\Shopware\ScheduledTask\ScheduleNotificationsHandler">
             <argument type="service" id="scheduled_task.repository" />
             <tag name="messenger.message_handler" />
+            <call method="setLogger">
+                <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
+            </call>
         </service>
 
         <!--Event subscribers-->

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -171,6 +171,20 @@
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
             <tag name="controller.service_arguments"/>
         </service>
+        <service id="Adyen\Shopware\ScheduledTask\ProcessNotifications">
+            <tag name="shopware.scheduled.task" />
+        </service>
+        <service id="Adyen\Shopware\ScheduledTask\ProcessNotificationsHandler">
+            <argument type="service" id="scheduled_task.repository" />
+            <tag name="messenger.message_handler" />
+        </service>
+        <service id="Adyen\Shopware\ScheduledTask\ScheduleNotifications">
+            <tag name="shopware.scheduled.task" />
+        </service>
+        <service id="Adyen\Shopware\ScheduledTask\ScheduleNotificationsHandler">
+            <argument type="service" id="scheduled_task.repository" />
+            <tag name="messenger.message_handler" />
+        </service>
 
         <!--Event subscribers-->
         <service id="Adyen\Shopware\Subscriber\PaymentSubscriber">

--- a/src/ScheduledTask/ProcessNotifications.php
+++ b/src/ScheduledTask/ProcessNotifications.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\ScheduledTask;
+
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+
+class ProcessNotifications extends ScheduledTask
+{
+    public static function getTaskName(): string
+    {
+        return 'adyen.process_notifications';
+    }
+
+    public static function getDefaultInterval(): int
+    {
+        return 60; // 1 minute
+    }
+}

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\ScheduledTask;
+
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+
+class ProcessNotificationsHandler extends ScheduledTaskHandler
+{
+    public static function getHandledMessages(): iterable
+    {
+        return [ ProcessNotifications::class ];
+    }
+
+    public function run()
+    {
+        // import logger and add debug lines
+    }
+}

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -24,10 +24,13 @@
 
 namespace Adyen\Shopware\ScheduledTask;
 
+use Psr\Log\LoggerAwareTrait;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 
 class ProcessNotificationsHandler extends ScheduledTaskHandler
 {
+    use LoggerAwareTrait;
+
     public static function getHandledMessages(): iterable
     {
         return [ ProcessNotifications::class ];
@@ -35,6 +38,7 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
 
     public function run()
     {
-        // import logger and add debug lines
+        // @todo do the business
+        $this->logger->debug(ProcessNotifications::class . ' tasks are running.');
     }
 }

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -36,7 +36,7 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
         return [ ProcessNotifications::class ];
     }
 
-    public function run()
+    public function run(): void
     {
         // @todo do the business
         $this->logger->debug(ProcessNotifications::class . ' tasks are running.');

--- a/src/ScheduledTask/ScheduleNotifications.php
+++ b/src/ScheduledTask/ScheduleNotifications.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\ScheduledTask;
+
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+
+class ScheduleNotifications extends ScheduledTask
+{
+    public static function getTaskName(): string
+    {
+        return 'adyen.schedule_notifications';
+    }
+
+    public static function getDefaultInterval(): int
+    {
+        return 60; // 1 minute
+    }
+}

--- a/src/ScheduledTask/ScheduleNotificationsHandler.php
+++ b/src/ScheduledTask/ScheduleNotificationsHandler.php
@@ -24,10 +24,13 @@
 
 namespace Adyen\Shopware\ScheduledTask;
 
+use Psr\Log\LoggerAwareTrait;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 
 class ScheduleNotificationsHandler extends ScheduledTaskHandler
 {
+    use LoggerAwareTrait;
+
     public static function getHandledMessages(): iterable
     {
         return [ ScheduleNotifications::class ];
@@ -35,6 +38,7 @@ class ScheduleNotificationsHandler extends ScheduledTaskHandler
 
     public function run()
     {
-        // import logger and add debug lines
+        // @todo do the business
+        $this->logger->debug(ScheduleNotifications::class . ' tasks are running.');
     }
 }

--- a/src/ScheduledTask/ScheduleNotificationsHandler.php
+++ b/src/ScheduledTask/ScheduleNotificationsHandler.php
@@ -36,7 +36,7 @@ class ScheduleNotificationsHandler extends ScheduledTaskHandler
         return [ ScheduleNotifications::class ];
     }
 
-    public function run()
+    public function run(): void
     {
         // @todo do the business
         $this->logger->debug(ScheduleNotifications::class . ' tasks are running.');

--- a/src/ScheduledTask/ScheduleNotificationsHandler.php
+++ b/src/ScheduledTask/ScheduleNotificationsHandler.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\ScheduledTask;
+
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+
+class ScheduleNotificationsHandler extends ScheduledTaskHandler
+{
+    public static function getHandledMessages(): iterable
+    {
+        return [ ScheduleNotifications::class ];
+    }
+
+    public function run()
+    {
+        // import logger and add debug lines
+    }
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
As part of the effort to add support for payment notifications,
We introduce 2 scheduled tasks for `ProcessNotifications` and `ScheduleNotifications` which run every minute
## Tested scenarios
<!-- Description of tested scenarios -->
Logged messages appear every minute in `var/log/adyen/notification.log`

**Fixed issue**:  PW-3587<!-- #-prefixed issue number -->
