### PR TITLE
[PW-3588] migration to add scheduled_processing_time to notification

### DIFF
--- a/src/Entity/Notification/NotificationEntity.php
+++ b/src/Entity/Notification/NotificationEntity.php
@@ -97,6 +97,11 @@ class NotificationEntity extends Entity
     protected $processing;
 
     /**
+     * @var \DateTimeInterface|null
+     */
+    protected $scheduledProcessingTime;
+
+    /**
      * @var int
      */
     protected $errorCount;
@@ -312,6 +317,22 @@ class NotificationEntity extends Entity
     public function setProcessing(string $processing): void
     {
         $this->processing = $processing;
+    }
+
+    /**
+     * @return \DateTimeInterface|null
+     */
+    public function getScheduledProcessingTime(): ?\DateTimeInterface
+    {
+        return $this->scheduledProcessingTime;
+    }
+
+    /**
+     * @param \DateTimeInterface $scheduleProcessingTime
+     */
+    public function setScheduledProcessingTime(\DateTimeInterface $scheduleProcessingTime): void
+    {
+        $this->scheduledProcessingTime = $scheduleProcessingTime;
     }
 
     /**

--- a/src/Entity/Notification/NotificationEntityDefinition.php
+++ b/src/Entity/Notification/NotificationEntityDefinition.php
@@ -31,6 +31,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
@@ -74,6 +75,7 @@ class NotificationEntityDefinition extends EntityDefinition
             new StringField('additional_data', 'additionalData'),
             new BoolField('done', 'done'),
             new BoolField('processing', 'processing'),
+            new DateTimeField('scheduled_processing_time', 'scheduledProcessingTime'),
             new IntField('error_count', 'errorCount'),
             new StringField('error_message', 'errorMessage'),
             new CreatedAtField(),

--- a/src/Migration/Migration1607529255AdyenNotification.php
+++ b/src/Migration/Migration1607529255AdyenNotification.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Adyen\Shopware\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1607529255AdyenNotification extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1607529255;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate("
+            alter table `adyen_notification`
+            add column scheduled_processing_time datetime null after processing;
+        ");
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Add new filed scheduled_processing_time via migration to the adyen_notification table.
## Tested scenarios
<!-- Description of tested scenarios -->
Check new table column exists after reinstalling or updating the plugin

**Fixed issue**:  PW-3588<!-- #-prefixed issue number -->
