### PR TITLE
[PW-3591] add method in NotificationService to set scheduled_processing_time on Notification

### DIFF
--- a/src/Entity/Notification/NotificationEntity.php
+++ b/src/Entity/Notification/NotificationEntity.php
@@ -34,7 +34,7 @@ class NotificationEntity extends Entity
     /**
      * @var string
      */
-    protected $pspReference;
+    protected $pspreference;
 
     /**
      * @var string
@@ -114,17 +114,17 @@ class NotificationEntity extends Entity
     /**
      * @return string
      */
-    public function getPspReference(): string
+    public function getPspreference(): string
     {
-        return $this->pspReference;
+        return $this->pspreference;
     }
 
     /**
-     * @param string $pspReference
+     * @param string $pspreference
      */
-    public function setPspReference(string $pspReference): void
+    public function setPspreference(string $pspreference): void
     {
-        $this->pspReference = $pspReference;
+        $this->pspreference = $pspreference;
     }
 
     /**

--- a/src/Entity/Notification/NotificationEntityDefinition.php
+++ b/src/Entity/Notification/NotificationEntityDefinition.php
@@ -62,7 +62,7 @@ class NotificationEntityDefinition extends EntityDefinition
     {
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
-            new StringField('pspreference', 'pspReference'),
+            new StringField('pspreference', 'pspreference'),
             new StringField('original_reference', 'originalReference'),
             new StringField('merchant_reference', 'merchantReference'),
             new StringField('event_code', 'eventCode'),

--- a/src/Service/ConfigurationService.php
+++ b/src/Service/ConfigurationService.php
@@ -158,10 +158,10 @@ class ConfigurationService
 
     /**
      * Returns HMAC Key based on the configured environment
-     * @param string|null $salesChannelId
+     * @param string $salesChannelId
      * @return array|mixed|null
      */
-    public function getHmacKey(string $salesChannelId = null)
+    public function getHmacKey(string $salesChannelId)
     {
         if ($this->getEnvironment($salesChannelId) === Environment::LIVE) {
             return $this->getHmacLive($salesChannelId);

--- a/src/Service/NotificationReceiverService.php
+++ b/src/Service/NotificationReceiverService.php
@@ -122,6 +122,7 @@ class NotificationReceiverService
 
             // Process each notification item
             foreach ($request['notificationItems'] as $notificationItem) {
+                $notificationItem['NotificationRequestItem']['live'] = $request['live'];
                 if (!$this->processNotificationItem($notificationItem['NotificationRequestItem'])) {
                     throw new ValidationException();
                 }

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -72,38 +72,38 @@ class NotificationService
     {
         //TODO Handle the notification as a model object to avoid this?
         $fields = [];
-        if (!empty($notification['pspreference'])) {
-            $fields['pspreference'] = $notification['pspreference'];
+        if (!empty($notification['pspReference'])) {
+            $fields['pspreference'] = $notification['pspReference'];
         }
-        if (!empty($notification['original_reference'])) {
-            $fields['original_reference'] = $notification['original_reference'];
+        if (!empty($notification['originalReference'])) {
+            $fields['originalReference'] = $notification['originalReference'];
         }
-        if (!empty($notification['merchant_reference'])) {
-            $fields['merchant_reference'] = $notification['merchant_reference'];
+        if (!empty($notification['merchantReference'])) {
+            $fields['merchantReference'] = $notification['merchantReference'];
         }
-        if (!empty($notification['event_code'])) {
-            $fields['event_code'] = $notification['event_code'];
+        if (!empty($notification['eventCode'])) {
+            $fields['eventCode'] = $notification['eventCode'];
         }
         if (!empty($notification['success'])) {
-            $fields['success'] = (bool)$notification['success'];
+            $fields['success'] = "true" === $notification['success'];
         }
-        if (!empty($notification['payment_method'])) {
-            $fields['payment_method'] = $notification['payment_method'];
+        if (!empty($notification['paymentMethod'])) {
+            $fields['paymentMethod'] = $notification['paymentMethod'];
         }
-        if (!empty($notification['amount_value'])) {
-            $fields['amount_value'] = $notification['amount_value'];
+        if (!empty($notification['amount']['value'])) {
+            $fields['amountValue'] = (string)$notification['amount']['value'];
         }
-        if (!empty($notification['amount_currency'])) {
-            $fields['amount_currency'] = $notification['amount_currency'];
+        if (!empty($notification['amount']['currency'])) {
+            $fields['amountCurrency'] = $notification['amount']['currency'];
         }
         if (!empty($notification['reason'])) {
             $fields['reason'] = $notification['reason'];
         }
         if (!empty($notification['live'])) {
-            $fields['live'] = $notification['live'];
+            $fields['live'] = "true" === $notification['live'];
         }
-        if (!empty($notification['additional_data'])) {
-            $fields['additional_data'] = $notification['additional_data'];
+        if (!empty($notification['additionalData'])) {
+            $fields['additionalData'] = json_encode($notification['additionalData']);
         }
 
         $this->notificationRepository->create(

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -24,7 +24,6 @@
 
 namespace Adyen\Shopware\Service;
 
-use Adyen\Shopware\Entity\Notification\NotificationEntity;
 use DateTimeInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
@@ -115,13 +114,15 @@ class NotificationService
         );
     }
 
-    public function scheduleNotification(NotificationEntity $notification, DateTimeInterface $scheduledProcessingTime)
+    public function setNotificationSchedule(string $notificationId, DateTimeInterface $scheduledProcessingTime)
     {
-        $fields = $notification->getVars();
-        $fields['scheduledProcessingTime'] = $scheduledProcessingTime;
-
         $this->notificationRepository->update(
-            [$fields],
+            [
+                [
+                    'id' => $notificationId,
+                    'scheduledProcessingTime' => $scheduledProcessingTime
+                ]
+            ],
             Context::createDefaultContext()
         );
     }

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -24,6 +24,8 @@
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\Shopware\Entity\Notification\NotificationEntity;
+use DateTimeInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -31,6 +33,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 
 class NotificationService
 {
+    /** @var EntityRepositoryInterface */
     protected $notificationRepository;
 
     public function __construct(EntityRepositoryInterface $notificationRepository)
@@ -108,7 +111,18 @@ class NotificationService
 
         $this->notificationRepository->create(
             [$fields],
-            \Shopware\Core\Framework\Context::createDefaultContext()
+            Context::createDefaultContext()
+        );
+    }
+
+    public function scheduleNotification(NotificationEntity $notification, DateTimeInterface $scheduledProcessingTime)
+    {
+        $fields = $notification->getVars();
+        $fields['scheduledProcessingTime'] = $scheduledProcessingTime;
+
+        $this->notificationRepository->update(
+            [$fields],
+            Context::createDefaultContext()
         );
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Add method in `NotificationService` to set the scheduled processing time on a notification, which will be triggered via the scheduled task (shopware cron job) for every notification that needs to be scheduled.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->
`scheduled_processing_time` field is updated in database.
the whole flow can be tested when the scheduled task is implemented in a subsequent PR

**Fixed issue**:  PW-3591 <!-- #-prefixed issue number -->
