### PR TITLE
[PW-3589] Add getScheduledUnprocessedNotifications() to NotificationService

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/src/Service/ConfigurationService.php
+++ b/src/Service/ConfigurationService.php
@@ -93,8 +93,8 @@ class ConfigurationService
     }
 
     /**
-     * @param string $salesChannelId
-     * @return array|mixed|null
+     * @param string|null $salesChannelId
+     * @return string
      */
     public function getEnvironment(string $salesChannelId = null)
     {

--- a/src/Service/NotificationReceiverService.php
+++ b/src/Service/NotificationReceiverService.php
@@ -119,7 +119,7 @@ class NotificationReceiverService
         $pluginIsLive = $this->configurationService->getEnvironment() === Environment::LIVE;
 
         // Is the notification coming from live environment?
-        if(!is_bool($request['live'] ?? null)) {
+        if (!is_bool($request['live'] ?? null)) {
             $request['live'] = isset($request['live']) && $request['live'] === 'true';
         }
 

--- a/src/Service/NotificationReceiverService.php
+++ b/src/Service/NotificationReceiverService.php
@@ -115,10 +115,11 @@ class NotificationReceiverService
         }
 
         $acceptedMessage = '[accepted]';
+        $isLive = isset($request['live']) && $request['live'] === 'true';
 
         // Process each notification item
         foreach ($request['notificationItems'] as $notificationItem) {
-            $notificationItem['NotificationRequestItem']['live'] = isset($request['live']) && $request['live'] === 'true';
+            $notificationItem['NotificationRequestItem']['live'] = $isLive;
             if (!$this->processNotificationItem($notificationItem['NotificationRequestItem'], $salesChannelId)) {
                 throw new ValidationException();
             }

--- a/src/Service/NotificationReceiverService.php
+++ b/src/Service/NotificationReceiverService.php
@@ -24,6 +24,7 @@
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\Environment;
 use Adyen\Shopware\Exception\AuthenticationException;
 use Adyen\Shopware\Exception\AuthorizationException;
 use Adyen\Shopware\Exception\HMACKeyValidationException;
@@ -94,7 +95,7 @@ class NotificationReceiverService
         $basicAuthUser = $requestObject->server->get('PHP_AUTH_USER');
         $basicAuthPassword = $requestObject->server->get('PHP_AUTH_PW');
 
-        // Validate if notification is not empty
+        // Checks if notification is empty
         if (empty($request)) {
             $message = 'Notification is empty';
             $this->logger->critical($message);
@@ -114,35 +115,16 @@ class NotificationReceiverService
             throw new AuthorizationException();
         }
 
-        // Is the plugin configured to live environment
-        $pluginMode = $this->configurationService->getEnvironment();
+        // Is the plugin configured to live environment?
+        $pluginIsLive = $this->configurationService->getEnvironment() === Environment::LIVE;
 
-        // Validate notification and process the notification items
-        if (!empty($request['live']) && $this->validateNotificationMode($request['live'], $pluginMode)) {
-            $acceptedMessage = '[accepted]';
+        // Is the notification coming from live environment?
+        if(!is_bool($request['live'] ?? null)) {
+            $request['live'] = isset($request['live']) && $request['live'] === 'true';
+        }
 
-            // Process each notification item
-            foreach ($request['notificationItems'] as $notificationItem) {
-                $notificationItem['NotificationRequestItem']['live'] = $request['live'];
-                if (!$this->processNotificationItem($notificationItem['NotificationRequestItem'], $salesChannelId)) {
-                    throw new ValidationException();
-                }
-            }
-
-            // Run the query for checking unprocessed notifications, do this only for test notifications coming from
-            // the Adyen Customer Area
-            if ($isTestNotification) {
-                $unprocessedNotifications = $this->notificationService->getNumberOfUnprocessedNotifications();
-                if ($unprocessedNotifications > 0) {
-                    $acceptedMessage .= "\nYou have $unprocessedNotifications unprocessed notifications.";
-                }
-            }
-            $this->logger->info('The result is accepted');
-
-            return new JsonResponse(
-                $this->returnAccepted($acceptedMessage)
-            );
-        } else {
+        // Checks if notification mode and the store mode configuration matches
+        if ($request['live'] !== $pluginIsLive) {
             $message = 'Mismatch between Live/Test modes of Shopware store and the Adyen platform';
             $this->logger->critical($message);
             return new JsonResponse(
@@ -152,6 +134,30 @@ class NotificationReceiverService
                 )
             );
         }
+
+        $acceptedMessage = '[accepted]';
+
+        // Process each notification item
+        foreach ($request['notificationItems'] as $notificationItem) {
+            $notificationItem['NotificationRequestItem']['live'] = $request['live'];
+            if (!$this->processNotificationItem($notificationItem['NotificationRequestItem'], $salesChannelId)) {
+                throw new ValidationException();
+            }
+        }
+
+        // Run the query for checking unprocessed notifications, do this only for test notifications coming from
+        // the Adyen Customer Area
+        if ($isTestNotification) {
+            $unprocessedNotifications = $this->notificationService->getNumberOfUnprocessedNotifications();
+            if ($unprocessedNotifications > 0) {
+                $acceptedMessage .= "\nYou have $unprocessedNotifications unprocessed notifications.";
+            }
+        }
+        $this->logger->info('The result is accepted');
+
+        return new JsonResponse(
+            $this->returnAccepted($acceptedMessage)
+        );
     }
 
     /**
@@ -166,7 +172,7 @@ class NotificationReceiverService
      * @throws HMACKeyValidationException
      * @throws MerchantAccountCodeException
      */
-    protected function isValidated($notification, $merchantAccount, $hmacKey)
+    private function isValidated($notification, $merchantAccount, $hmacKey)
     {
         // Check if the notification is a test notification
         $isTestNotification = $this->isTestNotificationPspReference($notification['pspReference']);
@@ -258,7 +264,7 @@ class NotificationReceiverService
      * @throws HMACKeyValidationException
      * @throws MerchantAccountCodeException
      */
-    protected function processNotificationItem($notificationItem, $salesChannelId)
+    private function processNotificationItem($notificationItem, $salesChannelId)
     {
         $merchantAccount = $this->configurationService->getMerchantAccount();
         $hmacKey = $this->configurationService->getHmacKey($salesChannelId);
@@ -292,31 +298,12 @@ class NotificationReceiverService
     }
 
     /**
-     * Checks if notification mode and the store mode configuration matches
-     *
-     * @param string|bool $notificationMode
-     * @param bool $pluginMode
-     * @return bool
-     */
-    protected function validateNotificationMode($notificationMode, $pluginMode)
-    {
-        // Notification mode can be a string or a boolean
-        if (($pluginMode && ($notificationMode == 'false' || $notificationMode == false)) ||
-            (!$pluginMode && ($notificationMode == 'true' || $notificationMode == true))
-        ) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
      * Checks if the notification object was sent for testing purposes from the CA
      *
-     * @param $notification
+     * @param array $notification
      * @return bool
      */
-    private function isTestNotification($notification)
+    private function isTestNotification(array $notification)
     {
         // Get notification item from notification
         if (empty($notification['notificationItems'][0])) {
@@ -333,10 +320,10 @@ class NotificationReceiverService
     /**
      * If notification is a test notification from Adyen Customer Area
      *
-     * @param $pspReference
+     * @param string $pspReference
      * @return bool
      */
-    protected function isTestNotificationPspReference($pspReference)
+    private function isTestNotificationPspReference(string $pspReference)
     {
         if (strpos(strtolower($pspReference), 'test_') !== false
             || strpos(strtolower($pspReference), 'testnotification_') !== false
@@ -350,10 +337,10 @@ class NotificationReceiverService
     /**
      * Check if notification is a report notification
      *
-     * @param $eventCode
+     * @param string $eventCode
      * @return bool
      */
-    protected function isReportNotification($eventCode)
+    private function isReportNotification(string $eventCode)
     {
         if (strpos($eventCode, 'REPORT_') !== false) {
             return true;

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -74,37 +74,37 @@ class NotificationService
     {
         //TODO Handle the notification as a model object to avoid this?
         $fields = [];
-        if (!empty($notification['pspReference'])) {
+        if (array_key_exists('pspReference', $notification)) {
             $fields['pspreference'] = $notification['pspReference'];
         }
-        if (!empty($notification['originalReference'])) {
+        if (array_key_exists('originalReference', $notification)) {
             $fields['originalReference'] = $notification['originalReference'];
         }
-        if (!empty($notification['merchantReference'])) {
+        if (array_key_exists('merchantReference', $notification)) {
             $fields['merchantReference'] = $notification['merchantReference'];
         }
-        if (!empty($notification['eventCode'])) {
+        if (array_key_exists('eventCode', $notification)) {
             $fields['eventCode'] = $notification['eventCode'];
         }
-        if (!empty($notification['success'])) {
+        if (array_key_exists('success', $notification)) {
             $fields['success'] = "true" === $notification['success'];
         }
-        if (!empty($notification['paymentMethod'])) {
+        if (array_key_exists('paymentMethod', $notification)) {
             $fields['paymentMethod'] = $notification['paymentMethod'];
         }
-        if (!empty($notification['amount']['value'])) {
-            $fields['amountValue'] = (string)$notification['amount']['value'];
+        if (array_key_exists('value', $notification['amount'] ?? [])) {
+            $fields['amountValue'] = (string) $notification['amount']['value'];
         }
-        if (!empty($notification['amount']['currency'])) {
+        if (array_key_exists('currency', $notification['amount'] ?? [])) {
             $fields['amountCurrency'] = $notification['amount']['currency'];
         }
-        if (!empty($notification['reason'])) {
+        if (array_key_exists('reason', $notification)) {
             $fields['reason'] = $notification['reason'];
         }
-        if (!empty($notification['live'])) {
-            $fields['live'] = "true" === $notification['live'];
+        if (array_key_exists('live', $notification)) {
+            $fields['live'] = $notification['live'];
         }
-        if (!empty($notification['additionalData'])) {
+        if (array_key_exists('additionalData', $notification)) {
             $fields['additionalData'] = json_encode($notification['additionalData']);
         }
 

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -78,37 +78,37 @@ class NotificationService
     {
         //TODO Handle the notification as a model object to avoid this?
         $fields = [];
-        if (array_key_exists('pspReference', $notification)) {
+        if (isset($notification['pspReference'])) {
             $fields['pspreference'] = $notification['pspReference'];
         }
-        if (array_key_exists('originalReference', $notification)) {
+        if (isset($notification['originalReference'])) {
             $fields['originalReference'] = $notification['originalReference'];
         }
-        if (array_key_exists('merchantReference', $notification)) {
+        if (isset($notification['merchantReference'])) {
             $fields['merchantReference'] = $notification['merchantReference'];
         }
-        if (array_key_exists('eventCode', $notification)) {
+        if (isset($notification['eventCode'])) {
             $fields['eventCode'] = $notification['eventCode'];
         }
-        if (array_key_exists('success', $notification)) {
+        if (isset($notification['success'])) {
             $fields['success'] = "true" === $notification['success'];
         }
-        if (array_key_exists('paymentMethod', $notification)) {
+        if (isset($notification['paymentMethod'])) {
             $fields['paymentMethod'] = $notification['paymentMethod'];
         }
-        if (array_key_exists('value', $notification['amount'] ?? [])) {
+        if (isset($notification['amount']['value'])) {
             $fields['amountValue'] = (string) $notification['amount']['value'];
         }
-        if (array_key_exists('currency', $notification['amount'] ?? [])) {
+        if (isset($notification['amount']['currency'])) {
             $fields['amountCurrency'] = $notification['amount']['currency'];
         }
-        if (array_key_exists('reason', $notification)) {
+        if (isset($notification['reason'])) {
             $fields['reason'] = $notification['reason'];
         }
-        if (array_key_exists('live', $notification)) {
+        if (isset($notification['live'])) {
             $fields['live'] = $notification['live'];
         }
-        if (array_key_exists('additionalData', $notification)) {
+        if (isset($notification['additionalData'])) {
             $fields['additionalData'] = json_encode($notification['additionalData']);
         }
 

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -55,17 +55,17 @@ class NotificationService
     public function isDuplicateNotification(array $notification): bool
     {
         $filters = [];
-        if (!empty($notification['pspreference'])) {
-            $filters[] = new EqualsFilter('pspReference', $notification['pspreference']);
+        if (!empty($notification['pspReference'])) {
+            $filters[] = new EqualsFilter('pspreference', $notification['pspReference']);
         }
         if (!empty($notification['success'])) {
             $filters[] = new EqualsFilter('success', $notification['success']);
         }
-        if (!empty($notification['event_code'])) {
-            $filters[] = new EqualsFilter('eventCode', $notification['event_code']);
+        if (!empty($notification['eventCode'])) {
+            $filters[] = new EqualsFilter('eventCode', $notification['eventCode']);
         }
-        if (!empty($notification['original_reference'])) {
-            $filters[] = new EqualsFilter('originalReference', $notification['original_reference']);
+        if (!empty($notification['originalReference'])) {
+            $filters[] = new EqualsFilter('originalReference', $notification['originalReference']);
         }
 
         return $this->notificationRepository->search(
@@ -133,6 +133,8 @@ class NotificationService
 
     public function getScheduledUnprocessedNotifications(): EntityCollection
     {
+        $oneDayAgo = (new \DateTime())->sub(new \DateInterval('P1D'));
+        $oneMinuteAgo = (new \DateTime())->sub(new \DateInterval('PT1M'));
         return $this->notificationRepository->search(
             (new Criteria())->addFilter(
                 new EqualsFilter('done', 0),
@@ -144,8 +146,8 @@ class NotificationService
                 new RangeFilter(
                     'scheduledProcessingTime',
                     [
-                        RangeFilter::GTE => (new \DateTime())->sub(new \DateInterval('P1D')),
-                        RangeFilter::LT => (new \DateTime())->sub(new \DateInterval('PT1M'))
+                        RangeFilter::GTE => $oneDayAgo->format('Y-m-d H:i:s'),
+                        RangeFilter::LT => $oneMinuteAgo->format('Y-m-d H:i:s')
                     ]
                 )
             )

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -134,8 +134,7 @@ class NotificationService
     public function getScheduledUnprocessedNotifications(): EntityCollection
     {
         return $this->notificationRepository->search(
-            (new Criteria())
-                ->addFilter(
+            (new Criteria())->addFilter(
                 new EqualsFilter('done', 0),
                 new EqualsFilter('processing', 0),
                 new NotFilter(
@@ -150,7 +149,8 @@ class NotificationService
                     ]
                 )
             )
-            ->addSorting(new FieldSorting('scheduledProcessingTime', FieldSorting::ASCENDING)),
+            ->addSorting(new FieldSorting('scheduledProcessingTime', FieldSorting::ASCENDING))
+            ->setLimit(100),
             Context::createDefaultContext()
         )->getEntities();
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Retrieve a collection of notifications:
 * between T-1 day and T-1 minute, 
 * that are not done and 
 * not being processed and 
 * `scheduled_processing_time` is not null, 
 * limited to 100 rows at a time, 
 * sorted by `scheduled_processing_time`

## Tested scenarios
<!-- Description of tested scenarios -->
Returns collection that fits above criteria

**Fixed issue**:  PW-3589<!-- #-prefixed issue number -->
