### PR TITLE
Set PHP version to 7.4 in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
For our test workflows, the virtual environment `ubuntu-latest` [now includes PHP 8.0.0](https://github.com/actions/virtual-environments/pull/2162) and this is installed by default. Because of this our new tests are [failing due to many packages depending on PHP ^7.*](https://github.com/Adyen/adyen-shopware6/runs/1570111729?check_suite_focus=true) 
This PR applies a fix to pin the version of PHP to 7.4
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->
Main workflow runs successfully

**Fixed issue**:  <!-- #-prefixed issue number -->
