### PR TITLE
PW-3590 get unscheduled notifications in NotificationService

### DIFF
--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -131,6 +131,20 @@ class NotificationService
         );
     }
 
+    public function getUnscheduledNotifications(): EntityCollection
+    {
+        return $this->notificationRepository->search(
+            (new Criteria())->addFilter(
+                new EqualsFilter('done', 0),
+                new EqualsFilter('processing', 0),
+                new EqualsFilter('scheduledProcessingTime', null)
+            )
+            ->addSorting(new FieldSorting('createdAt'))
+            ->setLimit(100),
+            Context::createDefaultContext()
+        )->getEntities();
+    }
+
     public function getScheduledUnprocessedNotifications(): EntityCollection
     {
         $oneDayAgo = (new \DateTime())->sub(new \DateInterval('P1D'));


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Add new method to `NotificationService` for retrieving unprocessed notifications.
Returns a `NotificationEntityCollection` of max 100 records at a time
Ordered by creation timestamp
## Tested scenarios
<!-- Description of tested scenarios -->
Returns `NotificationEntityCollection` with max 100 notifications ordered by `created_at` datetime

**Fixed issue**:  PW-3590<!-- #-prefixed issue number -->
