### PR TITLE
PW-3120 add weekly cron to fetch PM logos

### DIFF
--- a/src/Command/FetchPaymentMethodLogosCommand.php
+++ b/src/Command/FetchPaymentMethodLogosCommand.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Command;
+
+use Adyen\Shopware\ScheduledTask\FetchPaymentMethodLogosHandler;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FetchPaymentMethodLogosCommand extends Command
+{
+    protected static $defaultName = 'adyen:fetch-logos';
+
+    /**
+     * @var FetchPaymentMethodLogosHandler
+     */
+    protected $handler;
+
+    public function __construct(FetchPaymentMethodLogosHandler $handler)
+    {
+        parent::__construct();
+        $this->handler = $handler;
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Fetch and update logos for Adyen payment methods.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->handler->run();
+        $output->writeln('All available logos have been updated.');
+    }
+}

--- a/src/Migration/Migration1609373668AdyenMediaFolder.php
+++ b/src/Migration/Migration1609373668AdyenMediaFolder.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Adyen\Shopware\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class Migration1609373668AdyenMediaFolder extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1609373668;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->transactional(function (Connection $connection) {
+            $defaultFolderId = Uuid::randomBytes();
+            $configurationId = Uuid::randomBytes();
+            $connection->executeUpdate('
+                INSERT INTO `media_default_folder` (`id`, `association_fields`, `entity`, `created_at`)
+                VALUES (:id, :associationFields, :entity, :createdAt)
+            ', [
+                'id' => $defaultFolderId,
+                'associationFields' => '[]',
+                'entity' => 'adyen',
+                'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)
+            ]);
+            $connection->executeUpdate("
+                INSERT INTO `media_folder_configuration` (`id`, `thumbnail_quality`, `create_thumbnails`, `private`, created_at)
+                VALUES (:id, 80, 1, 0, :createdAt)
+            ", [
+                'id' => $configurationId,
+                'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)
+            ]);
+            $connection->executeUpdate('
+                INSERT into `media_folder` (`id`, `name`, `default_folder_id`, `media_folder_configuration_id`, `use_parent_configuration`, `child_count`, `created_at`)
+                VALUES (:id, :folderName, :defaultFolderId, :configurationId, 0, 0, :createdAt)
+            ', [
+                'id' => Uuid::randomBytes(),
+                'folderName' => 'Adyen Media',
+                'defaultFolderId' => $defaultFolderId,
+                'configurationId' => $configurationId,
+                'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]);
+        });
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Migration/Migration1609373668AdyenMediaFolder.php
+++ b/src/Migration/Migration1609373668AdyenMediaFolder.php
@@ -29,15 +29,27 @@ class Migration1609373668AdyenMediaFolder extends MigrationStep
                 'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)
             ]);
             $connection->executeUpdate("
-                INSERT INTO `media_folder_configuration` (`id`, `thumbnail_quality`, `create_thumbnails`, `private`, created_at)
-                VALUES (:id, 80, 1, 0, :createdAt)
+                INSERT INTO `media_folder_configuration`
+                    (`id`, `thumbnail_quality`, `create_thumbnails`, `private`, created_at)
+                VALUES
+                    (:id, 80, 1, 0, :createdAt)
             ", [
                 'id' => $configurationId,
                 'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)
             ]);
             $connection->executeUpdate('
-                INSERT into `media_folder` (`id`, `name`, `default_folder_id`, `media_folder_configuration_id`, `use_parent_configuration`, `child_count`, `created_at`)
-                VALUES (:id, :folderName, :defaultFolderId, :configurationId, 0, 0, :createdAt)
+                INSERT INTO `media_folder`
+                    (
+                        `id`,
+                        `name`,
+                        `default_folder_id`,
+                        `media_folder_configuration_id`,
+                        `use_parent_configuration`,
+                        `child_count`,
+                        `created_at`
+                    )
+                VALUES
+                    (:id, :folderName, :defaultFolderId, :configurationId, 0, 0, :createdAt)
             ', [
                 'id' => Uuid::randomBytes(),
                 'folderName' => 'Adyen Media',

--- a/src/PaymentMethods/CardsPaymentMethod.php
+++ b/src/PaymentMethods/CardsPaymentMethod.php
@@ -85,7 +85,7 @@ class CardsPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/card.png';
+        return 'card.png';
     }
 
     /**

--- a/src/PaymentMethods/GiroPayPaymentMethod.php
+++ b/src/PaymentMethods/GiroPayPaymentMethod.php
@@ -85,7 +85,7 @@ class GiroPayPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/giropay.png';
+        return 'giropay.png';
     }
 
     /**

--- a/src/PaymentMethods/IdealPaymentMethod.php
+++ b/src/PaymentMethods/IdealPaymentMethod.php
@@ -85,7 +85,7 @@ class IdealPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/ideal.png';
+        return 'ideal.png';
     }
 
     /**

--- a/src/PaymentMethods/KlarnaAccountPaymentMethod.php
+++ b/src/PaymentMethods/KlarnaAccountPaymentMethod.php
@@ -85,7 +85,7 @@ class KlarnaAccountPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/klarna_account.png';
+        return 'klarna_account.png';
     }
 
     /**

--- a/src/PaymentMethods/KlarnaPayLaterPaymentMethod.php
+++ b/src/PaymentMethods/KlarnaPayLaterPaymentMethod.php
@@ -85,7 +85,7 @@ class KlarnaPayLaterPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/klarna.png';
+        return 'klarna.png';
     }
 
     /**

--- a/src/PaymentMethods/KlarnaPayNowPaymentMethod.php
+++ b/src/PaymentMethods/KlarnaPayNowPaymentMethod.php
@@ -85,7 +85,7 @@ class KlarnaPayNowPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'klarna.png';
+        return 'klarna_paynow.png';
     }
 
     /**

--- a/src/PaymentMethods/KlarnaPayNowPaymentMethod.php
+++ b/src/PaymentMethods/KlarnaPayNowPaymentMethod.php
@@ -85,7 +85,7 @@ class KlarnaPayNowPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/klarna.png';
+        return 'klarna.png';
     }
 
     /**

--- a/src/PaymentMethods/OneClickPaymentMethod.php
+++ b/src/PaymentMethods/OneClickPaymentMethod.php
@@ -85,7 +85,7 @@ class OneClickPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/card.png';
+        return 'card.png';
     }
 
     /**

--- a/src/PaymentMethods/PaypalPaymentMethod.php
+++ b/src/PaymentMethods/PaypalPaymentMethod.php
@@ -85,7 +85,7 @@ class PaypalPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/paypal.png';
+        return 'paypal.png';
     }
 
     /**

--- a/src/PaymentMethods/SepaPaymentMethod.php
+++ b/src/PaymentMethods/SepaPaymentMethod.php
@@ -85,7 +85,7 @@ class SepaPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/sepa.png';
+        return 'sepa.png';
     }
 
     /**

--- a/src/PaymentMethods/SofortPaymentMethod.php
+++ b/src/PaymentMethods/SofortPaymentMethod.php
@@ -85,7 +85,7 @@ class SofortPaymentMethod implements PaymentMethodInterface
      */
     public function getLogo(): string
     {
-        return 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/sofort.png';
+        return 'sofort.png';
     }
 
     /**

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -179,7 +179,7 @@
             <tag name="shopware.scheduled.task" />
         </service>
         <service id="Adyen\Shopware\ScheduledTask\FetchPaymentMethodLogosHandler">
-            <argument type="service" id="scheduled_task.repository" />
+            <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="Shopware\Core\Content\Media\MediaService"/>
             <argument type="service" id="payment_method.repository"/>
@@ -189,6 +189,12 @@
             <call method="setLogger">
                 <argument key="$logger" type="service" id="monolog.logger.adyen_cron"/>
             </call>
+        </service>
+
+        <!--Commands-->
+        <service id="Adyen\Shopware\Command\FetchPaymentMethodLogosCommand">
+            <argument type="service" id="Adyen\Shopware\ScheduledTask\FetchPaymentMethodLogosHandler"/>
+            <tag name="console.command"/>
         </service>
 
         <!--Event subscribers-->

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -175,6 +175,18 @@
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
             <tag name="controller.service_arguments"/>
         </service>
+        <service id="Adyen\Shopware\ScheduledTask\FetchPaymentMethodLogos">
+            <tag name="shopware.scheduled.task" />
+        </service>
+        <service id="Adyen\Shopware\ScheduledTask\FetchPaymentMethodLogosHandler">
+            <argument type="service" id="scheduled_task.repository" />
+            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
+            <argument type="service" id="Symfony\Component\Filesystem\Filesystem"/>
+            <tag name="messenger.message_handler" />
+            <call method="setLogger">
+                <argument key="$logger" type="service" id="monolog.logger.adyen_cron"/>
+            </call>
+        </service>
 
         <!--Event subscribers-->
         <service id="Adyen\Shopware\Subscriber\PaymentSubscriber">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -181,7 +181,9 @@
         <service id="Adyen\Shopware\ScheduledTask\FetchPaymentMethodLogosHandler">
             <argument type="service" id="scheduled_task.repository" />
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
-            <argument type="service" id="Symfony\Component\Filesystem\Filesystem"/>
+            <argument type="service" id="Shopware\Core\Content\Media\MediaService"/>
+            <argument type="service" id="payment_method.repository"/>
+            <argument type="service" id="media.repository"/>
             <tag name="messenger.message_handler" />
             <call method="setLogger">
                 <argument key="$logger" type="service" id="monolog.logger.adyen_cron"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -184,6 +184,7 @@
             <argument type="service" id="Shopware\Core\Content\Media\MediaService"/>
             <argument type="service" id="payment_method.repository"/>
             <argument type="service" id="media.repository"/>
+            <argument>%shopware.media.enable_url_upload_feature%</argument>
             <tag name="messenger.message_handler" />
             <call method="setLogger">
                 <argument key="$logger" type="service" id="monolog.logger.adyen_cron"/>

--- a/src/ScheduledTask/FetchPaymentMethodLogos.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogos.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\ScheduledTask;
+
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+
+class FetchPaymentMethodLogos extends ScheduledTask
+{
+    public static function getTaskName(): string
+    {
+        return 'adyen.fetch_payment_method_logos';
+    }
+
+    public static function getDefaultInterval(): int
+    {
+        return 604800; // 7 days
+    }
+}

--- a/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
@@ -26,6 +26,7 @@ namespace Adyen\Shopware\ScheduledTask;
 
 use Adyen\Shopware\PaymentMethods\PaymentMethods;
 use Adyen\Shopware\Service\ConfigurationService;
+use Exception;
 use Psr\Log\LoggerAwareTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
@@ -72,7 +73,12 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
                 $logo
             );
             $target = $logosDirectory . $logo;
-            $this->filesystem->copy($source, $target);
+            try {
+                $this->filesystem->copy($source, $target);
+            } catch (Exception $exception) {
+                $this->logger->notice("Unable to update {$logo}: {$exception->getMessage()}");
+                continue;
+            }
         }
     }
 }

--- a/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
@@ -62,7 +62,7 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
     public function run(): void
     {
         $environment = $this->configurationService->getEnvironment();
-        $logosDirectory = __DIR__ . '/../Resources/public/logos/';
+        $logosDirectory = __DIR__ . '/../Resources/public/images/logos/';
 
         foreach (PaymentMethods::PAYMENT_METHODS as $paymentMethod) {
             $logo = (new $paymentMethod())->getLogo();

--- a/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
@@ -106,6 +106,8 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
                 )),
                 $context
             );
+
+            // Skip if the payment method is not registered in ShopWare
             if ($result->getTotal() === 0) {
                 continue;
             }

--- a/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
@@ -107,13 +107,13 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
                 $context
             );
 
-            // Skip if the payment method is not registered in ShopWare
+            // Skip if the payment method is not registered in ShopWare.
             if ($result->getTotal() === 0) {
                 continue;
             }
 
-            // Skip if the remote file is temporarily unavailable.
             $media = $this->fetchLogoFromUrl($paymentMethod, $environment);
+            // Skip if the remote file is temporarily unavailable.
             if (!$media) {
                 continue;
             }

--- a/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
@@ -110,7 +110,7 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
         }
     }
 
-    private function fetchAndAttachLogo (
+    private function fetchAndAttachLogo(
         PaymentMethodInterface $paymentMethod,
         string $paymentMethodEntityId,
         Context $context,
@@ -131,7 +131,9 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
         $this->mediaService->saveMediaFile(
             $media,
             strtolower($paymentMethod->getGatewayCode()),
-            $context, 'adyen', $mediaId
+            $context,
+            'adyen',
+            $mediaId
         );
 
         $this->paymentMethodRepository->update([

--- a/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2020 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\ScheduledTask;
+
+use Adyen\Shopware\PaymentMethods\PaymentMethods;
+use Adyen\Shopware\Service\ConfigurationService;
+use Psr\Log\LoggerAwareTrait;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use Symfony\Component\Filesystem\Filesystem;
+
+class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var ConfigurationService
+     */
+    private $configurationService;
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    public function __construct(
+        EntityRepositoryInterface $scheduledTaskRepository,
+        ConfigurationService $configurationService,
+        Filesystem $filesystem
+    ) {
+        parent::__construct($scheduledTaskRepository);
+        $this->configurationService = $configurationService;
+        $this->filesystem = $filesystem;
+    }
+
+    public static function getHandledMessages(): iterable
+    {
+        return [ FetchPaymentMethodLogos::class ];
+    }
+
+    public function run(): void
+    {
+        $environment = $this->configurationService->getEnvironment();
+        $logosDirectory = __DIR__ . '/../Resources/public/logos/';
+
+        foreach (PaymentMethods::PAYMENT_METHODS as $paymentMethod) {
+            $logo = (new $paymentMethod())->getLogo();
+            $source = sprintf(
+                'https://checkoutshopper-%s.adyen.com/checkoutshopper/images/logos/medium/%s',
+                $environment,
+                $logo
+            );
+            $target = $logosDirectory . $logo;
+            $this->filesystem->copy($source, $target);
+        }
+    }
+}

--- a/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
@@ -72,11 +72,10 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
                 $environment,
                 $logo
             );
-            $target = $logosDirectory . $logo;
             try {
-                $this->filesystem->copy($source, $target);
+                $this->filesystem->copy($source, $logosDirectory . $logo);
             } catch (Exception $exception) {
-                $this->logger->notice("Unable to update {$logo}: {$exception->getMessage()}");
+                $this->logger->notice(sprintf("Failed to update %s: %s", $logo, $exception->getMessage()));
                 continue;
             }
         }

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -144,7 +144,6 @@ class PaymentSubscriber implements EventSubscriberInterface
         $this->paymentMethodsService = $paymentMethodsService;
         $this->pluginIdProvider = $pluginIdProvider;
         $this->paymentMethodRepository = $paymentMethodRepository;
-        $this->paymentMethodRepository = $paymentMethodRepository;
         $this->session = $session;
         $this->container = $container;
         $this->logger = $logger;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Each payment method has a function: public function getLogo(): string to retrieve the logo but we return the https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/sofort.png' url instead of downloading it and providing it from the server of the merchant.
Show the logos using the resources from the server.

### Changes
Fix involves creation of scheduled task  to fetch logos weekly and upload them to create Shopware media entities and then attaching them to the payment_method entities.
Weekly cron will first delete the old media and then recreate new ones from the downloaded file
Fallback is that in the case where a remote URL is temporarily unreachable, the payment method will be skipped, thereby preserving its media from the previous run.
New Command `adyen:fetch-logos` is also introduced to fetch logos on demand.

### Requirement
Merchants need to make sure that the following configuration is set to enabled:
`shopware.media.enable_url_upload_feature`
This is enabled by default in `platform/src/Core/Framework/Resources/config/packages/shopware.yaml`

New MediaFolder `Adyen` will be created with migration.
## Tested scenarios
<!-- Description of tested scenarios -->
Logos are downloaded into Media entities and attached to PMs, display accordingly in checkout and in Administration content section.
Logos are overwritten with every run of scheduled task.
Unavailable remote? PM is skipped.

