### PR TITLE
[PW-2843] implement notification auth from the library

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -53,13 +53,15 @@
         </service>
         <service id="Adyen\Util\Currency" autowire="true"/>
         <service id="Adyen\Util\HmacSignature" autowire="true"/>
+        <service id="Adyen\Service\NotificationReceiver" autowire="true"/>
         <service id="Adyen\Shopware\Service\ConfigurationService" autowire="true">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="Adyen\Shopware\Service\NotificationReceiverService" autowire="true">
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
-            <argument type="service" id="Adyen\Util\HmacSignature"/>
+            <argument type="service" id="Adyen\Shopware\Service\NotificationService"/>
+            <argument type="service" id="Adyen\Service\NotificationReceiver"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_notification"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -175,6 +177,8 @@
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
             <tag name="controller.service_arguments"/>
         </service>
+
+        <!--Scheduled Tasks-->
         <service id="Adyen\Shopware\ScheduledTask\ProcessNotifications">
             <tag name="shopware.scheduled.task" />
         </service>
@@ -190,11 +194,12 @@
         </service>
         <service id="Adyen\Shopware\ScheduledTask\ScheduleNotificationsHandler">
             <argument type="service" id="scheduled_task.repository" />
-            <argument type="service" id="Adyen\Shopware\Service\NotificationService" />
+            <argument type="service" id="Adyen\Shopware\Service\NotificationService"/>
             <tag name="messenger.message_handler" />
             <call method="setLogger">
                 <argument key="$logger" type="service" id="monolog.logger.adyen_notification"/>
             </call>
+        </service>
         <service id="Adyen\Shopware\ScheduledTask\FetchPaymentMethodLogos">
             <tag name="shopware.scheduled.task" />
         </service>

--- a/src/Service/NotificationReceiverService.php
+++ b/src/Service/NotificationReceiverService.php
@@ -105,10 +105,10 @@ class NotificationReceiverService
 
         // Authorize notification
         if (!$this->notificationReceiver->isAuthenticated(
-                $firstNotificationItem,
-                $this->configurationService->getMerchantAccount(),
-                $basicAuthUser,
-                $basicAuthPassword
+            $firstNotificationItem,
+            $this->configurationService->getMerchantAccount(),
+            $basicAuthUser,
+            $basicAuthPassword
         )) {
             throw new AuthenticationException();
         }

--- a/src/Service/NotificationReceiverService.php
+++ b/src/Service/NotificationReceiverService.php
@@ -104,14 +104,12 @@ class NotificationReceiverService
         $firstNotificationItem = $request['notificationItems'][0]['NotificationRequestItem'];
 
         // Authorize notification
-        if (
-            !$this->notificationReceiver->isAuthenticated(
+        if (!$this->notificationReceiver->isAuthenticated(
                 $firstNotificationItem,
                 $this->configurationService->getMerchantAccount(),
                 $basicAuthUser,
                 $basicAuthPassword
-            )
-        ) {
+        )) {
             throw new AuthenticationException();
         }
 

--- a/src/Service/NotificationReceiverService.php
+++ b/src/Service/NotificationReceiverService.php
@@ -90,8 +90,6 @@ class NotificationReceiverService
     {
         $request = $requestObject->request->all();
         $salesChannelId = $requestObject->attributes->get('sw-sales-channel-id');
-        $basicAuthUser = $requestObject->server->get('PHP_AUTH_USER');
-        $basicAuthPassword = $requestObject->server->get('PHP_AUTH_PW');
 
         // Checks if notification is empty
         if (empty($request) || empty($request['notificationItems'][0])) {
@@ -106,9 +104,9 @@ class NotificationReceiverService
         // Authorize notification
         if (!$this->notificationReceiver->isAuthenticated(
             $firstNotificationItem,
-            $this->configurationService->getMerchantAccount(),
-            $basicAuthUser,
-            $basicAuthPassword
+            $this->configurationService->getMerchantAccount($salesChannelId),
+            $this->configurationService->getNotificationUsername($salesChannelId),
+            $this->configurationService->getNotificationPassword($salesChannelId)
         )) {
             throw new AuthenticationException();
         }

--- a/src/Service/NotificationReceiverService.php
+++ b/src/Service/NotificationReceiverService.php
@@ -90,6 +90,14 @@ class NotificationReceiverService
     {
         $request = $requestObject->request->all();
         $salesChannelId = $requestObject->attributes->get('sw-sales-channel-id');
+        $notificationUsername = $this->configurationService->getNotificationUsername($salesChannelId);
+        $notificationPassword = $this->configurationService->getNotificationPassword($salesChannelId);
+
+        if (!$notificationUsername || !$notificationPassword) {
+            $message = 'Unable to process payment notifications. Notification credentials are not set in config.';
+            $this->logger->critical($message);
+            return new JsonResponse(['success' => false, 'message' => $message]);
+        }
 
         // Checks if notification is empty
         if (empty($request) || empty($request['notificationItems'][0])) {
@@ -105,8 +113,8 @@ class NotificationReceiverService
         if (!$this->notificationReceiver->isAuthenticated(
             $firstNotificationItem,
             $this->configurationService->getMerchantAccount($salesChannelId),
-            $this->configurationService->getNotificationUsername($salesChannelId),
-            $this->configurationService->getNotificationPassword($salesChannelId)
+            $notificationUsername,
+            $notificationPassword
         )) {
             throw new AuthenticationException();
         }

--- a/src/Service/NotificationReceiverService.php
+++ b/src/Service/NotificationReceiverService.php
@@ -24,24 +24,19 @@
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\Environment;
+use Adyen\Service\NotificationReceiver;
 use Adyen\Shopware\Exception\AuthenticationException;
-use Adyen\Shopware\Exception\AuthorizationException;
 use Adyen\Shopware\Exception\HMACKeyValidationException;
 use Adyen\Shopware\Exception\ValidationException;
 use Adyen\Shopware\Exception\MerchantAccountCodeException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Adyen\AdyenException;
-use Adyen\Util\HmacSignature;
 use Symfony\Component\HttpFoundation\Request;
 
 class NotificationReceiverService
 {
-    /**
-     * @var HmacSignature
-     */
-    private $hmacSignature;
-
     /**
      * @var ConfigurationService
      */
@@ -53,6 +48,11 @@ class NotificationReceiverService
     private $notificationService;
 
     /**
+     * @var NotificationReceiver
+     */
+    private $notificationReceiver;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
@@ -61,19 +61,19 @@ class NotificationReceiverService
      * NotificationReceiverService constructor.
      *
      * @param ConfigurationService $configurationService
-     * @param HmacSignature $hmacSignature
-     * @param LoggerInterface $logger
      * @param NotificationService $notificationService
+     * @param NotificationReceiver $notificationReceiver
+     * @param LoggerInterface $logger
      */
     public function __construct(
         ConfigurationService $configurationService,
-        HmacSignature $hmacSignature,
-        LoggerInterface $logger,
-        NotificationService $notificationService
+        NotificationService $notificationService,
+        NotificationReceiver $notificationReceiver,
+        LoggerInterface $logger
     ) {
         $this->configurationService = $configurationService;
-        $this->hmacSignature = $hmacSignature;
         $this->notificationService = $notificationService;
+        $this->notificationReceiver = $notificationReceiver;
         $this->logger = $logger;
     }
 
@@ -82,7 +82,6 @@ class NotificationReceiverService
      * @return string|JsonResponse
      * @throws AdyenException
      * @throws AuthenticationException
-     * @throws AuthorizationException
      * @throws HMACKeyValidationException
      * @throws MerchantAccountCodeException
      * @throws ValidationException
@@ -95,23 +94,25 @@ class NotificationReceiverService
         $basicAuthPassword = $requestObject->server->get('PHP_AUTH_PW');
 
         // Checks if notification is empty
-        if (empty($request)) {
+        if (empty($request) || empty($request['notificationItems'][0])) {
             $message = 'Notification is empty';
             $this->logger->critical($message);
-            return new JsonResponse(
-                [
-                    'success' => false,
-                    'message' => $message
-                ]
-            );
+            return new JsonResponse(['success' => false, 'message' => $message]);
         }
 
-        // Checks if notification is a test notification
-        $isTestNotification = $this->isTestNotification($request);
+        // First item in the notification
+        $firstNotificationItem = $request['notificationItems'][0]['NotificationRequestItem'];
 
         // Authorize notification
-        if (!$this->isAuthorized($isTestNotification, $basicAuthUser, $basicAuthPassword)) {
-            throw new AuthorizationException();
+        if (
+            !$this->notificationReceiver->isAuthenticated(
+                $firstNotificationItem,
+                $this->configurationService->getMerchantAccount(),
+                $basicAuthUser,
+                $basicAuthPassword
+            )
+        ) {
+            throw new AuthenticationException();
         }
 
         $acceptedMessage = '[accepted]';
@@ -127,110 +128,16 @@ class NotificationReceiverService
 
         // Run the query for checking unprocessed notifications, do this only for test notifications coming from
         // the Adyen Customer Area
-        if ($isTestNotification) {
+        if ($this->notificationReceiver->isTestNotification($firstNotificationItem['pspReference'])) {
             $unprocessedNotifications = $this->notificationService->getNumberOfUnprocessedNotifications();
             if ($unprocessedNotifications > 0) {
                 $acceptedMessage .= "\nYou have $unprocessedNotifications unprocessed notifications.";
             }
         }
+
         $this->logger->info('The result is accepted');
 
-        return new JsonResponse(
-            $this->returnAccepted($acceptedMessage)
-        );
-    }
-
-    /**
-     * Validation of the notification
-     * Testing the notification against the plugin environment and the HMAC signature
-     *
-     * @param $notification
-     * @param $merchantAccount
-     * @param $hmacKey
-     * @return bool
-     * @throws AdyenException
-     * @throws HMACKeyValidationException
-     * @throws MerchantAccountCodeException
-     */
-    private function isValidated($notification, $merchantAccount, $hmacKey)
-    {
-        // Check if the notification is a test notification
-        $isTestNotification = $this->isTestNotificationPspReference($notification['pspReference']);
-
-        // Validate if notification or configuration merchant account value is missing
-        if (empty($notification['merchantAccountCode']) || empty($merchantAccount)) {
-            if ($isTestNotification) {
-                $message = 'MerchantAccountCode or merchant account configuration is empty.';
-                throw new MerchantAccountCodeException($message);
-            }
-
-            return false;
-        }
-
-        // Validate HMAC signature
-        if (!$this->hmacSignature->isValidNotificationHMAC($hmacKey, $notification)) {
-            if ($isTestNotification) {
-                $message = 'HMAC key validation failed';
-                throw new HMACKeyValidationException($message);
-            }
-
-            return false;
-        }
-
-        // Notification is validated
-        return true;
-    }
-
-    /**
-     * Authorize notification based on Basic Authentication
-     *
-     * @param $isTestNotification
-     * @param $requestUser
-     * @param $requestPassword
-     * @return bool
-     * @throws AuthenticationException
-     */
-    private function isAuthorized($isTestNotification, $requestUser, $requestPassword)
-    {
-        // Retrieve username and password from config
-        $userName = $this->configurationService->getNotificationUsername();
-        $password = $this->configurationService->getNotificationPassword();
-
-        // Validate if username and password is sent
-        if ((is_null($requestUser) || is_null($requestPassword))) {
-            if ($isTestNotification) {
-                $message = 'PHP_AUTH_USER or PHP_AUTH_PW is not in the request.';
-                throw new AuthenticationException($message);
-            }
-
-            return false;
-        }
-
-        // Validate if username and password is configured
-        if ((is_null($userName) || is_null($password))) {
-            if ($isTestNotification) {
-                $message = 'Notifications username and/or password are not configured.';
-                throw new AuthenticationException($message);
-            }
-
-            return false;
-        }
-
-        // Validate the username and password
-        $usernameCmp = hash_equals($userName, $requestUser);
-        $passwordCmp = hash_equals($password, $requestPassword);
-        if ($usernameCmp === false || $passwordCmp === false) {
-            if ($isTestNotification) {
-                $message = 'Username (PHP_AUTH_USER) and\or password (PHP_AUTH_PW) are not the same as ' .
-                    ' configuration settings';
-                throw new AuthenticationException($message);
-            }
-
-            return false;
-        }
-
-        // The notification is authorized
-        return true;
+        return new JsonResponse($acceptedMessage);
     }
 
     /**
@@ -246,17 +153,16 @@ class NotificationReceiverService
      */
     private function processNotificationItem($notificationItem, $salesChannelId)
     {
-        $merchantAccount = $this->configurationService->getMerchantAccount();
         $hmacKey = $this->configurationService->getHmacKey($salesChannelId);
 
         // validate the notification
-        if ($this->isValidated($notificationItem, $merchantAccount, $hmacKey)) {
+        if ($this->notificationReceiver->validateHmac($notificationItem, $hmacKey)) {
             // log the notification
             $this->logger->info('The content of the notification item is: ' .
                 print_r($notificationItem, true));
 
             // skip report notifications
-            if ($this->isReportNotification($notificationItem['eventCode'])) {
+            if ($this->notificationReceiver->isReportNotification($notificationItem['eventCode'])) {
                 $this->logger->info('Notification is a REPORT notification from ' .
                     'Adyen Customer Area');
                 return true;
@@ -275,72 +181,5 @@ class NotificationReceiverService
         }
 
         return false;
-    }
-
-    /**
-     * Checks if the notification object was sent for testing purposes from the CA
-     *
-     * @param array $notification
-     * @return bool
-     */
-    private function isTestNotification(array $notification)
-    {
-        // Get notification item from notification
-        if (empty($notification['notificationItems'][0])) {
-            return false;
-        }
-
-        // First item in the notification
-        $notificationItem = $notification['notificationItems'][0]['NotificationRequestItem'];
-
-        // Checks if psp reference is test
-        return $this->isTestNotificationPspReference($notificationItem['pspReference']);
-    }
-
-    /**
-     * If notification is a test notification from Adyen Customer Area
-     *
-     * @param string $pspReference
-     * @return bool
-     */
-    private function isTestNotificationPspReference(string $pspReference)
-    {
-        if (strpos(strtolower($pspReference), 'test_') !== false
-            || strpos(strtolower($pspReference), 'testnotification_') !== false
-        ) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Check if notification is a report notification
-     *
-     * @param string $eventCode
-     * @return bool
-     */
-    private function isReportNotification(string $eventCode)
-    {
-        if (strpos($eventCode, 'REPORT_') !== false) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Return '[accepted]' if $acceptedMessage is empty otherwise return $acceptedMessage
-     *
-     * @param $acceptedMessage
-     * @return string
-     */
-    private function returnAccepted($acceptedMessage)
-    {
-        if (empty($acceptedMessage)) {
-            $acceptedMessage = '[accepted]';
-        }
-
-        return $acceptedMessage;
     }
 }

--- a/src/Storefront/Controller/NotificationReceiverController.php
+++ b/src/Storefront/Controller/NotificationReceiverController.php
@@ -26,7 +26,6 @@ namespace Adyen\Shopware\Storefront\Controller;
 
 use Adyen\AdyenException;
 use Adyen\Shopware\Exception\AuthenticationException;
-use Adyen\Shopware\Exception\AuthorizationException;
 use Adyen\Shopware\Exception\HMACKeyValidationException;
 use Adyen\Shopware\Exception\MerchantAccountCodeException;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
@@ -59,7 +58,6 @@ class NotificationReceiverController extends StorefrontController
      * @return JsonResponse
      * @throws AdyenException
      * @throws AuthenticationException
-     * @throws AuthorizationException
      * @throws HMACKeyValidationException
      * @throws MerchantAccountCodeException
      */


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Use: https://github.com/Adyen/adyen-php-api-library/blob/develop/src/Adyen/Service/NotificationReceiver.php services instead of maintaining the same code in shopware6 here: https://github.com/Adyen/adyen-shopware6/blob/develop/src/Service/NotificationReceiverService.php
## Tested scenarios
<!-- Description of tested scenarios -->
Receiving of notifications still works the same:
- Authentication checks, Hmac checks still work as expected
- Test notifications still return expected results
