### PR TITLE
PW-3049 bugfix fix additional_data definition in adyen notifications

### DIFF
--- a/src/Entity/Notification/NotificationEntityDefinition.php
+++ b/src/Entity/Notification/NotificationEntityDefinition.php
@@ -78,7 +78,7 @@ class NotificationEntityDefinition extends EntityDefinition
             new BoolField('processing', 'processing'),
             new DateTimeField('scheduled_processing_time', 'scheduledProcessingTime'),
             new IntField('error_count', 'errorCount'),
-            new StringField('error_message', 'errorMessage'),
+            new LongTextField('error_message', 'errorMessage'),
             new CreatedAtField(),
             new UpdatedAtField()
         ]);

--- a/src/Entity/Notification/NotificationEntityDefinition.php
+++ b/src/Entity/Notification/NotificationEntityDefinition.php
@@ -29,6 +29,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
@@ -72,7 +73,7 @@ class NotificationEntityDefinition extends EntityDefinition
             new StringField('amount_currency', 'amountCurrency'),
             new StringField('reason', 'reason'),
             new BoolField('live', 'live'),
-            new StringField('additional_data', 'additionalData'),
+            new LongTextField('additional_data', 'additionalData'),
             new BoolField('done', 'done'),
             new BoolField('processing', 'processing'),
             new DateTimeField('scheduled_processing_time', 'scheduledProcessingTime'),


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
additional_data field was unable to receive very long data in notifications because it was set to string in entity definition
## Tested scenarios
<!-- Description of tested scenarios -->
Send notification with very long (longer than 255 chars) additional data

**Fixed issue**:  <!-- #-prefixed issue number -->
