### PR TITLE
[PW-3768] replace usage of sales-channel-api with store-api

### DIFF
--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 /**
  *                       ######
  *                       ######
@@ -16,7 +15,7 @@ declare(strict_types=1);
  *
  * Adyen Payment Module
  *
- * Copyright (c) 2020 Adyen B.V.
+ * Copyright (c) 2021 Adyen B.V.
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  *
@@ -31,69 +30,53 @@ use Adyen\Shopware\Service\PaymentDetailsService;
 use Adyen\Shopware\Service\PaymentMethodsService;
 use Adyen\Shopware\Service\PaymentResponseService;
 use Adyen\Shopware\Service\PaymentStatusService;
-use Exception;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Adyen\Shopware\Service\OriginKeyService;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Adyen\Shopware\Service\Repository\SalesChannelRepository;
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
+use Shopware\Core\Framework\Store\Api\AbstractStoreController;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
 
-class SalesChannelApiController extends AbstractController
+class StoreApiController extends AbstractStoreController
 {
-
-    /**
-     * @var OriginKeyService
-     */
-    private $originKeyService;
-
     /**
      * @var PaymentMethodsService
      */
     private $paymentMethodsService;
-
     /**
      * @var SalesChannelRepository
      */
     private $salesChannelRepository;
-
     /**
      * @var PaymentDetailsService
      */
     private $paymentDetailsService;
-
     /**
      * @var CheckoutStateDataValidator
      */
     private $checkoutStateDataValidator;
-
     /**
      * @var PaymentStatusService
      */
     private $paymentStatusService;
-
-    /**
-     * @var PaymentResponseService
-     */
-    private $paymentResponseService;
-
     /**
      * @var PaymentResponseHandler
      */
     private $paymentResponseHandler;
-
+    /**
+     * @var PaymentResponseService
+     */
+    private $paymentResponseService;
     /**
      * @var LoggerInterface
      */
     private $logger;
 
     /**
-     * SalesChannelApiController constructor.
+     * StoreApiController constructor.
      *
-     * @param OriginKeyService $originKeyService
      * @param PaymentMethodsService $paymentMethodsService
      * @param SalesChannelRepository $salesChannelRepository
      * @param PaymentDetailsService $paymentDetailsService
@@ -104,7 +87,6 @@ class SalesChannelApiController extends AbstractController
      * @param LoggerInterface $logger
      */
     public function __construct(
-        OriginKeyService $originKeyService,
         PaymentMethodsService $paymentMethodsService,
         SalesChannelRepository $salesChannelRepository,
         PaymentDetailsService $paymentDetailsService,
@@ -114,7 +96,6 @@ class SalesChannelApiController extends AbstractController
         PaymentResponseService $paymentResponseService,
         LoggerInterface $logger
     ) {
-        $this->originKeyService = $originKeyService;
         $this->paymentMethodsService = $paymentMethodsService;
         $this->salesChannelRepository = $salesChannelRepository;
         $this->paymentDetailsService = $paymentDetailsService;
@@ -126,34 +107,10 @@ class SalesChannelApiController extends AbstractController
     }
 
     /**
-     * @RouteScope(scopes={"sales-channel-api"})
+     * @RouteScope(scopes={"store-api"})
      * @Route(
-     *     "/sales-channel-api/v{version}/adyen/origin-key",
-     *     name="sales-channel-api.action.adyen.origin-key",
-     *     methods={"GET"}
-     * )
-     *
-     * @deprecated Version 2.0.0 will use client key only
-     *
-     * @param SalesChannelContext $context
-     * @return JsonResponse
-     */
-    public function originKey(SalesChannelContext $context): JsonResponse
-    {
-        return new JsonResponse(
-            [
-                $this->originKeyService
-                    ->getOriginKeyForOrigin($this->salesChannelRepository->getSalesChannelUrl($context))
-                    ->getOriginKey()
-            ]
-        );
-    }
-
-    /**
-     * @RouteScope(scopes={"sales-channel-api"})
-     * @Route(
-     *     "/sales-channel-api/v{version}/adyen/payment-methods",
-     *     name="sales-channel-api.action.adyen.payment-methods",
+     *     "/store-api/v{version}/adyen/payment-methods",
+     *     name="store-api.action.adyen.payment-methods",
      *     methods={"GET"}
      * )
      *
@@ -166,10 +123,10 @@ class SalesChannelApiController extends AbstractController
     }
 
     /**
-     * @RouteScope(scopes={"sales-channel-api"})
+     * @RouteScope(scopes={"store-api"})
      * @Route(
-     *     "/sales-channel-api/v{version}/adyen/payment-details",
-     *     name="sales-channel-api.action.adyen.payment-details",
+     *     "/store-api/v{version}/adyen/payment-details",
+     *     name="store-api.action.adyen.payment-details",
      *     methods={"POST"}
      * )
      *
@@ -216,10 +173,10 @@ class SalesChannelApiController extends AbstractController
     }
 
     /**
-     * @RouteScope(scopes={"sales-channel-api"})
+     * @RouteScope(scopes={"store-api"})
      * @Route(
-     *     "/sales-channel-api/v{version}/adyen/payment-status",
-     *     name="sales-channel-api.action.adyen.payment-status",
+     *     "/store-api/v{version}/adyen/payment-status",
+     *     name="store-api.action.adyen.payment-status",
      *     methods={"POST"}
      * )
      *

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -25,7 +25,7 @@ export default class ConfirmOrderPlugin extends Plugin {
         }
 
         if (!!adyenCheckoutOptions && !!adyenCheckoutOptions.paymentStatusUrl &&
-            adyenCheckoutOptions.checkoutOrderUrl) {
+            adyenCheckoutOptions.checkoutOrderUrl && adyenCheckoutOptions.paymentHandleUrl) {
             event.preventDefault();
 
             // get selected payment method
@@ -92,20 +92,24 @@ export default class ConfirmOrderPlugin extends Plugin {
             // TODO error handling
             return;
         }
-        window.orderId = order.data.id;
+        if (!!order.data) {
+            order = order.data;
+        }
+        window.orderId = order.id;
         const finishUrl = new URL(
             location.origin + adyenCheckoutOptions.paymentFinishUrl);
-        finishUrl.searchParams.set('orderId', order.data.id);
+        finishUrl.searchParams.set('orderId', order.id);
         const errorUrl = new URL(
             location.origin + adyenCheckoutOptions.paymentErrorUrl);
-        errorUrl.searchParams.set('orderId', order.data.id);
+        errorUrl.searchParams.set('orderId', order.id);
         const params = {
+            'orderId': window.orderId,
             'finishUrl': finishUrl.toString(),
             'errorUrl': errorUrl.toString(),
         };
 
         this._client.post(
-            `${adyenCheckoutOptions.checkoutOrderUrl}/${window.orderId}/pay`,
+            adyenCheckoutOptions.paymentHandleUrl,
             JSON.stringify(params),
             this.afterPayOrder.bind(this, window.orderId),
         );
@@ -116,7 +120,7 @@ export default class ConfirmOrderPlugin extends Plugin {
             const responseObject = JSON.parse(response);
             if (responseObject.success) {
                 this.afterCreateOrder(
-                    JSON.stringify({data: {id: adyenCheckoutOptions.orderId}}));
+                    JSON.stringify({id: adyenCheckoutOptions.orderId}));
             }
         } catch (e) {
             console.log(e);
@@ -126,7 +130,7 @@ export default class ConfirmOrderPlugin extends Plugin {
     afterPayOrder(orderId, response) {
         try {
             response = JSON.parse(response);
-            window.returnUrl = response.paymentUrl;
+            window.returnUrl = response.redirectUrl;
 
             this._client.post(
                 `${adyenCheckoutOptions.paymentStatusUrl}`,

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -30,6 +30,17 @@
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
             <tag name="controller.service_arguments"/>
         </service>
+        <service id="Adyen\Shopware\Controller\StoreApiController">
+            <argument type="service" id="Adyen\Shopware\Service\PaymentMethodsService"/>
+            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentDetailsService"/>
+            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentStatusService"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentResponseService"/>
+            <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
+            <tag name="controller.service_arguments"/>
+        </service>
         <service id="Adyen\Shopware\Service\OriginKeyService" autowire="true">
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
         </service>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -18,18 +18,6 @@
             <argument type="service" id="order.repository"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
         </service>
-        <service id="Adyen\Shopware\Controller\SalesChannelApiController">
-            <argument type="service" id="Adyen\Shopware\Service\OriginKeyService"/>
-            <argument type="service" id="Adyen\Shopware\Service\PaymentMethodsService"/>
-            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
-            <argument type="service" id="Adyen\Shopware\Service\PaymentDetailsService"/>
-            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
-            <argument type="service" id="Adyen\Shopware\Service\PaymentStatusService"/>
-            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
-            <argument type="service" id="Adyen\Shopware\Service\PaymentResponseService"/>
-            <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
-            <tag name="controller.service_arguments"/>
-        </service>
         <service id="Adyen\Shopware\Controller\StoreApiController">
             <argument type="service" id="Adyen\Shopware\Service\PaymentMethodsService"/>
             <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -8,6 +8,7 @@
              data-language-id="{{ adyenFrontendData.languageId }}"
              data-payment-status-url="{{ adyenFrontendData.paymentStatusUrl }}"
              data-checkout-order-url="{{ adyenFrontendData.checkoutOrderUrl }}"
+             data-payment-handle-url="{{ adyenFrontendData.paymentHandleUrl }}"
              data-payment-details-url="{{ adyenFrontendData.paymentDetailsUrl }}"
              data-payment-finish-url="{{ adyenFrontendData.paymentFinishUrl }}"
              data-payment-error-url="{{ adyenFrontendData.paymentErrorUrl }}"

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -213,15 +213,19 @@ class PaymentSubscriber implements EventSubscriberInterface
             new ArrayEntity(
                 [
                     'paymentStatusUrl' => $this->router->generate(
-                        'sales-channel-api.action.adyen.payment-status',
+                        'store-api.action.adyen.payment-status',
                         ['version' => 2]
                     ),
                     'checkoutOrderUrl' => $this->router->generate(
-                        'sales-channel-api.checkout.order.create',
+                        'store-api.checkout.cart.order',
+                        ['version' => 2]
+                    ),
+                    'paymentHandleUrl' => $this->router->generate(
+                        'store-api.payment.handle',
                         ['version' => 2]
                     ),
                     'paymentDetailsUrl' => $this->router->generate(
-                        'sales-channel-api.action.adyen.payment-details',
+                        'store-api.action.adyen.payment-details',
                         ['version' => 2]
                     ),
                     'paymentFinishUrl' => $this->router->generate(


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Sales Channel API is being deprecated in S6.4 https://docs.shopware.com/en/shopware-platform-dev-en/sales-channel-api/sales-channel-context-api
Reimplement all the methods in SalesChannelApiController in a new custom StoreApiController and under the store-api scope.
Update route references in PaymentSubscriber and generate checkoutOrderUrl using store-api
## Tested scenarios
<!-- Description of tested scenarios -->
Checkout flow

**Fixed issue**:  <!-- #-prefixed issue number -->
