### PR TITLE
[PW-3117] remove extra fields in api test

### DIFF
--- a/src/Controller/ApiTestController.php
+++ b/src/Controller/ApiTestController.php
@@ -67,12 +67,6 @@ class ApiTestController
 
             $params = array(
                 'merchantAccount' => $dataBag->get(ConfigurationService::BUNDLE_NAME . '.config.merchantAccount'),
-                'countryCode' => 'NL',
-                'amount' => array(
-                    'currency' => 'EUR',
-                    'value' => 1000
-                ),
-                'channel' => 'Web'
             );
             $result = $service->paymentMethods($params);
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Only keep merchant account and remove the rest of config fields for the test.
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
