### PR TITLE
[PW-3114] use config from selected sales channel when testing api config

### DIFF
--- a/src/Resources/app/administration/src/component/adyen-config-check-button/index.js
+++ b/src/Resources/app/administration/src/component/adyen-config-check-button/index.js
@@ -42,7 +42,7 @@ Component.register('adyen-config-check-button', {
 
     computed: {
         pluginConfig() {
-            return this.$parent.$parent.$parent.actualConfigData.null;
+            return this.$parent.$parent.$parent.actualConfigData[this.$parent.$parent.$parent.currentSalesChannelId];
         }
     },
 

--- a/src/Resources/app/administration/src/component/adyen-config-check-button/index.js
+++ b/src/Resources/app/administration/src/component/adyen-config-check-button/index.js
@@ -42,7 +42,10 @@ Component.register('adyen-config-check-button', {
 
     computed: {
         pluginConfig() {
-            return this.$parent.$parent.$parent.actualConfigData[this.$parent.$parent.$parent.currentSalesChannelId];
+            let selectedSalesChannelId = this.$parent.$parent.$parent.currentSalesChannelId;
+            let config = this.$parent.$parent.$parent.actualConfigData;
+            // Properties NOT set in the sales channel config will be inherited from default config.
+            return Object.assign({}, config.null, config[selectedSalesChannelId]);
         }
     },
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
When testing API details the All Sales Channels form data and config was always used.
If a user enters different API details in a separate sales channel form it should be possible to test those as well.
This PR fixes it.
## Tested scenarios
<!-- Description of tested scenarios -->
Test API config with selected sales channel

**Fixed issue**:  <!-- #-prefixed issue number -->
