### PR TITLE
[PW-3624] Fixing check to remove OneClick from PM list

### DIFF
--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -92,10 +92,7 @@ export default class ConfirmOrderPlugin extends Plugin {
             // TODO error handling
             return;
         }
-        if (!!order.data) {
-            order = order.data;
-        }
-        window.orderId = order.id;
+        window.orderId = !!order.data ? order.data.id : order.id;
         const finishUrl = new URL(
             location.origin + adyenCheckoutOptions.paymentFinishUrl);
         finishUrl.searchParams.set('orderId', order.id);

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -292,19 +292,21 @@ class PaymentSubscriber implements EventSubscriberInterface
                     continue;
                 }
 
-                $pmFound = array_filter(
+                $methodFoundInResponse = array_filter(
                     $adyenPaymentMethods['paymentMethods'],
                     function ($value) use ($pmCode) {
                         return $value['type'] == $pmCode;
                     }
                 );
 
-                //Remove the PM if it isn't in the paymentMethods response or if it isn't OneClick
-                if (empty($pmFound) &&
-                    ($pmCode != OneClickPaymentMethodHandler::getPaymentMethodCode() &&
-                        empty($adyenPaymentMethods[OneClickPaymentMethodHandler::getPaymentMethodCode()])
-                    )
-                ) {
+                $shopwareMethodIsOneClick = $pmCode == OneClickPaymentMethodHandler::getPaymentMethodCode();
+                $oneClickInResponse = !empty(
+                    $adyenPaymentMethods[OneClickPaymentMethodHandler::getPaymentMethodCode()]
+                );
+
+                //Remove the PM if it isn't in the paymentMethods response
+                //and if it is OneClick while not present in the response
+                if (empty($methodFoundInResponse) && ($shopwareMethodIsOneClick && !$oneClickInResponse)) {
                     $originalPaymentMethods->remove($paymentMethodEntity->getId());
                 }
             }


### PR DESCRIPTION
## Summary
The check to remove OneClick from the PM list was wrong.

In this new check we're only removing the Shopware PM from the list if:
- It isn't in the `/paymentMethods` response.
- It is OneClick but OneClick isn't in the `/paymentMethods` response.

The orderId was not being fetched successfully from the place order response.

## Tested scenarios
Loading the PM list with no OneClick method removes the OneClick option.
Loading the PM list with OneClick methods doesn't remove the OneClick option.

**Fixed issue**:  PW-3624
