### PR TITLE
[PW-3922] Fix problem with completing a failed payment

### DIFF
--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -186,13 +186,14 @@ class StoreApiController extends AbstractStoreController
      */
     public function getPaymentStatus(Request $request, SalesChannelContext $context): JsonResponse
     {
-        if (empty($request->get('orderId'))) {
+        $orderId = $request->get('orderId');
+        if (empty($orderId)) {
             return new JsonResponse('Order ID not provided');
         }
 
         try {
             return new JsonResponse(
-                $this->paymentStatusService->getWithOrderId($request->get('orderId'))
+                $this->paymentStatusService->getWithOrderId($orderId)
             );
         } catch (Exception $exception) {
             $this->logger->error($exception->getMessage());

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -92,7 +92,7 @@ export default class ConfirmOrderPlugin extends Plugin {
             // TODO error handling
             return;
         }
-        window.orderId = !!order.data ? order.data.id : order.id;
+        window.orderId = order.id;
         const finishUrl = new URL(
             location.origin + adyenCheckoutOptions.paymentFinishUrl);
         finishUrl.searchParams.set('orderId', order.id);

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -83,6 +83,8 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     afterCreateOrder(response) {
+        //response.subscribe(res =>
+            console.log('afterCreateOrder', response);//);
         let order;
 
         try {
@@ -113,6 +115,8 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     afterSetPayment(response) {
+        //response.subscribe(res =>
+        console.log('afterSetPayment', response);//);
         try {
             const responseObject = JSON.parse(response);
             if (responseObject.success) {
@@ -125,6 +129,9 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     afterPayOrder(orderId, response) {
+        //response.subscribe(res =>
+        console.log('afterPayOrder', response);//);
+        debugger;
         try {
             response = JSON.parse(response);
             window.returnUrl = response.redirectUrl;
@@ -140,13 +147,15 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     handlePaymentAction(paymentAction) {
+        console.log('handlePaymentAction', paymentAction);
         try {
             const paymentActionResponse = JSON.parse(paymentAction);
             if (paymentActionResponse.isFinal) {
                 location.href = window.returnUrl;
             }
-            window.adyenCheckout.createFromAction(paymentActionResponse.action).
-                mount('[data-adyen-payment-action-container]');
+            if (!!paymentActionResponse.action) {
+                window.adyenCheckout.createFromAction(paymentActionResponse.action).mount('[data-adyen-payment-action-container]');
+            }
         } catch (e) {
             console.log(e);
         }

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -83,8 +83,6 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     afterCreateOrder(response) {
-        //response.subscribe(res =>
-            console.log('afterCreateOrder', response);//);
         let order;
 
         try {
@@ -115,8 +113,6 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     afterSetPayment(response) {
-        //response.subscribe(res =>
-        console.log('afterSetPayment', response);//);
         try {
             const responseObject = JSON.parse(response);
             if (responseObject.success) {
@@ -129,9 +125,6 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     afterPayOrder(orderId, response) {
-        //response.subscribe(res =>
-        console.log('afterPayOrder', response);//);
-        debugger;
         try {
             response = JSON.parse(response);
             window.returnUrl = response.redirectUrl;
@@ -147,18 +140,17 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     handlePaymentAction(paymentAction) {
-        console.log('handlePaymentAction', paymentAction);
         try {
             const paymentActionResponse = JSON.parse(paymentAction);
-            if (paymentActionResponse.isFinal) {
-                location.href = window.returnUrl;
-            }
             if (!!paymentActionResponse.action) {
                 window.adyenCheckout.createFromAction(paymentActionResponse.action).mount('[data-adyen-payment-action-container]');
+                return;
+            }
+            if (paymentActionResponse.isFinal) {
+                location.href = window.returnUrl;
             }
         } catch (e) {
             console.log(e);
         }
-
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -168,6 +168,7 @@
         </service>
         <service id="Adyen\Shopware\Handlers\PaymentResponseHandler" autowire="true">
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
+            <argument key="$orderTransactionRepository" type="service" id="order_transaction.repository"/>
         </service>
         <service id="Adyen\Shopware\Service\ContainerParametersService" autowire="true">
         </service>

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 
 class PaymentResponseService
 {
@@ -75,7 +76,8 @@ class PaymentResponseService
             ->search(
                 (new Criteria())
                     ->addFilter((new EqualsFilter('orderId', $orderId)))
-                    ->addAssociation('order'),
+                    ->addAssociation('order')
+                ->addSorting(new FieldSorting('createdAt', FieldSorting::DESCENDING)),
                 Context::createDefaultContext()
             )
             ->first();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
From the issue created in GitHub (https://github.com/Adyen/adyen-shopware6/issues/127)
## Tested scenarios
<!-- Description of tested scenarios -->
Pay with failing card details, then pay with one of redirect payment methods.
Pay with failing  redirect payment method, then pay with another redirect PM
Pay with failing card, the pay with valid card details

**Fixed issue**: #127 #92  <!-- #-prefixed issue number -->
