### PR TITLE
[PW-3983] small fix, validate details in resultHandler

### DIFF
--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -198,7 +198,7 @@ class PaymentResponseHandler
             return;
         }
 
-        // Get already stored transaction custom fileds
+        // Get already stored transaction custom fields
         $storedTransactionCustomFields = $transaction->getOrderTransaction()->getCustomFields() ?: [];
 
         // Store action, additionalData and originalPspReference in the transaction
@@ -217,7 +217,7 @@ class PaymentResponseHandler
         }
 
         // Only store additional data for the transaction if this is the first additional data
-        $additionalData = $this->paymentResponseHandlerResult->getAction();
+        $additionalData = $this->paymentResponseHandlerResult->getAdditionalData();
         if (empty($storedTransactionCustomFields[self::ADDITIONAL_DATA]) && !empty($additionalData)) {
             $transactionCustomFields[self::ADDITIONAL_DATA] = $additionalData;
         }

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -139,6 +139,15 @@ class ResultHandler
                 $details[self::PAYLOAD] = $payload;
             }
 
+            if (empty($details)) {
+                $error = 'Payment details are missing.';
+                $this->logger->error(
+                    $error,
+                    ['orderId' => $transaction->getOrder()->getId()]
+                );
+                throw new PaymentFailedException($error);
+            }
+
             // Validate the return
             $result = $this->paymentDetailsService->doPaymentDetails(
                 $details,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
[PW-3983] is solved by setting the `checkoutThreeDS1AuthorisationBehavior` ADP to `Auto` in the Customer Area.
This PR only introduces a minor change to check that the payment details exist before attempting to send the request to the [/payment/details API](https://docs.adyen.com/api-explorer/#/CheckoutService/v66/post/payments/details)
## Tested scenarios
<!-- Description of tested scenarios -->
3DS1 payment on Chrome v80+
