### PR TITLE
[PW-3652] bug fix in payment methods filter

### DIFF
--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -328,14 +328,13 @@ class PaymentSubscriber implements EventSubscriberInterface
         PaymentMethodCollection $originalPaymentMethods,
         SalesChannelContext $salesChannelContext,
         string $adyenPluginId
-    ): PaymentMethodCollection
-    {
+    ): PaymentMethodCollection {
         // Get Adyen /paymentMethods response
         $adyenPaymentMethods = $this->paymentMethodsService->getPaymentMethods($salesChannelContext);
 
         // If the /paymentMethods response returns empty, remove all Adyen payment methods from the list and return
-        if(empty($adyenPaymentMethods['paymentMethods'])) {
-            return $originalPaymentMethods->filter(function(PaymentMethodEntity $item) use ($adyenPluginId) {
+        if (empty($adyenPaymentMethods['paymentMethods'])) {
+            return $originalPaymentMethods->filter(function (PaymentMethodEntity $item) use ($adyenPluginId) {
                 return $item->getPluginId() !== $adyenPluginId;
             });
         }

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -347,10 +347,12 @@ class PaymentSubscriber implements EventSubscriberInterface
                 $pmCode = $pmHandlerIdentifier::getPaymentMethodCode();
 
                 if ($pmCode == OneClickPaymentMethodHandler::getPaymentMethodCode()) {
+                    // For OneClick, remove it if /paymentMethod response has no stored payment methods
                     if (empty($adyenPaymentMethods[OneClickPaymentMethodHandler::getPaymentMethodCode()])) {
                         $originalPaymentMethods->remove($paymentMethodEntity->getId());
                     }
                 } else {
+                    // For all other PMs, search in /paymentMethods response for payment method with matching `type`
                     $paymentMethodFoundInResponse = array_filter(
                         $adyenPaymentMethods['paymentMethods'],
                         function ($value) use ($pmCode) {
@@ -358,7 +360,7 @@ class PaymentSubscriber implements EventSubscriberInterface
                         }
                     );
 
-                    //Remove the PM if it isn't in the paymentMethods response
+                    // Remove the PM if it isn't in the paymentMethods response
                     if (empty($paymentMethodFoundInResponse)) {
                         $originalPaymentMethods->remove($paymentMethodEntity->getId());
                     }

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -39,6 +39,8 @@ use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartCalculator;
 use Shopware\Core\Checkout\Cart\CartPersisterInterface;
 use Shopware\Core\Checkout\Cart\Exception\CartTokenNotFoundException;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -233,20 +235,21 @@ class PaymentSubscriber implements EventSubscriberInterface
             }
         }
 
+        $adyenPluginId = $this->pluginIdProvider->getPluginIdByBaseClass(
+            \Adyen\Shopware\AdyenPaymentShopware6::class,
+            $salesChannelContext->getContext()
+        );
+
         $filteredPaymentMethods = $this->filterShopwarePaymentMethods(
             $page->getPaymentMethods(),
-            $salesChannelContext
+            $salesChannelContext,
+            $adyenPluginId
         );
 
         $page->setPaymentMethods($filteredPaymentMethods);
 
         $stateDataPaymentMethod = $this->paymentStateDataService->getPaymentMethodType(
             $salesChannelContext->getToken()
-        );
-
-        $adyenPluginId = $this->pluginIdProvider->getPluginIdByBaseClass(
-            \Adyen\Shopware\AdyenPaymentShopware6::class,
-            $salesChannelContext->getContext()
         );
 
         $paymentMethodsResponse = $this->paymentMethodsService->getPaymentMethods($salesChannelContext, $orderId);
@@ -315,45 +318,51 @@ class PaymentSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Removes payment methods from the Shopware list if not present in Adyen's /paymentMethods response
+     * Removes Adyen payment methods from the Shopware list if not present in Adyen's /paymentMethods response
      *
-     * @param $originalPaymentMethods
+     * @param PaymentMethodCollection $originalPaymentMethods
      * @param SalesChannelContext $salesChannelContext
-     * @return mixed
+     * @return PaymentMethodCollection
      */
-    private function filterShopwarePaymentMethods($originalPaymentMethods, SalesChannelContext $salesChannelContext)
+    private function filterShopwarePaymentMethods(
+        PaymentMethodCollection $originalPaymentMethods,
+        SalesChannelContext $salesChannelContext,
+        string $adyenPluginId
+    ): PaymentMethodCollection
     {
-        //Adyen /paymentMethods response
+        // Get Adyen /paymentMethods response
         $adyenPaymentMethods = $this->paymentMethodsService->getPaymentMethods($salesChannelContext);
 
+        // If the /paymentMethods response returns empty, remove all Adyen payment methods from the list and return
+        if(empty($adyenPaymentMethods['paymentMethods'])) {
+            return $originalPaymentMethods->filter(function(PaymentMethodEntity $item) use ($adyenPluginId) {
+                return $item->getPluginId() !== $adyenPluginId;
+            });
+        }
+
         foreach ($originalPaymentMethods as $paymentMethodEntity) {
-            $pmHandlerIdentifier = $paymentMethodEntity->getHandlerIdentifier();
-
             //If this is an Adyen PM installed it will only be enabled if it's present in the /paymentMethods response
-            if (strpos($paymentMethodEntity->getFormattedHandlerIdentifier(), 'adyen') !== false) {
+            /** @var PaymentMethodEntity $paymentMethodEntity */
+            if ($paymentMethodEntity->getPluginId() === $adyenPluginId) {
+                $pmHandlerIdentifier = $paymentMethodEntity->getHandlerIdentifier();
                 $pmCode = $pmHandlerIdentifier::getPaymentMethodCode();
-                // In case the paymentMethods response has no payment methods, remove it from the list
-                if (empty($adyenPaymentMethods)) {
-                    $originalPaymentMethods->remove($paymentMethodEntity->getId());
-                    continue;
-                }
 
-                $methodFoundInResponse = array_filter(
-                    $adyenPaymentMethods['paymentMethods'],
-                    function ($value) use ($pmCode) {
-                        return $value['type'] == $pmCode;
+                if ($pmCode == OneClickPaymentMethodHandler::getPaymentMethodCode()) {
+                    if (empty($adyenPaymentMethods[OneClickPaymentMethodHandler::getPaymentMethodCode()])) {
+                        $originalPaymentMethods->remove($paymentMethodEntity->getId());
                     }
-                );
+                } else {
+                    $paymentMethodFoundInResponse = array_filter(
+                        $adyenPaymentMethods['paymentMethods'],
+                        function ($value) use ($pmCode) {
+                            return $value['type'] == $pmCode;
+                        }
+                    );
 
-                $shopwareMethodIsOneClick = $pmCode == OneClickPaymentMethodHandler::getPaymentMethodCode();
-                $oneClickInResponse = !empty(
-                    $adyenPaymentMethods[OneClickPaymentMethodHandler::getPaymentMethodCode()]
-                );
-
-                //Remove the PM if it isn't in the paymentMethods response
-                //and if it is OneClick while not present in the response
-                if (empty($methodFoundInResponse) && ($shopwareMethodIsOneClick && !$oneClickInResponse)) {
-                    $originalPaymentMethods->remove($paymentMethodEntity->getId());
+                    //Remove the PM if it isn't in the paymentMethods response
+                    if (empty($paymentMethodFoundInResponse)) {
+                        $originalPaymentMethods->remove($paymentMethodEntity->getId());
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Fixed bug in payment methods filter for checkout page, that allowed PMs not returned by the `/paymentMethods` call to still be displayed in checkout
## Tested scenarios
<!-- Description of tested scenarios -->
iDeal does not show up for Belgium address
OneClick PMs do show up if they exist
