### PR TITLE
[PW-3938] Using TaxDetector to subtract tax from order lines

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -107,6 +107,7 @@
             <argument type="service" id="security.csrf.token_manager"/>
             <argument type="service" id="currency.repository"/>
             <argument type="service" id="product.repository"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\Tax\TaxDetector"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
         </service>
         <service id="Adyen\Shopware\Handlers\CardsPaymentMethodHandler"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
If the customer belongs to a "Tax display = Net" group the order line's price is already tax exclusive. In this PR a check with TaxDetector is used to include or exclude the tax from the lines in the payments request.

## Tested scenarios
"Tax display = Net" group, the tax is not subtracted from the order lines.
"Tax display = Gross" group, the tax is subtracted from the order lines.

**Fixed issue**: PW-3938
