### PR TITLE
[PW-3938] Switching to taxStatus to determine if the order tax type is Net or Gross

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -43,7 +43,6 @@ use Adyen\Shopware\Storefront\Controller\RedirectResultController;
 use Adyen\Util\Currency;
 use Exception;
 use Psr\Log\LoggerInterface;
-use Shopware\Core\Checkout\Cart\Tax\TaxDetector;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentFinalizeException;
@@ -168,11 +167,6 @@ abstract class AbstractPaymentMethodHandler
     protected $productRepository;
 
     /**
-     * @var TaxDetector
-     */
-    protected $taxDetector;
-
-    /**
      * AbstractPaymentMethodHandler constructor.
      * @param ConfigurationService $configurationService
      * @param CheckoutService $checkoutService
@@ -192,7 +186,6 @@ abstract class AbstractPaymentMethodHandler
      * @param CsrfTokenManagerInterface $csrfTokenManager
      * @param EntityRepositoryInterface $currencyRepository
      * @param EntityRepositoryInterface $productRepository
-     * @param TaxDetector $taxDetector
      * @param LoggerInterface $logger
      */
     public function __construct(
@@ -214,7 +207,6 @@ abstract class AbstractPaymentMethodHandler
         CsrfTokenManagerInterface $csrfTokenManager,
         EntityRepositoryInterface $currencyRepository,
         EntityRepositoryInterface $productRepository,
-        TaxDetector $taxDetector,
         LoggerInterface $logger
     ) {
         $this->checkoutService = $checkoutService;
@@ -236,7 +228,6 @@ abstract class AbstractPaymentMethodHandler
         $this->csrfTokenManager = $csrfTokenManager;
         $this->currencyRepository = $currencyRepository;
         $this->productRepository = $productRepository;
-        $this->taxDetector = $taxDetector;
     }
 
     abstract public static function getPaymentMethodCode();
@@ -577,7 +568,7 @@ abstract class AbstractPaymentMethodHandler
                     $productName,
                     $this->currency->sanitize(
                         $price->getUnitPrice() -
-                        ($this->taxDetector->useGross($salesChannelContext) ? $lineTax : 0),
+                        ($transaction->getOrder()->getTaxStatus() == 'gross' ? $lineTax : 0),
                         $this->getCurrency(
                             $transaction->getOrder()->getCurrencyId(),
                             $salesChannelContext->getContext()

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -107,7 +107,6 @@
             <argument type="service" id="security.csrf.token_manager"/>
             <argument type="service" id="currency.repository"/>
             <argument type="service" id="product.repository"/>
-            <argument type="service" id="Shopware\Core\Checkout\Cart\Tax\TaxDetector"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
         </service>
         <service id="Adyen\Shopware\Handlers\CardsPaymentMethodHandler"


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Removing the dependency on TaxDetector and using taxStatus to determine if the order is type Net or Gross.

## Tested scenarios
"Tax display = Net" group, the tax is not subtracted from the order lines.
"Tax display = Gross" group, the tax is subtracted from the order lines.

**Fixed issue**:  PW-3938
