### PR TITLE
PW-4180 bugfix revert to default context

### DIFF
--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -400,7 +400,7 @@ class PaymentSubscriber implements EventSubscriberInterface
             $selectedPaymentMethod = $this->paymentMethodRepository->search(
                 (new Criteria())
                     ->addFilter(new EqualsFilter('id', $event->getRequestDataBag()->get('paymentMethodId'))),
-                $event->getSalesChannelContext()
+                Context::createDefaultContext()
             )->first();
 
             $selectedPaymentMethodIsStoredPM =


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
I introduced a bug in the previous PR ([[PW-4180]](https://github.com/Adyen/adyen-shopware6/pull/141)) by switching to the event context [here](https://github.com/Adyen/adyen-shopware6/pull/141/files#diff-94c3ec56b7a92d80e1953086cde504fc4919edaefee871ac714fdf3fd3e57562R403)
This causes the following error:
```
Argument 2 passed to Shopware\Core\Checkout\Payment\DataAbstractionLayer\PaymentMethodRepositoryDecorator::search() must be an instance of Shopware\Core\Framework\Context, instance of Shopware\Core\System\SalesChannel\SalesChannelContext given, called in /home/vagrant/shopware-dev/vendor/adyen/adyen-shopware6/src/Subscriber/PaymentSubscriber.php on line 403
```

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
