### PR TITLE
[PW-4158] add missing reverse relationship

### DIFF
--- a/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionExtension.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionExtension.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen plugin for Shopware 6
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ */
+
+namespace Adyen\Shopware\Core\Checkout\Order\Aggregate\OrderTransaction;
+
+use Adyen\Shopware\Entity\PaymentResponse\PaymentResponseEntityDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityExtension;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class OrderTransactionExtension extends EntityExtension
+{
+    /**
+     * @inheritDoc
+     */
+    public function getDefinitionClass(): string
+    {
+        return OrderTransactionDefinition::class;
+    }
+
+    public function extendFields(FieldCollection $collection): void
+    {
+        $collection->add(
+            new OneToManyAssociationField(
+                'paymentResponses',
+                PaymentResponseEntityDefinition::class,
+                'order_transaction_id'
+            )
+        );
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionExtension.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionExtension.php
@@ -43,7 +43,7 @@ class OrderTransactionExtension extends EntityExtension
     {
         $collection->add(
             new OneToManyAssociationField(
-                'paymentResponses',
+                'adyenPaymentResponses',
                 PaymentResponseEntityDefinition::class,
                 'order_transaction_id'
             )

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -80,6 +80,9 @@
         <service id="Adyen\Shopware\Entity\PaymentResponse\PaymentResponseEntityDefinition">
             <tag name="shopware.entity.definition" entity="adyen_payment_response"/>
         </service>
+        <service id="Adyen\Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionExtension">
+            <tag name="shopware.entity.extension"/>
+        </service>
         <service id="Adyen\Shopware\Service\NotificationService">
             <argument type="service" id="adyen_notification.repository"/>
         </service>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Github issue https://github.com/Adyen/adyen-shopware6/issues/133
bin/console dal:validate returns the following error in v6.3.5.1

* Missing reverse one to many association for Adyen\Shopware\Entity\PaymentResponse\PaymentResponseEntityDefinition <-> Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition (orderTransaction)

This PR adds the missing extension

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**: Closes #133  <!-- #-prefixed issue number -->
