### PR TITLE
[PW-4474] add refund notification processor

### DIFF
--- a/src/Entity/Notification/NotificationEntity.php
+++ b/src/Entity/Notification/NotificationEntity.php
@@ -102,7 +102,7 @@ class NotificationEntity extends Entity
     protected $scheduledProcessingTime;
 
     /**
-     * @var int
+     * @var int|null
      */
     protected $errorCount;
 
@@ -336,9 +336,9 @@ class NotificationEntity extends Entity
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getErrorCount(): int
+    public function getErrorCount(): ?int
     {
         return $this->errorCount;
     }

--- a/src/NotificationProcessor/NotificationEventCodes.php
+++ b/src/NotificationProcessor/NotificationEventCodes.php
@@ -28,4 +28,5 @@ final class NotificationEventCodes
 {
     public const AUTHORISATION = 'AUTHORISATION';
     public const OFFER_CLOSED = 'OFFER_CLOSED';
+    public const REFUND = 'REFUND';
 }

--- a/src/NotificationProcessor/NotificationProcessor.php
+++ b/src/NotificationProcessor/NotificationProcessor.php
@@ -30,19 +30,9 @@ use Psr\Log\LoggerAwareTrait;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Checkout\Order\OrderEntity;
 
-abstract class NotificationProcessor
+abstract class NotificationProcessor implements NotificationProcessorInterface
 {
     use LoggerAwareTrait;
-
-    /**
-     * @var Currency
-     */
-    protected $currencyUtil;
-
-    public function __construct()
-    {
-        $this->currencyUtil = new Currency();
-    }
 
     /**
      * @var OrderEntity
@@ -56,6 +46,18 @@ abstract class NotificationProcessor
      * @var OrderTransactionStateHandler
      */
     protected $transactionStateHandler;
+
+    /**
+     * @var Currency
+     */
+    protected $currencyUtil;
+
+    public function __construct()
+    {
+        $this->currencyUtil = new Currency();
+    }
+
+    abstract public function process(): void;
 
     /**
      * @return OrderEntity

--- a/src/NotificationProcessor/NotificationProcessor.php
+++ b/src/NotificationProcessor/NotificationProcessor.php
@@ -25,14 +25,24 @@
 namespace Adyen\Shopware\NotificationProcessor;
 
 use Adyen\Shopware\Entity\Notification\NotificationEntity;
+use Adyen\Util\Currency;
 use Psr\Log\LoggerAwareTrait;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Checkout\Order\OrderEntity;
-use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 
 abstract class NotificationProcessor
 {
     use LoggerAwareTrait;
+
+    /**
+     * @var Currency
+     */
+    protected $currencyUtil;
+
+    public function __construct()
+    {
+        $this->currencyUtil = new Currency();
+    }
 
     /**
      * @var OrderEntity

--- a/src/NotificationProcessor/NotificationProcessorFactory.php
+++ b/src/NotificationProcessor/NotificationProcessorFactory.php
@@ -42,7 +42,7 @@ class NotificationProcessorFactory
         OrderEntity $order,
         OrderTransactionStateHandler $transactionStateHandler,
         LoggerInterface $logger
-    ): NotificationProcessor {
+    ): NotificationProcessorInterface {
         /** @var NotificationProcessor $notificationProcessor */
         $notificationProcessor = array_key_exists($notification->getEventCode(), self::$adyenEventCodeProcessors)
             ? new self::$adyenEventCodeProcessors[$notification->getEventCode()]

--- a/src/NotificationProcessor/NotificationProcessorFactory.php
+++ b/src/NotificationProcessor/NotificationProcessorFactory.php
@@ -34,6 +34,7 @@ class NotificationProcessorFactory
     private static $adyenEventCodeProcessors = [
         NotificationEventCodes::AUTHORISATION => AuthorisationNotificationProcessor::class,
         NotificationEventCodes::OFFER_CLOSED => OfferClosedNotificationProcessor::class,
+        NotificationEventCodes::REFUND => RefundNotificationProcessor::class,
     ];
 
     public static function create(
@@ -41,7 +42,7 @@ class NotificationProcessorFactory
         OrderEntity $order,
         OrderTransactionStateHandler $transactionStateHandler,
         LoggerInterface $logger
-    ): NotificationProcessorInterface {
+    ): NotificationProcessor {
         /** @var NotificationProcessor $notificationProcessor */
         $notificationProcessor = array_key_exists($notification->getEventCode(), self::$adyenEventCodeProcessors)
             ? new self::$adyenEventCodeProcessors[$notification->getEventCode()]

--- a/src/NotificationProcessor/RefundNotificationProcessor.php
+++ b/src/NotificationProcessor/RefundNotificationProcessor.php
@@ -49,6 +49,12 @@ class RefundNotificationProcessor extends NotificationProcessor implements Notif
                 $orderTransaction->getAmount()->getTotalPrice(),
                 $this->getOrder()->getCurrency()->getIsoCode()
             );
+
+            if ($refundedAmount > $transactionAmount) {
+                $this->logger->warning('The refunded amount is greater than the transaction amount.', $logContext);
+                return;
+            }
+
             $partial = $refundedAmount < $transactionAmount;
             $newState = $partial
                 ? OrderTransactionStates::STATE_PARTIALLY_REFUNDED

--- a/src/NotificationProcessor/RefundNotificationProcessor.php
+++ b/src/NotificationProcessor/RefundNotificationProcessor.php
@@ -51,8 +51,7 @@ class RefundNotificationProcessor extends NotificationProcessor implements Notif
             );
 
             if ($refundedAmount > $transactionAmount) {
-                $this->logger->warning('The refunded amount is greater than the transaction amount.', $logContext);
-                return;
+                throw new \Exception('The refunded amount is greater than the transaction amount.');
             }
 
             $newState = $refundedAmount < $transactionAmount

--- a/src/NotificationProcessor/RefundNotificationProcessor.php
+++ b/src/NotificationProcessor/RefundNotificationProcessor.php
@@ -67,7 +67,8 @@ class RefundNotificationProcessor extends NotificationProcessor implements Notif
         $this->logger->info('Processed ' . NotificationEventCodes::REFUND . ' notification.', $logContext);
     }
 
-    private function doRefund(OrderTransactionEntity $orderTransaction, Context $context, bool $partial=false) {
+    private function doRefund(OrderTransactionEntity $orderTransaction, Context $context, bool $partial = false)
+    {
         try {
             if ($partial) {
                 $this->getTransactionStateHandler()->refundPartially($orderTransaction->getId(), $context);

--- a/src/NotificationProcessor/RefundNotificationProcessor.php
+++ b/src/NotificationProcessor/RefundNotificationProcessor.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\NotificationProcessor;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\System\StateMachine\Exception\IllegalTransitionException;
+
+class RefundNotificationProcessor extends NotificationProcessor implements NotificationProcessorInterface
+{
+    public function process(): void
+    {
+        $context = Context::createDefaultContext();
+        $orderTransaction = $this->getOrder()->getTransactions()->first();
+        $state = $orderTransaction->getStateMachineState()->getTechnicalName();
+        $logContext = [
+            'orderId' => $this->getOrder()->getId(),
+            'orderNumber' => $this->getOrder()->getOrderNumber(),
+            'eventCode' => NotificationEventCodes::REFUND,
+            'originalState' => $state
+        ];
+
+        if ($this->getNotification()->isSuccess()) {
+            $refundedAmount = (int) $this->getNotification()->getAmountValue();
+            $transactionAmount = $this->currencyUtil->sanitize(
+                $orderTransaction->getAmount()->getTotalPrice(),
+                $this->getOrder()->getCurrency()->getIsoCode()
+            );
+            $partial = $refundedAmount < $transactionAmount;
+            $newState = $partial
+                ? OrderTransactionStates::STATE_PARTIALLY_REFUNDED
+                : OrderTransactionStates::STATE_REFUNDED;
+            // Transactions in refunded state cannot be transitioned to any other state,
+            // however refunded_partially can be transitioned to refunded.
+            if (in_array($state, [$newState, OrderTransactionStates::STATE_REFUNDED])) {
+                $this->logger->info("Transaction is already in the {$newState} state.", $logContext);
+                return;
+            }
+
+            $this->doRefund($orderTransaction, $context, $partial);
+            $logContext['newState'] = $newState;
+        }
+
+        $this->logger->info('Processed ' . NotificationEventCodes::REFUND . ' notification.', $logContext);
+    }
+
+    private function doRefund(OrderTransactionEntity $orderTransaction, Context $context, bool $partial=false) {
+        try {
+            if ($partial) {
+                $this->getTransactionStateHandler()->refundPartially($orderTransaction->getId(), $context);
+            } else {
+                $this->getTransactionStateHandler()->refund($orderTransaction->getId(), $context);
+            }
+        } catch (IllegalTransitionException $exception) {
+            // set to paid, and then try again
+            $this->getTransactionStateHandler()->paid($orderTransaction->getId(), $context);
+            $this->doRefund($orderTransaction, $context, $partial);
+        }
+    }
+}

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -101,9 +101,10 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
 
             $this->markAsProcessing($notification->getId());
 
-            $order = $this->orderRepository->getWithOrderNumber(
+            $order = $this->orderRepository->getOrderByOrderNumber(
                 $notification->getMerchantReference(),
-                $context
+                $context,
+                ['transactions', 'currency']
             );
 
             if (!$order) {

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -138,9 +138,8 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
             } catch (\Exception $exception) {
                 $this->logger->error($exception->getMessage());
                 // set notification error and increment error count
-                $errorMessage = $exception->getTraceAsString();
-                $errorCount = $notification->getErrorCount();
-                $this->notificationService->saveError($notification->getId(), $errorMessage, ++$errorCount);
+                $errorCount = (int) $notification->getErrorCount();
+                $this->notificationService->saveError($notification->getId(), $exception->getMessage(), ++$errorCount);
                 $this->logger->error('Notification processing failed.', $logContext);
 
                 if ($errorCount < self::MAX_ERROR_COUNT) {

--- a/src/Service/Repository/OrderRepository.php
+++ b/src/Service/Repository/OrderRepository.php
@@ -48,12 +48,9 @@ class OrderRepository
         try {
             $criteria = new Criteria();
             $criteria->addFilter(new EqualsFilter('id', $orderId));
-            foreach ($associations as $association) {
-                $criteria->addAssociation($association);
-            }
 
             /** @var OrderEntity $order */
-            $order = $this->orderRepository->search($criteria, $context)->first();
+            $order = $this->getOrderByCriteria($criteria, $context, $associations);
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage(), [$e]);
         }
@@ -61,14 +58,20 @@ class OrderRepository
         return $order;
     }
 
-    public function getWithOrderNumber(string $orderNumber, Context $context): ?OrderEntity
+    public function getOrderByCriteria(Criteria $criteria, Context $context, array $associations = []): ?OrderEntity
     {
-        return $this->orderRepository->search(
-            (new Criteria())
-            ->addFilter(new EqualsFilter('orderNumber', $orderNumber))
-            ->addAssociation('transactions'),
-            $context
-        )->first();
+        foreach ($associations as $association) {
+            $criteria->addAssociation($association);
+        }
+        return $this->orderRepository->search($criteria, $context)->first();
+    }
+
+    public function getOrderByOrderNumber(string $orderNumber, Context $context, array $associations = []): ?OrderEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('orderNumber', $orderNumber));
+
+        return $this->getOrderByCriteria($criteria, $context, $associations);
     }
 
     public function update(string $orderId, array $data, Context $context)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Create REFUND notification processor.
Transition order transactions to refunded/refunded_partially when notification is received and handle illegal state transitions
## Tested scenarios
<!-- Description of tested scenarios -->
open -> refunded (illegal: moves to paid and then to refunded) ✅
refunded -> refunded (illegal: skips) ❌
refunded -> [other] (illegal: skips) ❌
paid -> refunded ✅
cancelled -> refunded ✅
refunded_partially -> refunded ✅

**Fixed issue**:  Resolves #157 <!-- #-prefixed issue number -->
