### PR TITLE
Return only payment method config for each PM extension

### DIFF
--- a/src/Struct/AdyenPaymentMethodDataStruct.php
+++ b/src/Struct/AdyenPaymentMethodDataStruct.php
@@ -36,7 +36,7 @@ class AdyenPaymentMethodDataStruct extends Struct
     /**
      * @var array|null
      */
-    protected $paymentMethodsResponse = null;
+    protected $paymentMethodConfig = null;
 
     public function getType(): ?string
     {
@@ -48,13 +48,13 @@ class AdyenPaymentMethodDataStruct extends Struct
         $this->type = $type;
     }
 
-    public function getPaymentMethodsResponse(): ?array
+    public function getPaymentMethodConfig(): ?array
     {
-        return $this->paymentMethodsResponse;
+        return $this->paymentMethodConfig;
     }
 
-    public function setPaymentMethodsResponse(?array $paymentMethodsResponse): void
+    public function setPaymentMethodConfig(?array $paymentMethodConfig): void
     {
-        $this->paymentMethodsResponse = $paymentMethodsResponse;
+        $this->paymentMethodConfig = $paymentMethodConfig;
     }
 }

--- a/src/Subscriber/Response/PaymentMethodRouteResponseSubscriber.php
+++ b/src/Subscriber/Response/PaymentMethodRouteResponseSubscriber.php
@@ -143,17 +143,13 @@ class PaymentMethodRouteResponseSubscriber implements EventSubscriberInterface, 
         if (empty($paymentMethodsResponse['paymentMethods'])) {
             return null;
         }
-        $paymentMethodsResponse['paymentMethods'] = array_values(array_filter(
-            $paymentMethodsResponse['paymentMethods'],
-            function ($value) use ($type) {
-                return ($value['type'] ?? null) == $type;
+        foreach ($paymentMethodsResponse['paymentMethods'] as $paymentMethodConfig) {
+            if (($paymentMethodConfig['type'] ?? null) == $type) {
+                return $paymentMethodConfig;
             }
-        ));
-        if (empty($paymentMethodsResponse['paymentMethods'])) {
-            return null;
         }
 
-        return $paymentMethodsResponse['paymentMethods'][0];
+        return null;
     }
 
     private function getPaymentMethodType(PaymentMethodEntity $method): ?string

--- a/src/Subscriber/Response/PaymentMethodRouteResponseSubscriber.php
+++ b/src/Subscriber/Response/PaymentMethodRouteResponseSubscriber.php
@@ -130,28 +130,30 @@ class PaymentMethodRouteResponseSubscriber implements EventSubscriberInterface, 
             $extension->setType($type);
 
             if (!empty($type)) {
-                $extension->setPaymentMethodsResponse($this->getPaymentMethodsResponseForType($context, $type));
+                $extension->setPaymentMethodConfig($this->getPaymentMethodConfigByType($context, $type));
             }
 
             $method->addExtension('adyenData', $extension);
         }
     }
 
-    private function getPaymentMethodsResponseForType(SalesChannelContext $context, string $type)
+    private function getPaymentMethodConfigByType(SalesChannelContext $context, string $type)
     {
         $paymentMethodsResponse = $this->getPaymentMethodsResponse($context);
         if (empty($paymentMethodsResponse['paymentMethods'])) {
-            return $paymentMethodsResponse;
+            return null;
         }
-
-        $paymentMethodsResponse['paymentMethods'] = array_filter(
+        $paymentMethodsResponse['paymentMethods'] = array_values(array_filter(
             $paymentMethodsResponse['paymentMethods'],
             function ($value) use ($type) {
                 return ($value['type'] ?? null) == $type;
             }
-        );
+        ));
+        if (empty($paymentMethodsResponse['paymentMethods'])) {
+            return null;
+        }
 
-        return $paymentMethodsResponse;
+        return $paymentMethodsResponse['paymentMethods'][0];
     }
 
     private function getPaymentMethodType(PaymentMethodEntity $method): ?string


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Changing payment-method extension to return only payment method config like below:
```json
...
"extensions": {
    "adyenData": {
        "type": "paypal",
        "paymentMethodConfig":  {
            "configuration": {
                "merchantId": "MERCHANT_ACCOUNT",
                "intent": "capture"
            },
            "name": "PayPal",
            "type": "paypal"
        },
        "apiAlias": "adyen_shopware_struct_adyen_payment_method_data_struct"
    }
},
```
instead of previous structure:
```json
...
"extensions": {
    "adyenData": {
        "type": "paypal",
        "paymentMethodsResponse": {
            "paymentMethods": {
                "1": {
                    "configuration": {
                        "merchantId": "MERCHANT_ACCOUNT",
                        "intent": "capture"
                    },
                    "name": "PayPal",
                    "type": "paypal"
                }
            }
        },
        "apiAlias": "adyen_shopware_struct_adyen_payment_method_data_struct"
    }
},
```
See [this discussion](https://github.com/Adyen/adyen-shopware6/pull/162#discussion_r638758389) for more info
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
