### PR TITLE
[PW-4704] Using product's name translation for openinvoice lineitem description

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -557,7 +557,7 @@ abstract class AbstractPaymentMethodHandler
                 }
 
                 $product = $this->getProduct($orderLine->getProductId(), $salesChannelContext->getContext());
-                $productName = $product->getName();
+                $productName = $product->getTranslation('name');
                 $productNumber = $product->getProductNumber();
 
                 //Getting line tax amount and rate


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When product variants inherit the parent's name the variant itself doesn't have a name property, it has a translation instead. This means that in those cases the openinvoice lineItems were not filling the description value. Here a translation on the field `name` is being fetched instead, which works for both parent and variants.

## Tested scenarios
Openinvoice payments with:

- Products with no variants.
- Products with variants.
- Variants.


**Fixed issue**:  PW-4704 #167 
