### PR TITLE
[PW-5011] Paypal button is not working in Firefox on IOS mobile

### DIFF
--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -25,3 +25,7 @@
 .adyen-payment-method-container-div, .adyen-update-payment-details{
     display: none;
 }
+
+.paypal-checkout-sandbox{
+    pointer-events: auto;
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Paypal is rendering an iframe instead of opening a new window for the login in case the customer is using firefox on ios. The PR can be found [here](https://github.com/paypal/paypal-checkout-components/pull/269/files#diff-69d37eb033f3d7b6d25e51188e38b2709976a4a72894c20d3fc4805b2a781699R346 ). 

Whenever a payment is started Shopware adds a `has-element-loader` class to the html body which applies `pointer-events: none;` on the child elements, therefore the paypal iframe as well. Since it's applied there the customer cannot click on the form elements or close the popup.

This PR makes sure the pointer-events is set to auto for the paypal iframe.

## Tested scenarios
IOS firefox paypal
Chrome web paypal