### PR TITLE
[PW-5253] add snippet_name for all cookies.

### DIFF
--- a/src/Framework/Cookie/AdyenCookieProvider.php
+++ b/src/Framework/Cookie/AdyenCookieProvider.php
@@ -31,47 +31,68 @@ class AdyenCookieProvider implements CookieProviderInterface
         ],
         [
             'cookie' => '_uetvid',
-            "hidden" => true
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ],
         [
             'cookie' => '_uetsid',
-            "hidden" => true
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ],
         [
-            'cookie' => '__cfduid',
-            "hidden" => true
+            'cookie' => 'datadome',
+            'snippet_name' => 'cookie',
+            'hidden' => true
+        ],
+        [
+            'cookie' => 'rl_anonymous_id',
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ],
         [
             'cookie' => '_mkto_trk',
-            "hidden" => true
+            'snippet_name' => 'cookie',
+            'hidden' => true
+        ],
+        [
+            'cookie' => 'rl_user_id',
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ],
         [
             'cookie' => '_hjid',
-            "hidden" => true
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ],
         [
             'cookie' => 'lastUpdatedGdpr',
-            "hidden" => true
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ],
         [
             'cookie' => 'gdpr',
-            "hidden" => true
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ],
         [
             'cookie' => '_fbp',
-            "hidden" => true
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ],
         [
             'cookie' => '_ga',
-            "hidden" => true
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ],
         [
             'cookie' => '_gid',
-            "hidden" => true
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ],
         [
             'cookie' => '_gcl_au',
-            "hidden" => true
+            'snippet_name' => 'cookie',
+            'hidden' => true
         ]
     ];
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Missing `snippet_name` in cookies breaks in SW v6.4.
Add default name for all hidden snippets
Update cookies list to the new checkout component version's cookies
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**: Resolves #196  <!-- #-prefixed issue number -->
