### PR TITLE
[PW-5658] Fixed the wrong DoB format to fit Checkout API

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -485,7 +485,7 @@ abstract class AbstractPaymentMethodHandler
 
         if (empty($request['paymentMethod']['personalDetails']['dateOfBirth'])) {
             if ($salesChannelContext->getCustomer()->getBirthday()) {
-                $shopperDob = $salesChannelContext->getCustomer()->getBirthday()->format('d-m-Y');
+                $shopperDob = $salesChannelContext->getCustomer()->getBirthday()->format('Y-m-d');
             } else {
                 $shopperDob = '';
             }


### PR DESCRIPTION
## Summary
We were using the wrong format (d-m-Y) while sending the request to Checkout API, however Checkout API only accepts the format Y-m-d and if you were to pass the wrong format, it would throw 702 validation error. 

## Tested scenarios
Card payment with shopper birthday enabled

**Fixed issue**: PW-5658
