### PR TITLE
PW-5203 partial refunds

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -155,12 +155,18 @@ class AdminController
     {
         $context = Context::createDefaultContext();
         $orderId = $request->request->get('orderId');
+        $inputAmount = $request->request->get('inputAmount');
         // If payload does not contain orderNumber
         if (empty($orderId)) {
             $message = 'Order Id was not provided in request';
             $this->logger->error($message);
             return new JsonResponse($message, 400);
+        } elseif (empty($inputAmount)) {
+            $message = 'Input amount was not provided in request';
+            $this->logger->error($message);
+            return new JsonResponse($message, 400);
         }
+
 
         /** @var OrderEntity $order */
         $order = $this->orderRepository->getOrder(
@@ -174,7 +180,7 @@ class AdminController
             $this->logger->error($message);
             return new JsonResponse($message, 400);
         } else {
-            $amountInCents = $this->currencyUtil->sanitize($order->getAmountTotal(), null);
+            $amountInCents = $this->currencyUtil->sanitize($inputAmount, null);
             if (!$this->refundService->isAmountRefundable($order, $amountInCents)) {
                 return new JsonResponse([
                     'success' => false,
@@ -184,7 +190,7 @@ class AdminController
         }
 
         try {
-            $result = $this->refundService->refund($order);
+            $result = $this->refundService->refund($order, $inputAmount);
             // If response does not contain pspReference
             if (!array_key_exists('pspReference', $result)) {
                 $message = sprintf('Invalid response for refund on order %s', $order->getOrderNumber());
@@ -196,6 +202,7 @@ class AdminController
                 $result['pspReference'],
                 RefundEntity::SOURCE_SHOPWARE,
                 RefundEntity::STATUS_PENDING_WEBHOOK,
+                $inputAmount
             );
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());

--- a/src/Resources/app/administration/src/component/adyen-refund/adyen-refund.html.twig
+++ b/src/Resources/app/administration/src/component/adyen-refund/adyen-refund.html.twig
@@ -20,6 +20,10 @@
                         :title="$tc('adyen.createRefund')"
                         variant="small">
                     {{ $tc('adyen.refundConfirm') }}: <b>{{ order.orderNumber }}</b>
+                    <div>
+                        <sw-number-field value=null type="inputAmount" numberType="float" allowEmpty="false" v-model="inputAmount" numberType="float"
+                        ></sw-number-field>
+                    </div>
                     <template #modal-footer>
                         <sw-button @click="onCloseModal" size="small">
                             {{ $tc('global.default.cancel') }}

--- a/src/Resources/app/administration/src/component/adyen-refund/index.js
+++ b/src/Resources/app/administration/src/component/adyen-refund/index.js
@@ -49,6 +49,7 @@ Component.register('adyen-refund', {
                 { property: 'createdAt', label: this.$tc('adyen.columnHeaders.created') },
                 { property: 'updatedAt', label: this.$tc('adyen.columnHeaders.updated') }
             ],
+            inputAmount: 0,
             showModal: false,
             refunds: [],
             allowRefund: true,
@@ -70,7 +71,7 @@ Component.register('adyen-refund', {
 
         onRefund() {
             this.isLoadingRefund = true;
-            this.adyenService.postRefund(this.order.id).then((res) => {
+            this.adyenService.postRefund(this.order.id, this.inputAmount).then((res) => {
                 if (res.success) {
                     this.fetchRefunds();
                     this.createNotificationSuccess({
@@ -122,8 +123,10 @@ Component.register('adyen-refund', {
             const orderTransactions = this.order.transactions;
             let isAdyen = false;
             for (let i = 0; i < orderTransactions.length; i++) {
-                if (orderTransactions[i].customFields?.originalPspReference !== undefined) {
-                    isAdyen = true;
+                if (orderTransactions[i].customFields !== undefined) {
+                    if (orderTransactions[i].customFields.originalPspReference !== undefined) {
+                        isAdyen = true;
+                    }
                 }
             }
 

--- a/src/Resources/app/administration/src/component/adyen-refund/index.js
+++ b/src/Resources/app/administration/src/component/adyen-refund/index.js
@@ -49,7 +49,7 @@ Component.register('adyen-refund', {
                 { property: 'createdAt', label: this.$tc('adyen.columnHeaders.created') },
                 { property: 'updatedAt', label: this.$tc('adyen.columnHeaders.updated') }
             ],
-            inputAmount: 0,
+            inputAmount: '',
             showModal: false,
             refunds: [],
             allowRefund: true,

--- a/src/Resources/app/administration/src/service/adyenService.js
+++ b/src/Resources/app/administration/src/service/adyenService.js
@@ -55,15 +55,15 @@ class ApiClient extends ApiService {
             });
     }
 
-    postRefund(orderId) {
+    postRefund(orderId, inputAmount) {
         const headers = this.getBasicHeaders({});
-
         return this.httpClient
-            .post(this.getApiBasePath() + '/refunds', {orderId: orderId}, {
+            .post(this.getApiBasePath() + '/refunds', {orderId: orderId, inputAmount: inputAmount}, {
                 headers
             })
             .then((response) => {
                 return ApiService.handleResponse(response);
+
             }).catch((error) => {
                 console.error('An error occurred during post refund request: ' + error.message);
                 throw error;
@@ -89,8 +89,10 @@ class ApiClient extends ApiService {
         const orderTransactions = order.transactions;
         let isAdyen = false;
         for (let i = 0; i < orderTransactions.length; i++) {
-            if (orderTransactions[i].customFields?.originalPspReference !== undefined) {
-                isAdyen = true;
+            if (orderTransactions[i].customFields !== undefined) {
+                if (orderTransactions[i].customFields.originalPspReference !== undefined) {
+                    isAdyen = true;
+                }
             }
         }
 

--- a/src/Service/RefundService.php
+++ b/src/Service/RefundService.php
@@ -116,7 +116,7 @@ class RefundService
      * @return array
      * @throws AdyenException
      */
-    public function refund(OrderEntity $order): array
+    public function refund(OrderEntity $order, $inputAmount): array
     {
         $orderTransaction = $this->getAdyenOrderTransactionForRefund($order, self::REFUNDABLE_STATES);
 
@@ -132,7 +132,7 @@ class RefundService
 
         $pspReference = $orderTransaction->getCustomFields()[PaymentResponseHandler::ORIGINAL_PSP_REFERENCE];
         $currencyIso = $order->getCurrency()->getIsoCode();
-        $amount = $this->currency->sanitize($order->getAmountTotal(), $currencyIso);
+        $amount = $this->currency->sanitize($inputAmount, $currencyIso);
 
         $params = [
             'originalReference' => $pspReference,
@@ -142,7 +142,6 @@ class RefundService
             ],
             'merchantAccount' => $merchantAccount
         ];
-
         try {
             $modificationService = new Modification(
                 $this->clientService->getClient($order->getSalesChannelId())
@@ -150,6 +149,7 @@ class RefundService
 
             return $modificationService->refund($params);
         } catch (AdyenException $e) {
+
             $this->logger->error($e->getMessage());
             throw $e;
         }
@@ -206,11 +206,12 @@ class RefundService
         OrderEntity $order,
         string $pspReference,
         string $source,
-        string $status
+        string $status,
+        int $inputAmount
     ) : void {
         $orderTransaction = $this->getAdyenOrderTransactionForRefund($order, self::REFUNDABLE_STATES);
         $currencyIso = $order->getCurrency()->getIsoCode();
-        $amount = $this->currency->sanitize($order->getAmountTotal(), $currencyIso);
+        $amount = $this->currency->sanitize($inputAmount, $currencyIso);
 
         $this->adyenRefundRepository->getRepository()->create([
             [


### PR DESCRIPTION
## Summary
- update the frontend component to allow the admin to input a value, validate the value
- update the db table to save the total amount that has been refunded
- update the AdminController that is being called by Ajax request to accept the amount as a parameter
- update the refund() method of the RefundService to accept an amount and send it to Adyen

## Tested scenarios
- sent a partial refund which was successful (async and sync flow)
- sent a refund call with a empty value which threw an error as expected
- sent a refund call with a value that was higher than the allowed value which also failed with an error as expected
- async flow in all the cases working correctly