### PR TITLE
[PW-5892] dont render giftcard component in checkout and use HPP fallback

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -399,6 +399,10 @@ abstract class AbstractPaymentMethodHandler
             $paymentMethodType = $request['paymentMethod']['type'];
         }
 
+        if (static::$isGiftCard) {
+            $request['paymentMethod']['brand'] = static::getBrand();
+        }
+
         if (!empty($request['storePaymentMethod']) && $request['storePaymentMethod'] === true) {
             $request['recurringProcessingModel'] = 'CardOnFile';
             $request['shopperInteraction'] = 'Ecommerce';

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -115,15 +115,9 @@ export default class ConfirmOrderPlugin extends Plugin {
             return;
         }
 
-        let identifier = 'type';
-        // Filter payment method configs by brand in the case of giftcards
-        if (adyenCheckoutOptions.selectedPaymentMethodHandler.includes('giftcard')) {
-            identifier = 'brand';
-        }
-
         // Get the payment method object from paymentMethodsResponse
         let paymentMethodConfigs = $.grep(this.adyenCheckout.paymentMethodsResponse.paymentMethods, function(paymentMethod) {
-            return paymentMethod[identifier] === type;
+            return paymentMethod['type'] === type;
         });
         if (paymentMethodConfigs.length === 0) {
             if (this.adyenCheckout.options.environment === 'test') {
@@ -451,9 +445,6 @@ export default class ConfirmOrderPlugin extends Plugin {
         });
         if (!isOneClick && paymentMethod.type === 'scheme' && adyenCheckoutOptions.displaySaveCreditCardOption) {
             configuration.enableStoreDetails = true;
-        }
-        if (paymentMethod.type === 'giftcard') {
-            configuration.type = configuration.brand;
         }
         try {
             const paymentMethodInstance = this.adyenCheckout.create(paymentMethod.type, configuration);

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -93,10 +93,9 @@ export default class ConfirmOrderPlugin extends Plugin {
         // get selected payment method
         let selectedAdyenPaymentMethod = this.getSelectedPaymentMethodKey();
 
-        const giftCardSelected = adyenCheckoutOptions.selectedPaymentMethodHandler.includes('giftcard');
         const updatableSelected = adyenConfiguration.updatablePaymentMethods.includes(selectedAdyenPaymentMethod);
 
-        if (giftCardSelected || (updatableSelected && !this.stateData)) {
+        if (updatableSelected && !this.stateData) {
             // render component to collect payment data
             this.renderPaymentComponent(selectedAdyenPaymentMethod);
             $('[data-adyen-payment-component-modal]').modal({show: true}).on('hidden.bs.modal', function (e) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
We want to only have giftcards work via HPP. Hence it doesn't make sense for the customer to input the fields in the component and then again in the HPP.

### In this PR
- Removed logic for mounting giftcard components in checkout
- Added `brand` to  giftcard payment request in handler

## Tested scenarios
<!-- Description of tested scenarios -->
Giftcard payments don't render component and redirect to HPP fallback
