### PR TITLE
[PW-5944] Change the private function preparePaymentsRequest to protected

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -359,7 +359,7 @@ abstract class AbstractPaymentMethodHandler
      * @param string|null $stateData
      * @return array
      */
-    private function preparePaymentsRequest(
+    protected function preparePaymentsRequest(
         SalesChannelContext $salesChannelContext,
         AsyncPaymentTransactionStruct $transaction,
         ?string $stateData = null


### PR DESCRIPTION
The idea behind using the protected function instead of private is to be able to extend the AbstractPaymentMethodHandler so that the recurringProcessingModel can be passed as a parameter. Extending the AbstractPaymentMethodHandler would enable controlling the request parameters.

## Tested scenarios
<!-- Description of tested scenarios -->
Tested with credit card payment and refund.

**Fixed issue**:  <!-- #-prefixed issue number -->
