### PR TITLE
[PW-6142] remove REFUND_FAILED as a webhook payment state

### DIFF
--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -233,6 +233,12 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
         Context $context
     ) {
         $order = $orderTransaction->getOrder();
+        if ('REFUND_FAILED' === $notification->getEventCode()) {
+            $this->logger->info(sprintf('Handling REFUND_FAILED on order: %s', $order->getOrderNumber()));
+            $this->refundService->handleRefundNotification($order, $notification, RefundEntity::STATUS_FAILED);
+            return;
+        }
+
         switch ($state) {
             case PaymentStates::STATE_PAID:
                 $this->transactionStateHandler->paid($orderTransaction->getId(), $context);
@@ -263,10 +269,6 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
 
                 $this->refundService->doRefund($orderTransaction, $transitionState, $context);
 
-                break;
-            case PaymentStates::STATE_REFUND_FAILED:
-                $this->logger->info(sprintf('Handling REFUND_FAILED on order: %s', $order->getOrderNumber()));
-                $this->refundService->handleRefundNotification($order, $notification, RefundEntity::STATUS_FAILED);
                 break;
             default:
                 break;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Remove dependency on REFUND_FAILED constant from the `\Adyen\Webhook\PaymentStates`


