### PR TITLE
[PW-6351] - Do not use StoreService to get the shopware version

### DIFF
--- a/src/Resources/config/services/checkout-api.xml
+++ b/src/Resources/config/services/checkout-api.xml
@@ -43,10 +43,13 @@
         <service id="Adyen\Shopware\Service\PaymentStatusService" autowire="true">
             <argument type="service" id="Adyen\Shopware\Service\PaymentResponseService"/>
         </service>
-        <service id="Adyen\Shopware\Service\ClientService" autowire="true">
-            <argument key="$pluginRepository" type="service" id="plugin.repository"/>
-            <argument key="$genericLogger" type="service" id="monolog.logger.adyen_generic"/>
-            <argument key="$apiLogger" type="service" id="monolog.logger.adyen_api"/>
+        <service id="Adyen\Shopware\Service\ClientService">
+            <argument type="service" id="plugin.repository"/>
+            <argument type="service" id="monolog.logger.adyen_generic"/>
+            <argument type="service" id="monolog.logger.adyen_api"/>
+            <argument>%kernel.shopware_version%</argument>
+            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
+            <argument type="service" id="cache.tags"/>
         </service>
         <service id="Adyen\Shopware\Service\PaymentMethodsService" autowire="true">
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>

--- a/src/Service/ClientService.php
+++ b/src/Service/ClientService.php
@@ -57,9 +57,9 @@ class ClientService
     private $apiLogger;
 
     /**
-     * @var StoreService
+     * @var string
      */
-    private $storeService;
+    private $shopwareVersion;
 
     /**
      * @var EntityRepositoryInterface
@@ -77,24 +77,24 @@ class ClientService
      * @param EntityRepositoryInterface $pluginRepository
      * @param LoggerInterface $genericLogger
      * @param LoggerInterface $apiLogger
+     * @param string $shopwareVersion
      * @param ConfigurationService $configurationService
-     * @param StoreService $storeService
      * @param CacheItemPoolInterface $cache
      */
     public function __construct(
         EntityRepositoryInterface $pluginRepository,
         LoggerInterface $genericLogger,
         LoggerInterface $apiLogger,
+        string $shopwareVersion,
         ConfigurationService $configurationService,
-        StoreService $storeService,
         CacheItemPoolInterface $cache
     ) {
         $this->pluginRepository = $pluginRepository;
         $this->configurationService = $configurationService;
         $this->genericLogger = $genericLogger;
         $this->apiLogger = $apiLogger;
-        $this->storeService = $storeService;
         $this->cache = $cache;
+        $this->shopwareVersion = $shopwareVersion;
     }
 
     public function getClient($salesChannelId)
@@ -110,7 +110,7 @@ class ClientService
             $client = new Client();
             $client->setXApiKey($apiKey);
             $client->setMerchantApplication(self::MERCHANT_APPLICATION_NAME, $this->getModuleVersion());
-            $client->setExternalPlatform(self::EXTERNAL_PLATFORM_NAME, $this->storeService->getShopwareVersion());
+            $client->setExternalPlatform(self::EXTERNAL_PLATFORM_NAME, $this->shopwareVersion);
             $client->setEnvironment($environment, $liveEndpointUrlPrefix);
 
             $client->setLogger($this->apiLogger);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Since Shopware6 v6.4.8.0 the `StoreService::getShopwareVersion` was removed. Based on this [issue](https://github.com/shopware/platform/issues/2336#issuecomment-1044271516) on S6 it was removed because the class was marked as internal so shouldn't have been using it.

As suggested in the issue, the `kernel.shopware_version` parameter will now be used to obtain the version.

## Tested scenarios
* Install the adyen module on v6.4.8.1


**Fixed issue**:
#231
