### PR TITLE
[PW-6546] set idempotency key to avoid duplicated refund requests

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -285,7 +285,8 @@ class AdminController
 
             $statesToSearch = RefundService::REFUNDABLE_STATES;
             $orderTransaction = $this->refundService->getAdyenOrderTransactionForRefund($order, $statesToSearch);
-            $adyenRefund = $this->adyenRefundRepository->getRefundForOrderByPspReference($orderTransaction->getId(), $result['pspReference']);
+            $adyenRefund = $this->adyenRefundRepository
+                ->getRefundForOrderByPspReference($orderTransaction->getId(), $result['pspReference']);
 
             if (is_null($adyenRefund)) {
                 $this->refundService->insertAdyenRefund(

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -283,13 +283,19 @@ class AdminController
                 throw new AdyenException($message);
             }
 
-            $this->refundService->insertAdyenRefund(
-                $order,
-                $result['pspReference'],
-                RefundEntity::SOURCE_SHOPWARE,
-                RefundEntity::STATUS_PENDING_WEBHOOK,
-                $amountInMinorUnit
-            );
+            $statesToSearch = RefundService::REFUNDABLE_STATES;
+            $orderTransaction = $this->refundService->getAdyenOrderTransactionForRefund($order, $statesToSearch);
+            $adyenRefund = $this->adyenRefundRepository->getRefundForOrderByPspReference($orderTransaction->getId(), $result['pspReference']);
+
+            if (is_null($adyenRefund)) {
+                $this->refundService->insertAdyenRefund(
+                    $order,
+                    $result['pspReference'],
+                    RefundEntity::SOURCE_SHOPWARE,
+                    RefundEntity::STATUS_PENDING_WEBHOOK,
+                    $amountInMinorUnit
+                );
+            }
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
 

--- a/src/Service/Repository/AdyenRefundRepository.php
+++ b/src/Service/Repository/AdyenRefundRepository.php
@@ -24,12 +24,14 @@
 
 namespace Adyen\Shopware\Service\Repository;
 
+use Adyen\Shopware\Entity\Refund\RefundEntity;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 
 class AdyenRefundRepository
@@ -66,6 +68,23 @@ class AdyenRefundRepository
         $criteria->addFilter(new EqualsFilter('orderTransaction.order.id', $orderId));
 
         return $this->repository->search($criteria, Context::createDefaultContext());
+    }
+
+    /**
+     * Filtering with pspReference and orderTransactionId since multiple refunds are possible
+     * @param string $orderTransactionId
+     * @param string $pspReference
+     * @return RefundEntity|null
+     */
+    public function getRefundForOrderByPspReference(string $orderTransactionId, string $pspReference): ?RefundEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new AndFilter([
+            new EqualsFilter('orderTransactionId', $orderTransactionId),
+            new EqualsFilter('pspReference', $pspReference)
+        ]));
+
+        return $this->repository->search($criteria, Context::createDefaultContext())->first();
     }
 
     /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Use order transaction ID as idempotency key to avoid sending duplicate requests.
Update idempotency key to last saved refund if refund total amount is not exceeded.
Avoid saving refund with duplicate pspReference

## Tested scenarios
<!-- Description of tested scenarios -->
Multiple refund requests made at the same time
Subsequent refund requests with partial amounts
