### PR TITLE
[PW-6477] - Get sales channel url from the hreflang integration if it is set

### DIFF
--- a/src/Service/Repository/SalesChannelRepository.php
+++ b/src/Service/Repository/SalesChannelRepository.php
@@ -30,8 +30,7 @@ class SalesChannelRepository
     public function __construct(
         EntityRepositoryInterface $domainRepository,
         EntityRepositoryInterface $salesChannelRepository
-    )
-    {
+    ) {
         $this->domainRepository = $domainRepository;
         $this->salesChannelRepository = $salesChannelRepository;
     }

--- a/src/Service/Repository/SalesChannelRepository.php
+++ b/src/Service/Repository/SalesChannelRepository.php
@@ -42,8 +42,14 @@ class SalesChannelRepository
     public function getSalesChannelUrl(SalesChannelContext $context): string
     {
         $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('salesChannelId', $context->getSalesChannel()->getId()));
-        $criteria->setLimit(1);
+
+        if (!empty($context->getSalesChannel()->getHreflangDefaultDomainId())) {
+            $criteria->addFilter(new EqualsFilter('id', $context->getSalesChannel()->getHreflangDefaultDomainId()));
+        }
+        else {
+            $criteria->addFilter(new EqualsFilter('salesChannelId', $context->getSalesChannel()->getId()));
+            $criteria->setLimit(1);
+        }
 
         $domainEntity = $this->domainRepository
             ->search($criteria, $context->getContext())
@@ -53,9 +59,7 @@ class SalesChannelRepository
             throw new SalesChannelDomainNotFoundException($context->getSalesChannel());
         }
 
-        $url = $domainEntity->getUrl();
-
-        return $url;
+        return $domainEntity->getUrl();
     }
 
     /**

--- a/src/Service/Repository/SalesChannelRepository.php
+++ b/src/Service/Repository/SalesChannelRepository.php
@@ -30,7 +30,8 @@ class SalesChannelRepository
     public function __construct(
         EntityRepositoryInterface $domainRepository,
         EntityRepositoryInterface $salesChannelRepository
-    ) {
+    )
+    {
         $this->domainRepository = $domainRepository;
         $this->salesChannelRepository = $salesChannelRepository;
     }
@@ -45,8 +46,7 @@ class SalesChannelRepository
 
         if (!empty($context->getSalesChannel()->getHreflangDefaultDomainId())) {
             $criteria->addFilter(new EqualsFilter('id', $context->getSalesChannel()->getHreflangDefaultDomainId()));
-        }
-        else {
+        } else {
             $criteria->addFilter(new EqualsFilter('salesChannelId', $context->getSalesChannel()->getId()));
             $criteria->setLimit(1);
         }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->
## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
If a sales channel has more than one domain name assigned to it, 3DS flow breaks due to incorrect origin value in the request although returnUrl is correct. Domain name for the origin is being fetched according to creation order from DB. If the shopper is not on this domain, error occurs.

Default sales channel url is now being defined from the default domain of hreflang integration if it is set.
