### PR TITLE
[PW-6441] Add PreparedPayment flow for headless integrations

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -193,7 +193,7 @@ class AdminController
 
         try {
             $results = $this->captureService
-                ->doOpenInvoiceCapture($order->getOrderNumber(), $amountInMinorUnit, $context);
+                ->capture($context, $order->getOrderNumber(), $amountInMinorUnit);
         } catch (CaptureException $e) {
             $this->logger->error($e->getMessage());
 
@@ -381,7 +381,7 @@ class AdminController
                 $context
             );
             $result[] = [
-                'pspReference' => $entity->getPaymentReference(),
+                'pspReference' => $entity->getPspReference(),
                 'amount' => $amount,
                 'rawAmount' => $entity->getAmount(),
                 'status' => $entity->getStatus(),

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -33,10 +33,12 @@ use Adyen\Shopware\Exception\CaptureException;
 use Adyen\Shopware\Service\CaptureService;
 use Adyen\Shopware\Service\ConfigurationService;
 use Adyen\Shopware\Service\NotificationService;
+use Adyen\Shopware\Service\PaymentResponseService;
 use Adyen\Shopware\Service\RefundService;
 use Adyen\Shopware\Service\Repository\AdyenPaymentCaptureRepository;
 use Adyen\Shopware\Service\Repository\AdyenRefundRepository;
 use Adyen\Shopware\Service\Repository\OrderRepository;
+use Adyen\Shopware\Service\Repository\OrderTransactionRepository;
 use Adyen\Util\Currency;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -45,6 +47,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\Currency\CurrencyFormatter;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -74,7 +77,7 @@ class AdminController
     /**
      * @var NotificationService
      */
-    private NotificationService $notificationService;
+    private $notificationService;
 
     /** @var CurrencyFormatter */
     private $currencyFormatter;
@@ -88,12 +91,20 @@ class AdminController
     /** @var AdyenPaymentCaptureRepository */
     private $adyenPaymentCaptureRepository;
 
+    /** @var OrderTransactionRepository */
+    private $orderTransactionRepository;
+
+    /** @var ConfigurationService */
+    private $configurationService;
+
     /**
      * AdminController constructor.
      *
      * @param LoggerInterface $logger
      * @param OrderRepository $orderRepository
      * @param RefundService $refundService
+     * @param OrderTransactionRepository $orderTransactionRepository
+     * @param ConfigurationService $configurationService
      * @param AdyenRefundRepository $adyenRefundRepository
      * @param AdyenPaymentCaptureRepository $adyenPaymentCaptureRepository
      * @param NotificationService $notificationService
@@ -105,6 +116,8 @@ class AdminController
         LoggerInterface $logger,
         OrderRepository $orderRepository,
         RefundService $refundService,
+        OrderTransactionRepository $orderTransactionRepository,
+        ConfigurationService $configurationService,
         AdyenRefundRepository $adyenRefundRepository,
         AdyenPaymentCaptureRepository $adyenPaymentCaptureRepository,
         NotificationService $notificationService,
@@ -121,6 +134,8 @@ class AdminController
         $this->captureService = $captureService;
         $this->currencyFormatter = $currencyFormatter;
         $this->currencyUtil = $currencyUtil;
+        $this->orderTransactionRepository = $orderTransactionRepository;
+        $this->configurationService = $configurationService;
     }
 
     /**
@@ -356,6 +371,25 @@ class AdminController
                 'updatedAt' => $notification->getUpdatedAt()->format(self::ADMIN_DATETIME_FORMAT),
             ];
         }
+
+        return new JsonResponse($response);
+    }
+
+    /**
+     * @Route(
+     *     "/api/adyen/orders/{orderId}/payment-details",
+     *     methods={"GET"}
+     * )
+     */
+    public function getPaymentDetails(string $orderId): JsonResponse
+    {
+        $orderTransaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction($orderId);
+        $customFields = $orderTransaction->getCustomFields();
+        $response = [
+            'paymentReference' => $customFields['paymentReference'] ?? null,
+            'pspReference' => $customFields['originalPspReference'] ?? null,
+            'environment' => $this->configurationService->getEnvironment()
+        ];
 
         return new JsonResponse($response);
     }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -381,7 +381,7 @@ class AdminController
                 $context
             );
             $result[] = [
-                'pspReference' => $entity->getPspReference(),
+                'pspReference' => $entity->getPaymentReference(),
                 'amount' => $amount,
                 'rawAmount' => $entity->getAmount(),
                 'status' => $entity->getStatus(),

--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -323,6 +323,34 @@ class StoreApiController
     }
 
     /**
+     * @Route(
+     *     "/store-api/adyen/prepared-payment-status",
+     *     name="store-api.action.adyen.prepared-payment-status",
+     *     methods={"POST"}
+     * )
+     *
+     * @param Request $request
+     * @param SalesChannelContext $context
+     * @return JsonResponse
+     */
+    public function getPreparedPaymentStatus(Request $request, SalesChannelContext $context): JsonResponse
+    {
+        $paymentReference = $request->get('paymentReference');
+        if (empty($paymentReference)) {
+            return new JsonResponse('Payment reference not provided', 400);
+        }
+
+        try {
+            return new JsonResponse(
+                $this->paymentStatusService->getWithPaymentReference($paymentReference)
+            );
+        } catch (\Exception $exception) {
+            $this->logger->error($exception->getMessage());
+            return new JsonResponse(["isFinal" => true]);
+        }
+    }
+
+    /**
      * @OA\Post(
      *      path="/adyen/set-payment",
      *      summary="set payment for an order",

--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -209,7 +209,7 @@ class StoreApiController
         $totalPrice = $calculatedCart->getPrice()->getTotalPrice();
         $paymentMethod = $context->getPaymentMethod();
         $paymentHandler = $paymentMethod->getHandlerIdentifier();
-        $reference = Uuid::fromStringToHex($calculatedCart->getToken()); // todo save to transaction/order
+        $reference = Uuid::fromStringToHex($calculatedCart->getToken());
         $currency = $this->paymentRequestService->getCurrency($context->getCurrencyId(), $context->getContext());
         $lineItems = $this->paymentRequestService->getLineItems(
             $calculatedCart->getLineItems(),

--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -109,9 +109,18 @@ class StoreApiController
      * @var LoggerInterface
      */
     private $logger;
-    private CartService $cartService;
-    private CartCalculator $cartCalculator;
-    private ClientService $clientService;
+    /**
+     * @var CartService
+     */
+    private $cartService;
+    /**
+     * @var CartCalculator
+     */
+    private $cartCalculator;
+    /**
+     * @var ClientService 
+     */
+    private $clientService;
 
     /**
      * StoreApiController constructor.

--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -118,7 +118,7 @@ class StoreApiController
      */
     private $cartCalculator;
     /**
-     * @var ClientService 
+     * @var ClientService
      */
     private $clientService;
 

--- a/src/Entity/PaymentResponse/PaymentResponseEntity.php
+++ b/src/Entity/PaymentResponse/PaymentResponseEntity.php
@@ -44,7 +44,7 @@ class PaymentResponseEntity extends Entity
     /**
      * @var string
      */
-    protected $pspReference;
+    protected $paymentReference;
 
     /**
      * @var string
@@ -98,14 +98,14 @@ class PaymentResponseEntity extends Entity
         $this->orderTransaction = $orderTransaction;
     }
 
-    public function getPspReference(): ?string
+    public function getPaymentReference(): ?string
     {
-        return $this->pspReference;
+        return $this->paymentReference;
     }
 
-    public function setPspReference(string $pspReference): void
+    public function setPaymentReference(string $paymentReference): void
     {
-        $this->pspReference = $pspReference;
+        $this->paymentReference = $paymentReference;
     }
 
     /**

--- a/src/Entity/PaymentResponse/PaymentResponseEntity.php
+++ b/src/Entity/PaymentResponse/PaymentResponseEntity.php
@@ -44,6 +44,11 @@ class PaymentResponseEntity extends Entity
     /**
      * @var string
      */
+    protected $pspReference;
+
+    /**
+     * @var string
+     */
     protected $resultCode;
 
     /**
@@ -62,9 +67,9 @@ class PaymentResponseEntity extends Entity
     protected $response;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getOrderTransactionId(): string
+    public function getOrderTransactionId(): ?string
     {
         return $this->orderTransactionId;
     }
@@ -91,6 +96,16 @@ class PaymentResponseEntity extends Entity
     public function setOrderTransaction(OrderTransactionEntity $orderTransaction): void
     {
         $this->orderTransaction = $orderTransaction;
+    }
+
+    public function getPspReference(): ?string
+    {
+        return $this->pspReference;
+    }
+
+    public function setPspReference(string $pspReference): void
+    {
+        $this->pspReference = $pspReference;
     }
 
     /**

--- a/src/Entity/PaymentResponse/PaymentResponseEntityDefinition.php
+++ b/src/Entity/PaymentResponse/PaymentResponseEntityDefinition.php
@@ -66,7 +66,7 @@ class PaymentResponseEntityDefinition extends EntityDefinition
                 'orderTransactionId',
                 OrderTransactionDefinition::class
             )),
-            new StringField('psp_reference', 'pspReference'),
+            new StringField('payment_reference', 'paymentReference'),
             new StringField('result_code', 'resultCode'),
             new LongTextField('response', 'response'),
             new CreatedAtField(),

--- a/src/Entity/PaymentResponse/PaymentResponseEntityDefinition.php
+++ b/src/Entity/PaymentResponse/PaymentResponseEntityDefinition.php
@@ -65,7 +65,8 @@ class PaymentResponseEntityDefinition extends EntityDefinition
                 'order_transaction_id',
                 'orderTransactionId',
                 OrderTransactionDefinition::class
-            ))->addFlags(new Required()),
+            )),
+            new StringField('psp_reference', 'pspReference'),
             new StringField('result_code', 'resultCode'),
             new LongTextField('response', 'response'),
             new CreatedAtField(),

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -44,18 +44,25 @@ use Adyen\Shopware\Storefront\Controller\RedirectResultController;
 use Adyen\Util\Currency;
 use Exception;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PreparedPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentFinalizeException;
 use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentProcessException;
+use Shopware\Core\Checkout\Payment\Exception\CapturePreparedPaymentException;
 use Shopware\Core\Checkout\Payment\Exception\CustomerCanceledAsyncPaymentException;
 use Shopware\Core\Checkout\Payment\Exception\PaymentProcessException;
+use Shopware\Core\Checkout\Payment\Exception\ValidatePreparedPaymentException;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Currency\CurrencyEntity;
@@ -203,6 +210,7 @@ abstract class AbstractPaymentMethodHandler
      * @param OrderTransactionStateHandler $orderTransactionStateHandler
      * @param RouterInterface $router
      * @param CsrfTokenManagerInterface $csrfTokenManager
+     * @param Session $session
      * @param EntityRepositoryInterface $currencyRepository
      * @param EntityRepositoryInterface $productRepository
      * @param PaymentMethodsService $paymentMethodsService
@@ -348,6 +356,16 @@ abstract class AbstractPaymentMethodHandler
         } catch (PaymentFailedException $exception) {
             throw new AsyncPaymentFinalizeException($transactionId, $exception->getMessage());
         }
+    }
+
+    public function validate(Cart $cart, RequestDataBag $requestDataBag, SalesChannelContext $context): Struct
+    {
+        return new ArrayStruct(['valid']);
+    }
+
+    public function capture(PreparedPaymentTransactionStruct $transaction, RequestDataBag $requestDataBag, SalesChannelContext $context, Struct $preOrderPaymentStruct): void
+    {
+        // TODO: Implement capture() method.
     }
 
     /**

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -308,7 +308,6 @@ abstract class AbstractPaymentMethodHandler
      */
     public function validate(Cart $cart, RequestDataBag $requestDataBag, SalesChannelContext $context): Struct
     {
-        xdebug_break();
         if ($this->configurationService->usesPreparedPaymentFlow($context->getSalesChannelId())) {
             $paymentReference = $requestDataBag->get('paymentReference');
             if (empty($paymentReference)) {
@@ -341,7 +340,6 @@ abstract class AbstractPaymentMethodHandler
         SalesChannelContext $context,
         Struct $preOrderPaymentStruct
     ): void {
-        xdebug_break();
         if (!$this->configurationService->usesPreparedPaymentFlow($context->getSalesChannelId())) {
             return;
         }
@@ -368,11 +366,8 @@ abstract class AbstractPaymentMethodHandler
             );
         }
 
-        if (
-            $this->captureService->requiresManualCapture(
-                $transaction->getOrderTransaction()->getPaymentMethod()->getHandlerIdentifier()
-            )
-        ) {
+        if ($this->captureService
+            ->requiresManualCapture($transaction->getOrderTransaction()->getPaymentMethod()->getHandlerIdentifier())) {
             return;
         }
 
@@ -383,8 +378,8 @@ abstract class AbstractPaymentMethodHandler
             $this->captureService->capture(
                 $context->getContext(),
                 $transaction->getOrder()->getOrderNumber(),
-                $captureAmount, true)
-            ;
+                $captureAmount, true
+            );
         } catch (CaptureException $e) {
             $this->logger->error($e->getMessage());
             throw new CapturePreparedPaymentException(

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -183,10 +183,6 @@ abstract class AbstractPaymentMethodHandler
         RequestDataBag $dataBag,
         SalesChannelContext $salesChannelContext
     ): RedirectResponse {
-        if ($this->configurationService->usesPreparedPaymentFlow($salesChannelContext->getSalesChannelId())) {
-            return null;
-        }
-
         $transactionId = $transaction->getOrderTransaction()->getId();
         $checkoutService = new CheckoutService(
             $this->clientService->getClient($salesChannelContext->getSalesChannel()->getId())
@@ -256,10 +252,6 @@ abstract class AbstractPaymentMethodHandler
         Request $request,
         SalesChannelContext $salesChannelContext
     ): void {
-        if ($this->configurationService->usesPreparedPaymentFlow($salesChannelContext->getSalesChannelId())) {
-            return;
-        }
-
         $transactionId = $transaction->getOrderTransaction()->getId();
         try {
             $this->resultHandler->processResult($transaction, $request, $salesChannelContext);
@@ -288,7 +280,7 @@ abstract class AbstractPaymentMethodHandler
     ): void {
         if ($this->configurationService->usesPreparedPaymentFlow($context->getSalesChannelId())) {
             // TODO: Implement capture() method.
-
+            $paymentReference = $requestDataBag['paymentReference'];
         }
     }
 

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -182,7 +182,7 @@ abstract class AbstractPaymentMethodHandler
         AsyncPaymentTransactionStruct $transaction,
         RequestDataBag $dataBag,
         SalesChannelContext $salesChannelContext
-    ): ?RedirectResponse {
+    ): RedirectResponse {
         if ($this->configurationService->usesPreparedPaymentFlow($salesChannelContext->getSalesChannelId())) {
             return null;
         }
@@ -270,7 +270,7 @@ abstract class AbstractPaymentMethodHandler
         }
     }
 
-    public function validate(Cart $cart, RequestDataBag $requestDataBag, SalesChannelContext $context): ?Struct
+    public function validate(Cart $cart, RequestDataBag $requestDataBag, SalesChannelContext $context): Struct
     {
         if (!$this->configurationService->usesPreparedPaymentFlow($context->getSalesChannelId())) {
             return null;

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -368,7 +368,11 @@ abstract class AbstractPaymentMethodHandler
             );
         }
 
-        if ($this->captureService->requiresManualCapture($transaction->getOrderTransaction()->getPaymentMethod()->getHandlerIdentifier())) {
+        if (
+            $this->captureService->requiresManualCapture(
+                $transaction->getOrderTransaction()->getPaymentMethod()->getHandlerIdentifier()
+            )
+        ) {
             return;
         }
 
@@ -376,7 +380,11 @@ abstract class AbstractPaymentMethodHandler
         $captureAmount = $this->currency->sanitize($transaction->getOrder()->getAmountTotal(), $currency);
 
         try {
-            $this->captureService->capture($context->getContext(), $transaction->getOrder()->getOrderNumber(), $captureAmount, true);
+            $this->captureService->capture(
+                $context->getContext(),
+                $transaction->getOrder()->getOrderNumber(),
+                $captureAmount, true)
+            ;
         } catch (CaptureException $e) {
             $this->logger->error($e->getMessage());
             throw new CapturePreparedPaymentException(

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -272,10 +272,12 @@ abstract class AbstractPaymentMethodHandler
 
     public function validate(Cart $cart, RequestDataBag $requestDataBag, SalesChannelContext $context): Struct
     {
-        if (!$this->configurationService->usesPreparedPaymentFlow($context->getSalesChannelId())) {
-            return null;
+        if ($this->configurationService->usesPreparedPaymentFlow($context->getSalesChannelId())) {
+            // TODO
+            return new ArrayStruct(['valid']);
         }
-        return new ArrayStruct(['valid']);
+
+        return new ArrayStruct([]);
     }
 
     public function capture(
@@ -284,10 +286,10 @@ abstract class AbstractPaymentMethodHandler
         SalesChannelContext $context,
         Struct $preOrderPaymentStruct
     ): void {
-        if (!$this->configurationService->usesPreparedPaymentFlow($context->getSalesChannelId())) {
-            return;
+        if ($this->configurationService->usesPreparedPaymentFlow($context->getSalesChannelId())) {
+            // TODO: Implement capture() method.
+
         }
-        // TODO: Implement capture() method.
     }
 
     /**

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -44,6 +44,7 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 use Shopware\Core\Checkout\Payment\Cart\PreparedPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentFinalizeException;
@@ -61,7 +62,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
-abstract class AbstractPaymentMethodHandler
+abstract class AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     const PROMOTION = 'promotion';

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -378,7 +378,8 @@ abstract class AbstractPaymentMethodHandler
             $this->captureService->capture(
                 $context->getContext(),
                 $transaction->getOrder()->getOrderNumber(),
-                $captureAmount, true
+                $captureAmount,
+                true
             );
         } catch (CaptureException $e) {
             $this->logger->error($e->getMessage());

--- a/src/Handlers/AfterpayDefaultPaymentMethodHandler.php
+++ b/src/Handlers/AfterpayDefaultPaymentMethodHandler.php
@@ -26,14 +26,8 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class AfterpayDefaultPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class AfterpayDefaultPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static $isOpenInvoice = true;
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/AfterpayDefaultPaymentMethodHandler.php
+++ b/src/Handlers/AfterpayDefaultPaymentMethodHandler.php
@@ -30,7 +30,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class AfterpayDefaultPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static $isOpenInvoice = true;

--- a/src/Handlers/AfterpayDefaultPaymentMethodHandler.php
+++ b/src/Handlers/AfterpayDefaultPaymentMethodHandler.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class AfterpayDefaultPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static $isOpenInvoice = true;

--- a/src/Handlers/AlbelliGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/AlbelliGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class AlbelliGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class AlbelliGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/AlbelliGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/AlbelliGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class AlbelliGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/AlbelliGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/AlbelliGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class AlbelliGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/AlipayHkPaymentMethodHandler.php
+++ b/src/Handlers/AlipayHkPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class AlipayHkPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class AlipayHkPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/AlipayHkPaymentMethodHandler.php
+++ b/src/Handlers/AlipayHkPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class AlipayHkPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class AlipayHkPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/AlipayHkPaymentMethodHandler.php
+++ b/src/Handlers/AlipayHkPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class AlipayHkPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/AlipayPaymentMethodHandler.php
+++ b/src/Handlers/AlipayPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class AlipayPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class AlipayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/AlipayPaymentMethodHandler.php
+++ b/src/Handlers/AlipayPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class AlipayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class AlipayPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'alipay';

--- a/src/Handlers/AlipayPaymentMethodHandler.php
+++ b/src/Handlers/AlipayPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class AlipayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/AmazonPayPaymentMethodHandler.php
+++ b/src/Handlers/AmazonPayPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class AmazonPayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/AmazonPayPaymentMethodHandler.php
+++ b/src/Handlers/AmazonPayPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class AmazonPayPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class AmazonPayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/AmazonPayPaymentMethodHandler.php
+++ b/src/Handlers/AmazonPayPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class AmazonPayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class AmazonPayPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'amazonpay';

--- a/src/Handlers/ApplePayPaymentMethodHandler.php
+++ b/src/Handlers/ApplePayPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class ApplePayPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class ApplePayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/ApplePayPaymentMethodHandler.php
+++ b/src/Handlers/ApplePayPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class ApplePayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class ApplePayPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'applepay';

--- a/src/Handlers/ApplePayPaymentMethodHandler.php
+++ b/src/Handlers/ApplePayPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class ApplePayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/BancontactCardPaymentMethodHandler.php
+++ b/src/Handlers/BancontactCardPaymentMethodHandler.php
@@ -26,9 +26,11 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 // phpcs:ignore Generic.Files.LineLength.TooLong
-class BancontactCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class BancontactCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/BancontactCardPaymentMethodHandler.php
+++ b/src/Handlers/BancontactCardPaymentMethodHandler.php
@@ -30,7 +30,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInt
 
 // phpcs:ignore Generic.Files.LineLength.TooLong
 class BancontactCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/BancontactCardPaymentMethodHandler.php
+++ b/src/Handlers/BancontactCardPaymentMethodHandler.php
@@ -25,15 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-// phpcs:ignore Generic.Files.LineLength.TooLong
-class BancontactCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class BancontactCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'bcmc';

--- a/src/Handlers/BeautyGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/BeautyGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class BeautyGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/BeautyGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/BeautyGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class BeautyGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/BeautyGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/BeautyGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class BeautyGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class BeautyGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/BijenkorfGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/BijenkorfGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class BijenkorfGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/BijenkorfGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/BijenkorfGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class BijenkorfGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/BijenkorfGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/BijenkorfGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class BijenkorfGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class BijenkorfGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/BlikPaymentMethodHandler.php
+++ b/src/Handlers/BlikPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class BlikPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/BlikPaymentMethodHandler.php
+++ b/src/Handlers/BlikPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class BlikPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class BlikPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/BlikPaymentMethodHandler.php
+++ b/src/Handlers/BlikPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class BlikPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class BlikPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'blik';

--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'scheme';

--- a/src/Handlers/ClearpayPaymentMethodHandler.php
+++ b/src/Handlers/ClearpayPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class ClearpayPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class ClearpayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/ClearpayPaymentMethodHandler.php
+++ b/src/Handlers/ClearpayPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class ClearpayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class ClearpayPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/ClearpayPaymentMethodHandler.php
+++ b/src/Handlers/ClearpayPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class ClearpayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/DeCadeaukaartGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/DeCadeaukaartGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class DeCadeaukaartGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/DeCadeaukaartGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/DeCadeaukaartGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class DeCadeaukaartGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class DeCadeaukaartGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/DeCadeaukaartGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/DeCadeaukaartGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class DeCadeaukaartGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/DotpayPaymentMethodHandler.php
+++ b/src/Handlers/DotpayPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class DotpayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class DotpayPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'dotpay';

--- a/src/Handlers/DotpayPaymentMethodHandler.php
+++ b/src/Handlers/DotpayPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class DotpayPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class DotpayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/DotpayPaymentMethodHandler.php
+++ b/src/Handlers/DotpayPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class DotpayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/EpsPaymentMethodHandler.php
+++ b/src/Handlers/EpsPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class EpsPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class EpsPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/EpsPaymentMethodHandler.php
+++ b/src/Handlers/EpsPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class EpsPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class EpsPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'eps';

--- a/src/Handlers/EpsPaymentMethodHandler.php
+++ b/src/Handlers/EpsPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class EpsPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/Facilypay10xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay10xPaymentMethodHandler.php
@@ -30,7 +30,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class Facilypay10xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay10xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay10xPaymentMethodHandler.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class Facilypay10xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay10xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay10xPaymentMethodHandler.php
@@ -26,12 +26,7 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class Facilypay10xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class Facilypay10xPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay12xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay12xPaymentMethodHandler.php
@@ -30,7 +30,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class Facilypay12xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay12xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay12xPaymentMethodHandler.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class Facilypay12xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay12xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay12xPaymentMethodHandler.php
@@ -26,12 +26,7 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class Facilypay12xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class Facilypay12xPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay3xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay3xPaymentMethodHandler.php
@@ -26,14 +26,8 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class Facilypay3xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class Facilypay3xPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static $isOpenInvoice = true;
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/Facilypay3xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay3xPaymentMethodHandler.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class Facilypay3xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static $isOpenInvoice = true;

--- a/src/Handlers/Facilypay3xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay3xPaymentMethodHandler.php
@@ -30,7 +30,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class Facilypay3xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static $isOpenInvoice = true;

--- a/src/Handlers/Facilypay4xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay4xPaymentMethodHandler.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class Facilypay4xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay4xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay4xPaymentMethodHandler.php
@@ -30,7 +30,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class Facilypay4xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay4xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay4xPaymentMethodHandler.php
@@ -26,12 +26,7 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class Facilypay4xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class Facilypay4xPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay6xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay6xPaymentMethodHandler.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class Facilypay6xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay6xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay6xPaymentMethodHandler.php
@@ -26,12 +26,7 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class Facilypay6xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class Facilypay6xPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/Facilypay6xPaymentMethodHandler.php
+++ b/src/Handlers/Facilypay6xPaymentMethodHandler.php
@@ -30,7 +30,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class Facilypay6xPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
 

--- a/src/Handlers/FashionChequeGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/FashionChequeGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class FashionChequeGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/FashionChequeGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/FashionChequeGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class FashionChequeGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/FashionChequeGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/FashionChequeGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class FashionChequeGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class FashionChequeGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/GallGallGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GallGallGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class GallGallGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class GallGallGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/GallGallGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GallGallGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class GallGallGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/GallGallGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GallGallGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class GallGallGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/GenericGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GenericGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class GenericGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/GenericGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GenericGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class GenericGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/GenericGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GenericGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class GenericGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class GenericGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/GiroPayPaymentMethodHandler.php
+++ b/src/Handlers/GiroPayPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class GiroPayPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class GiroPayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/GiroPayPaymentMethodHandler.php
+++ b/src/Handlers/GiroPayPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class GiroPayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class GiroPayPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'giropay';

--- a/src/Handlers/GiroPayPaymentMethodHandler.php
+++ b/src/Handlers/GiroPayPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class GiroPayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/GivexGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GivexGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class GivexGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/GivexGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GivexGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class GivexGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/GivexGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GivexGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class GivexGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class GivexGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/GooglePayPaymentMethodHandler.php
+++ b/src/Handlers/GooglePayPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class GooglePayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class GooglePayPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'paywithgoogle';

--- a/src/Handlers/GooglePayPaymentMethodHandler.php
+++ b/src/Handlers/GooglePayPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class GooglePayPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class GooglePayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/GooglePayPaymentMethodHandler.php
+++ b/src/Handlers/GooglePayPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class GooglePayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/HunkemollerLingerieGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/HunkemollerLingerieGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class HunkemollerLingerieGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/HunkemollerLingerieGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/HunkemollerLingerieGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class HunkemollerLingerieGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class HunkemollerLingerieGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/HunkemollerLingerieGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/HunkemollerLingerieGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class HunkemollerLingerieGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/IdealPaymentMethodHandler.php
+++ b/src/Handlers/IdealPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'ideal';

--- a/src/Handlers/IdealPaymentMethodHandler.php
+++ b/src/Handlers/IdealPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/IdealPaymentMethodHandler.php
+++ b/src/Handlers/IdealPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class IdealPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/KadowereldGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/KadowereldGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class KadowereldGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/KadowereldGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/KadowereldGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class KadowereldGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class KadowereldGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/KadowereldGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/KadowereldGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class KadowereldGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/KlarnaAccountPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaAccountPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-// phpcs:ignore Generic.Files.LineLength.TooLong
-class KlarnaAccountPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class KlarnaAccountPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static $isOpenInvoice = true;

--- a/src/Handlers/KlarnaAccountPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaAccountPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class KlarnaAccountPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static $isOpenInvoice = true;

--- a/src/Handlers/KlarnaAccountPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaAccountPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class KlarnaAccountPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class KlarnaAccountPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static $isOpenInvoice = true;
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class KlarnaPayLaterPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class KlarnaPayLaterPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static $isOpenInvoice = true;
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class KlarnaPayLaterPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static $isOpenInvoice = true;

--- a/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayLaterPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-// phpcs:ignore Generic.Files.LineLength.TooLong
-class KlarnaPayLaterPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class KlarnaPayLaterPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static $isOpenInvoice = true;

--- a/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class KlarnaPayNowPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static $isOpenInvoice = true;

--- a/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-// phpcs:ignore Generic.Files.LineLength.TooLong
-class KlarnaPayNowPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class KlarnaPayNowPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static $isOpenInvoice = true;

--- a/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
+++ b/src/Handlers/KlarnaPayNowPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class KlarnaPayNowPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class KlarnaPayNowPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static $isOpenInvoice = true;
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/OneClickPaymentMethodHandler.php
+++ b/src/Handlers/OneClickPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class OneClickPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class OneClickPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/OneClickPaymentMethodHandler.php
+++ b/src/Handlers/OneClickPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class OneClickPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/OneClickPaymentMethodHandler.php
+++ b/src/Handlers/OneClickPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class OneClickPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class OneClickPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'storedPaymentMethods';

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -111,12 +111,14 @@ class PaymentResponseHandler
 
     /**
      * @param array $response
-     * @param OrderTransactionEntity $orderTransaction
+     * @param string $orderTransactionId
+     * @param string|null $pspReference
      * @return PaymentResponseHandlerResult
      */
     public function handlePaymentResponse(
         array $response,
-        OrderTransactionEntity $orderTransaction
+        string $orderTransactionId,
+        string $pspReference = null
     ): PaymentResponseHandlerResult {
         // Retrieve result code from response array
         $resultCode = $response['resultCode'];
@@ -148,7 +150,7 @@ class PaymentResponseHandler
         // Store response for cart until the payment is finalised
         $this->paymentResponseService->insertPaymentResponse(
             $response,
-            $orderTransaction
+            $orderTransactionId
         );
 
         // Based on the result code start different payment flows
@@ -191,6 +193,8 @@ class PaymentResponseHandler
     }
 
     /**
+     * Update Order Transaction state based on payment response.
+     *
      * @param AsyncPaymentTransactionStruct $transaction
      * @param SalesChannelContext $salesChannelContext
      * @param PaymentResponseHandlerResult $paymentResponseHandlerResult
@@ -200,7 +204,7 @@ class PaymentResponseHandler
     public function handleShopwareApis(
         AsyncPaymentTransactionStruct $transaction,
         SalesChannelContext $salesChannelContext,
-        PaymentResponseHandlerResult $paymentResponseHandlerResult
+        PaymentResponseHandlerResult $paymentResponseHandlerResult // todo we don't need this argument, use $this->paymentResponseHa.....
     ): void {
         $orderTransactionId = $transaction->getOrderTransaction()->getId();
         $context = $salesChannelContext->getContext();

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -221,7 +221,7 @@ class PaymentResponseHandler
     public function handleShopwareApis(
         AsyncPaymentTransactionStruct $transaction,
         SalesChannelContext $salesChannelContext,
-        PaymentResponseHandlerResult $paymentResponseHandlerResult // todo we don't need this argument, use $this->pa..
+        PaymentResponseHandlerResult $paymentResponseHandlerResult // todo do we need this argument, use $this->pa..
     ): void {
         $orderTransactionId = $transaction->getOrderTransaction()->getId();
         $context = $salesChannelContext->getContext();

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -221,7 +221,7 @@ class PaymentResponseHandler
     public function handleShopwareApis(
         AsyncPaymentTransactionStruct $transaction,
         SalesChannelContext $salesChannelContext,
-        PaymentResponseHandlerResult $paymentResponseHandlerResult // todo we don't need this argument, use $this->paymentResponseHa.....
+        PaymentResponseHandlerResult $paymentResponseHandlerResult // todo we don't need this argument, use $this->pa..
     ): void {
         $orderTransactionId = $transaction->getOrderTransaction()->getId();
         $context = $salesChannelContext->getContext();

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -64,6 +64,8 @@ class PaymentResponseHandler
 
     // Merchant reference key in API response
     const MERCHANT_REFERENCE = 'merchantReference';
+
+    const PAYMENT_REFERENCE = 'paymentReference';
     const ORDER_TRANSACTION_ID = 'orderTransactionId';
     /**
      * @var LoggerInterface
@@ -114,12 +116,18 @@ class PaymentResponseHandler
     /**
      * @param array $response
      * @param string|null $orderTransactionId
+     * @param string|null $paymentReference
      * @return PaymentResponseHandlerResult
+     * @throws ValidationException
      */
     public function handlePaymentResponse(
         array $response,
-        string $orderTransactionId = null
+        string $orderTransactionId = null,
+        string $paymentReference = null
     ): PaymentResponseHandlerResult {
+        if (is_null($orderTransactionId) && is_null($paymentReference)) {
+            throw new ValidationException('Error: either orderTransactionId or paymentReference is required');
+        }
         // Retrieve result code from response array
         $resultCode = $response['resultCode'];
         if (array_key_exists('refusalReason', $response)) {
@@ -157,8 +165,8 @@ class PaymentResponseHandler
         } else {
             $this->paymentResponseService->insertPaymentResponse(
                 $response,
-                $response['pspReference'],
-                self::PSP_REFERENCE
+                $paymentReference,
+                self::PAYMENT_REFERENCE
             );
         }
 

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -163,6 +163,7 @@ class PaymentResponseHandler
                 self::ORDER_TRANSACTION_ID
             );
         } else {
+            $this->paymentResponseHandlerResult->setPaymentReference($paymentReference);
             $this->paymentResponseService->insertPaymentResponse(
                 $response,
                 $paymentReference,
@@ -333,43 +334,49 @@ class PaymentResponseHandler
 
         switch ($resultCode) {
             case self::AUTHORISED:
-                return [
+                $response = [
                     "isFinal" => true,
                     "resultCode" => $resultCode,
                 ];
+                break;
             case self::REFUSED:
             case self::ERROR:
             case self::CANCELLED:
-                return [
+                $response = [
                     "isFinal" => true,
                     "resultCode" => $resultCode,
                     "refusalReason" => $refusalReason,
                     "refusalReasonCode" => $refusalReasonCode
                 ];
+                break;
             case self::REDIRECT_SHOPPER:
             case self::IDENTIFY_SHOPPER:
             case self::CHALLENGE_SHOPPER:
             case self::PRESENT_TO_SHOPPER:
             case self::PENDING:
-                return [
+                $response = [
                     "isFinal" => false,
                     "resultCode" => $resultCode,
                     "action" => $action
                 ];
                 break;
             case self::RECEIVED:
-                return [
+                $response = [
                     "isFinal" => true,
                     "resultCode" => $resultCode,
                     "additionalData" => $additionalData
                 ];
                 break;
             default:
-                return [
+                $response = [
                     "isFinal" => true,
                     "resultCode" => self::ERROR,
                 ];
         }
+
+        $response['paymentReference'] = $paymentResponseHandlerResult->getPaymentReference() ?: null;
+
+        return $response;
     }
 
     /**

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -35,7 +35,7 @@ use Adyen\Shopware\Service\PaymentResponseService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
-use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
+use Shopware\Core\Checkout\Payment\Cart\SyncPaymentTransactionStruct;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -213,14 +213,14 @@ class PaymentResponseHandler
     /**
      * Update Order Transaction state based on payment response.
      *
-     * @param AsyncPaymentTransactionStruct $transaction
+     * @param SyncPaymentTransactionStruct $transaction
      * @param SalesChannelContext $salesChannelContext
      * @param PaymentResponseHandlerResult $paymentResponseHandlerResult
      * @throws PaymentCancelledException
      * @throws PaymentFailedException
      */
     public function handleShopwareApis(
-        AsyncPaymentTransactionStruct $transaction,
+        SyncPaymentTransactionStruct $transaction,
         SalesChannelContext $salesChannelContext,
         PaymentResponseHandlerResult $paymentResponseHandlerResult // todo do we need this argument, use $this->pa..
     ): void {

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -222,7 +222,7 @@ class PaymentResponseHandler
     public function handleShopwareApis(
         SyncPaymentTransactionStruct $transaction,
         SalesChannelContext $salesChannelContext,
-        PaymentResponseHandlerResult $paymentResponseHandlerResult // todo do we need this argument, use $this->pa..
+        PaymentResponseHandlerResult $paymentResponseHandlerResult
     ): void {
         $orderTransactionId = $transaction->getOrderTransaction()->getId();
         $context = $salesChannelContext->getContext();
@@ -243,19 +243,24 @@ class PaymentResponseHandler
         $transactionCustomFields = [];
 
         // Only store psp reference for the transaction if this is the first/original pspreference
-        $pspReference = $this->paymentResponseHandlerResult->getPspReference();
+        $pspReference = $paymentResponseHandlerResult->getPspReference();
         if (empty($storedTransactionCustomFields[self::ORIGINAL_PSP_REFERENCE]) && !empty($pspReference)) {
             $transactionCustomFields[self::ORIGINAL_PSP_REFERENCE] = $pspReference;
         }
 
+        $paymentReference = $paymentResponseHandlerResult->getPaymentReference();
+        if (empty($storedTransactionCustomFields[self::PAYMENT_REFERENCE]) && !empty($paymentReference)) {
+            $transactionCustomFields[self::PAYMENT_REFERENCE] = $paymentReference;
+        }
+
         // Only store action for the transaction if this is the first action
-        $action = $this->paymentResponseHandlerResult->getAction();
+        $action = $paymentResponseHandlerResult->getAction();
         if (empty($storedTransactionCustomFields[self::ACTION]) && !empty($action)) {
             $transactionCustomFields[self::ACTION] = $action;
         }
 
         // Only store additional data for the transaction if this is the first additional data
-        $additionalData = $this->paymentResponseHandlerResult->getAdditionalData();
+        $additionalData = $paymentResponseHandlerResult->getAdditionalData();
         if (empty($storedTransactionCustomFields[self::ADDITIONAL_DATA]) && !empty($additionalData)) {
             $transactionCustomFields[self::ADDITIONAL_DATA] = $additionalData;
         }

--- a/src/Handlers/PaymentResponseHandlerResult.php
+++ b/src/Handlers/PaymentResponseHandlerResult.php
@@ -11,6 +11,7 @@ class PaymentResponseHandlerResult
     private $refusalReason;
     private $refusalReasonCode;
     private $pspReference;
+    private $paymentReference;
     private $action;
     private $additionalData;
 
@@ -21,10 +22,10 @@ class PaymentResponseHandlerResult
      */
     public function createFromPaymentResponse(PaymentResponseEntity $paymentResponse): PaymentResponseHandlerResult
     {
-        // Set result code
         $this->setResultCode($paymentResponse->getResultCode());
         $this->setRefusalReason($paymentResponse->getRefusalReason());
         $this->setRefusalReasonCode($paymentResponse->getRefusalReasonCode());
+        $this->setPaymentReference($paymentResponse->getPaymentReference());
 
         $response = $paymentResponse->getResponse();
 
@@ -151,5 +152,21 @@ class PaymentResponseHandlerResult
     public function setAdditionalData($additionalData): void
     {
         $this->additionalData = $additionalData;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getPaymentReference(): ?string
+    {
+        return $this->paymentReference;
+    }
+
+    /**
+     * @param null|string $paymentReference
+     */
+    public function setPaymentReference(?string $paymentReference): void
+    {
+        $this->paymentReference = $paymentReference;
     }
 }

--- a/src/Handlers/PaypalPaymentMethodHandler.php
+++ b/src/Handlers/PaypalPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-// phpcs:ignore Generic.Files.LineLength.TooLong
-class PaypalPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class PaypalPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static function getPaymentMethodCode()
     {

--- a/src/Handlers/PaypalPaymentMethodHandler.php
+++ b/src/Handlers/PaypalPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class PaypalPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static function getPaymentMethodCode()
     {

--- a/src/Handlers/PaypalPaymentMethodHandler.php
+++ b/src/Handlers/PaypalPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class PaypalPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class PaypalPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static function getPaymentMethodCode()
     {

--- a/src/Handlers/PaysafecardPaymentMethodHandler.php
+++ b/src/Handlers/PaysafecardPaymentMethodHandler.php
@@ -30,7 +30,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class PaysafecardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/PaysafecardPaymentMethodHandler.php
+++ b/src/Handlers/PaysafecardPaymentMethodHandler.php
@@ -26,14 +26,8 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class PaysafecardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class PaysafecardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'paysafecard';

--- a/src/Handlers/PaysafecardPaymentMethodHandler.php
+++ b/src/Handlers/PaysafecardPaymentMethodHandler.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class PaysafecardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/RatepayDirectdebitPaymentMethodHandler.php
+++ b/src/Handlers/RatepayDirectdebitPaymentMethodHandler.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class RatepayDirectdebitPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
     

--- a/src/Handlers/RatepayDirectdebitPaymentMethodHandler.php
+++ b/src/Handlers/RatepayDirectdebitPaymentMethodHandler.php
@@ -26,12 +26,7 @@ declare(strict_types=1);
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class RatepayDirectdebitPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class RatepayDirectdebitPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isOpenInvoice = true;
     

--- a/src/Handlers/RatepayDirectdebitPaymentMethodHandler.php
+++ b/src/Handlers/RatepayDirectdebitPaymentMethodHandler.php
@@ -30,7 +30,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class RatepayDirectdebitPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
     

--- a/src/Handlers/RatepayPaymentMethodHandler.php
+++ b/src/Handlers/RatepayPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class RatepayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
     

--- a/src/Handlers/RatepayPaymentMethodHandler.php
+++ b/src/Handlers/RatepayPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class RatepayPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class RatepayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isOpenInvoice = true;
     

--- a/src/Handlers/RatepayPaymentMethodHandler.php
+++ b/src/Handlers/RatepayPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class RatepayPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class RatepayPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isOpenInvoice = true;
     

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -105,7 +105,8 @@ class ResultHandler
         SalesChannelContext $salesChannelContext
     ) {
         // Retrieve paymentResponse and if it exists
-        $paymentResponse = $this->paymentResponseService->getWithOrderTransaction($transaction->getOrderTransaction()->getId());
+        $paymentResponse = $this->paymentResponseService
+            ->getWithOrderTransaction($transaction->getOrderTransaction()->getId());
 
         if (!$paymentResponse) {
             throw new PaymentFailedException('Payment response not found.');

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -137,7 +137,8 @@ class ResultHandler
             // Validate the return
             $result = $this->paymentDetailsService->getPaymentDetails(
                 $requestData,
-                $transaction->getOrderTransaction()
+                $transaction->getOrder()->getSalesChannelId(),
+                $transaction->getOrderTransaction()->getId()
             );
         }
 

--- a/src/Handlers/ResultHandler.php
+++ b/src/Handlers/ResultHandler.php
@@ -105,7 +105,7 @@ class ResultHandler
         SalesChannelContext $salesChannelContext
     ) {
         // Retrieve paymentResponse and if it exists
-        $paymentResponse = $this->paymentResponseService->getWithOrderTransaction($transaction->getOrderTransaction());
+        $paymentResponse = $this->paymentResponseService->getWithOrderTransaction($transaction->getOrderTransaction()->getId());
 
         if (!$paymentResponse) {
             throw new PaymentFailedException('Payment response not found.');

--- a/src/Handlers/SVSGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/SVSGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class SVSGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/SVSGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/SVSGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class SVSGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class SVSGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/SVSGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/SVSGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class SVSGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/SepaPaymentMethodHandler.php
+++ b/src/Handlers/SepaPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class SepaPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class SepaPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'sepadirectdebit';

--- a/src/Handlers/SepaPaymentMethodHandler.php
+++ b/src/Handlers/SepaPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class SepaPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class SepaPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/SepaPaymentMethodHandler.php
+++ b/src/Handlers/SepaPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class SepaPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/SofortPaymentMethodHandler.php
+++ b/src/Handlers/SofortPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class SofortPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/SofortPaymentMethodHandler.php
+++ b/src/Handlers/SofortPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class SofortPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class SofortPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'directEbanking';

--- a/src/Handlers/SofortPaymentMethodHandler.php
+++ b/src/Handlers/SofortPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class SofortPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class SofortPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/SwishPaymentMethodHandler.php
+++ b/src/Handlers/SwishPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class SwishPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class SwishPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/SwishPaymentMethodHandler.php
+++ b/src/Handlers/SwishPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class SwishPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/SwishPaymentMethodHandler.php
+++ b/src/Handlers/SwishPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class SwishPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class SwishPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'swish';

--- a/src/Handlers/TCSTestGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/TCSTestGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class TCSTestGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class TCSTestGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/TCSTestGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/TCSTestGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class TCSTestGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/TCSTestGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/TCSTestGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class TCSTestGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/TrustlyPaymentMethodHandler.php
+++ b/src/Handlers/TrustlyPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class TrustlyPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/TrustlyPaymentMethodHandler.php
+++ b/src/Handlers/TrustlyPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class TrustlyPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class TrustlyPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/TrustlyPaymentMethodHandler.php
+++ b/src/Handlers/TrustlyPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class TrustlyPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class TrustlyPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'trustly';

--- a/src/Handlers/TwintPaymentMethodHandler.php
+++ b/src/Handlers/TwintPaymentMethodHandler.php
@@ -25,14 +25,8 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class TwintPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class TwintPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-
     public static function getPaymentMethodCode()
     {
         return 'twint';

--- a/src/Handlers/TwintPaymentMethodHandler.php
+++ b/src/Handlers/TwintPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class TwintPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/TwintPaymentMethodHandler.php
+++ b/src/Handlers/TwintPaymentMethodHandler.php
@@ -26,8 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
-class TwintPaymentMethodHandler extends AbstractPaymentMethodHandler implements AsynchronousPaymentHandlerInterface
+class TwintPaymentMethodHandler extends AbstractPaymentMethodHandler implements
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
 
     public static function getPaymentMethodCode()

--- a/src/Handlers/VVVGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/VVVGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class VVVGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class VVVGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/VVVGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/VVVGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class VVVGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/VVVGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/VVVGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class VVVGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/WebshopGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/WebshopGiftCardPaymentMethodHandler.php
@@ -25,12 +25,7 @@
 
 namespace Adyen\Shopware\Handlers;
 
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
-
-class WebshopGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface,
-    PreparedPaymentHandlerInterface
+class WebshopGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/WebshopGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/WebshopGiftCardPaymentMethodHandler.php
@@ -29,7 +29,8 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandle
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class WebshopGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface,
+    PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Handlers/WebshopGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/WebshopGiftCardPaymentMethodHandler.php
@@ -26,9 +26,10 @@
 namespace Adyen\Shopware\Handlers;
 
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PreparedPaymentHandlerInterface;
 
 class WebshopGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler implements
-    AsynchronousPaymentHandlerInterface
+    AsynchronousPaymentHandlerInterface, PreparedPaymentHandlerInterface
 {
     public static $isGiftCard = true;
 

--- a/src/Migration/Migration1653031120AdyenPaymentResponse.php
+++ b/src/Migration/Migration1653031120AdyenPaymentResponse.php
@@ -16,7 +16,7 @@ class Migration1653031120AdyenPaymentResponse extends MigrationStep
     {
         $connection->executeUpdate("
             alter table `adyen_payment_response`
-            add column psp_reference varchar(64) NULL after order_transaction_id;
+            add column payment_reference varchar(64) NULL after order_transaction_id;
         ");
     }
 

--- a/src/Migration/Migration1653031120AdyenPaymentResponse.php
+++ b/src/Migration/Migration1653031120AdyenPaymentResponse.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Adyen\Shopware\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1653031120AdyenPaymentResponse extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1653031120;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate("
+            alter table `adyen_payment_response`
+            add column psp_reference varchar(64) NULL after order_transaction_id;
+        ");
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // No destructive changes
+    }
+}

--- a/src/Resources/app/administration/src/component/adyen-payment-reference/adyen-payment-reference.html.twig
+++ b/src/Resources/app/administration/src/component/adyen-payment-reference/adyen-payment-reference.html.twig
@@ -1,0 +1,6 @@
+<sw-label v-if="refAvailable" size="medium" appearance="default">
+    Adyen Payment Reference:
+    <a target="_blank" :href="caLink">
+        {{ paymentReference }}
+    </a>
+</sw-label>

--- a/src/Resources/app/administration/src/component/adyen-payment-reference/index.js
+++ b/src/Resources/app/administration/src/component/adyen-payment-reference/index.js
@@ -1,0 +1,47 @@
+const { Component } = Shopware;
+import template from './adyen-payment-reference.html.twig';
+
+Component.register('adyen-payment-reference', {
+    template,
+
+    inject: ['adyenService'],
+
+    props: {
+        orderId: {
+            type: String,
+            required: true
+        }
+    },
+
+    mounted() {
+        this.getPaymentResponse();
+    },
+
+    data () {
+        return {
+            refAvailable: false,
+            paymentReference: null,
+            pspReference: null,
+            env: 'test'
+        }
+    },
+
+    computed: {
+        caLink() {
+            return 'https://ca-' + this.env + '.adyen.com/ca/ca/accounts/showTx.shtml?pspReference='
+                + this.pspReference;
+        }
+    },
+
+    methods: {
+        getPaymentResponse() {
+            this.adyenService.getPaymentDetails(this.orderId).then(res => {
+                this.paymentReference = res.paymentReference;
+                this.refAvailable = !!res.paymentReference;
+                this.pspReference = res.pspReference;
+                this.env = res.environment;
+            });
+
+        }
+    }
+})

--- a/src/Resources/app/administration/src/main.js
+++ b/src/Resources/app/administration/src/main.js
@@ -25,6 +25,8 @@ import './component/adyen-config-check-button';
 import './component/adyen-payment-capture';
 import './component/adyen-refund';
 import './component/adyen-notifications';
+import './component/adyen-payment-reference';
+import './sw-order-detail-override/index';
 import './sw-order-detail-base-override/index';
 import './component/entity/sw-entity-single-select-override';
 

--- a/src/Resources/app/administration/src/service/adyenService.js
+++ b/src/Resources/app/administration/src/service/adyenService.js
@@ -127,6 +127,21 @@ class ApiClient extends ApiService {
 
         return isAdyen;
     }
+
+    getPaymentDetails(orderId) {
+        const headers = this.getBasicHeaders({});
+
+        return this.httpClient
+            .get(this.getApiBasePath() + '/orders/' + orderId + '/payment-details', {
+                headers
+            })
+            .then((response) => {
+                return ApiService.handleResponse(response);
+            }).catch((error) => {
+                console.error('An error occurred: ' + error.message);
+                throw error;
+            });
+    }
 }
 
 Application.addServiceProvider('adyenService', (container) => {

--- a/src/Resources/app/administration/src/sw-order-detail-override/index.js
+++ b/src/Resources/app/administration/src/sw-order-detail-override/index.js
@@ -1,0 +1,5 @@
+import template from './sw-order-detail.html.twig';
+
+Shopware.Component.override('sw-order-detail', {
+    template
+})

--- a/src/Resources/app/administration/src/sw-order-detail-override/sw-order-detail.html.twig
+++ b/src/Resources/app/administration/src/sw-order-detail-override/sw-order-detail.html.twig
@@ -1,0 +1,7 @@
+{% block sw_order_detail_header_title %}
+    {% parent %}
+{% endblock %}
+{% block sw_order_detail_header_title_new %}
+    {% parent %}
+    <adyen-payment-reference :orderId="orderId"></adyen-payment-reference>
+{% endblock %}

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -141,4 +141,15 @@
             <label>Order Shipping State</label>
         </component>
     </card>
+    <card>
+        <title>Payment Flow</title>
+        <input-field type="bool">
+            <name>usePreparedPayment</name>
+            <label>Use Prepared Payment Flow</label>
+            <helpText>
+                This flow enables merchants with a custom checkout flow (e.g. headless integrations) to create a payment request before creating an order.
+                See https://github.com/shopware/platform/blob/trunk/adr/2021-10-01-payment-flow.md#accepting-pre-created-payments for more information.
+            </helpText>
+        </input-field>
+    </card>
 </config>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -66,6 +66,7 @@
             <argument type="service" id="Adyen\Shopware\Provider\AdyenPluginProvider"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentMethodsFilterService"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentRequestService"/>
             <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
             <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>

--- a/src/Resources/config/services/checkout-api.xml
+++ b/src/Resources/config/services/checkout-api.xml
@@ -58,11 +58,10 @@
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="Adyen\Util\Currency"/>
             <argument type="service" id="Adyen\Service\Builder\Customer"/>
-            <argument type="service" id="security.csrf.token_manager"/>
             <argument type="service" id="currency.repository"/>
             <argument type="service" id="product.repository"/>
+            <argument type="service" id="Adyen\Service\Builder\OpenInvoice"/>
             <argument type="service" id="Adyen\Service\Builder\Payment"/>
-            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
             <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
             <argument type="service" id="session"/>
         </service>

--- a/src/Resources/config/services/checkout-api.xml
+++ b/src/Resources/config/services/checkout-api.xml
@@ -37,8 +37,7 @@
         <service id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
         <service id="Adyen\Shopware\Service\PaymentResponseService" autowire="true">
             <argument type="service" id="adyen_payment_response.repository"/>
-            <argument type="service" id="order.repository"/>
-            <argument type="service" id="order_transaction.repository"/>
+            <argument type="service" id="Adyen\Shopware\Service\Repository\OrderTransactionRepository"/>
         </service>
         <service id="Adyen\Shopware\Service\PaymentStatusService" autowire="true">
             <argument type="service" id="Adyen\Shopware\Service\PaymentResponseService"/>

--- a/src/Resources/config/services/checkout-api.xml
+++ b/src/Resources/config/services/checkout-api.xml
@@ -51,6 +51,21 @@
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="cache.tags"/>
         </service>
+        <service id="Adyen\Shopware\Service\PaymentRequestService">
+            <argument type="service" id="Adyen\Service\Builder\Address"/>
+            <argument type="service" id="Adyen\Service\Builder\Browser"/>
+            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
+            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
+            <argument type="service" id="Adyen\Util\Currency"/>
+            <argument type="service" id="Adyen\Service\Builder\Customer"/>
+            <argument type="service" id="security.csrf.token_manager"/>
+            <argument type="service" id="currency.repository"/>
+            <argument type="service" id="product.repository"/>
+            <argument type="service" id="Adyen\Service\Builder\Payment"/>
+            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
+            <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
+            <argument type="service" id="session"/>
+        </service>
         <service id="Adyen\Shopware\Service\PaymentMethodsService" autowire="true">
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
         </service>

--- a/src/Resources/config/services/payment-handlers.xml
+++ b/src/Resources/config/services/payment-handlers.xml
@@ -28,6 +28,7 @@
     <services>
         <service id="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler" abstract="true">
             <argument type="service" id="Adyen\Shopware\Service\ClientService"/>
+            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
             <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
             <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>

--- a/src/Resources/config/services/payment-handlers.xml
+++ b/src/Resources/config/services/payment-handlers.xml
@@ -28,6 +28,8 @@
     <services>
         <service id="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler" abstract="true">
             <argument type="service" id="Adyen\Shopware\Service\ClientService"/>
+            <argument type="service" id="Adyen\Shopware\Service\CaptureService"/>
+            <argument type="service" id="Adyen\Util\Currency"/>
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
             <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
@@ -36,6 +38,7 @@
             <argument type="service"
                       id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandlerResult"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentResponseService"/>
             <argument type="service" id="security.csrf.token_manager"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentRequestService"/>

--- a/src/Resources/config/services/payment-handlers.xml
+++ b/src/Resources/config/services/payment-handlers.xml
@@ -27,27 +27,16 @@
         https://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler" abstract="true">
-            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="Adyen\Shopware\Service\ClientService"/>
-            <argument type="service" id="Adyen\Service\Builder\Browser"/>
-            <argument type="service" id="Adyen\Service\Builder\Address"/>
-            <argument type="service" id="Adyen\Service\Builder\Payment"/>
-            <argument type="service" id="Adyen\Service\Builder\OpenInvoice"/>
-            <argument type="service" id="Adyen\Util\Currency"/>
-            <argument type="service" id="Adyen\Service\Builder\Customer"/>
-            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
             <argument type="service" id="Adyen\Shopware\Service\Repository\SalesChannelRepository"/>
             <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
             <argument type="service" id="Adyen\Shopware\Handlers\ResultHandler"/>
             <argument type="service"
                       id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
-            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
-            <argument type="service" id="security.csrf.token_manager"/>
-            <argument type="service" id="session"/>
-            <argument type="service" id="currency.repository"/>
-            <argument type="service" id="product.repository"/>
-            <argument type="service" id="Adyen\Shopware\Service\PaymentMethodsService"/>
+            <argument type="service" id="Adyen\Service\Builder\OpenInvoice"/>
+            <argument type="service" id="Adyen\Util\Currency"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentRequestService"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
         </service>
         <service id="Adyen\Shopware\Handlers\CardsPaymentMethodHandler"

--- a/src/Resources/config/services/payment-handlers.xml
+++ b/src/Resources/config/services/payment-handlers.xml
@@ -36,6 +36,7 @@
             <argument type="service"
                       id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentResponseService"/>
             <argument type="service" id="security.csrf.token_manager"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentRequestService"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>

--- a/src/Resources/config/services/payment-handlers.xml
+++ b/src/Resources/config/services/payment-handlers.xml
@@ -34,8 +34,8 @@
             <argument type="service" id="Adyen\Shopware\Handlers\ResultHandler"/>
             <argument type="service"
                       id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
-            <argument type="service" id="Adyen\Service\Builder\OpenInvoice"/>
-            <argument type="service" id="Adyen\Util\Currency"/>
+            <argument type="service" id="Symfony\Component\Routing\RouterInterface"/>
+            <argument type="service" id="security.csrf.token_manager"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentRequestService"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_api"/>
         </service>

--- a/src/Resources/config/services/payment-handlers.xml
+++ b/src/Resources/config/services/payment-handlers.xml
@@ -53,186 +53,232 @@
         <service id="Adyen\Shopware\Handlers\CardsPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\IdealPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\KlarnaAccountPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\KlarnaPayNowPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\KlarnaPayLaterPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\RatepayPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\RatepayDirectdebitPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\SepaPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\SofortPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\PaypalPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\OneClickPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\GiroPayPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\ApplePayPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\GooglePayPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\DotpayPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\BancontactCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\AmazonPayPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\TwintPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\EpsPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\SwishPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\AlipayPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\AlipayHkPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\BlikPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\ClearpayPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\Facilypay3xPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\Facilypay4xPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\Facilypay6xPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\Facilypay10xPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\Facilypay12xPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\AfterpayDefaultPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\TrustlyPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\PaysafecardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\GivexGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\WebshopGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\KadowereldGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\TCSTestGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\AlbelliGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\BijenkorfGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\VVVGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\GenericGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\GallGallGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\HunkemollerLingerieGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\BeautyGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\SVSGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\FashionChequeGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
         <service id="Adyen\Shopware\Handlers\DeCadeaukaartGiftCardPaymentMethodHandler"
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
+            <tag name="shopware.payment.method.prepared"/>
         </service>
     </services>
 </container>

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -166,7 +166,7 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
             $logContext['orderId'] = $order->getId();
             $logContext['orderNumber'] = $order->getOrderNumber();
 
-            $orderTransaction = $this->orderTransactionRepository->getFirstAdyenOrderTransactionByStates(
+            $orderTransaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction(
                 $order->getId(),
                 self::WEBHOOK_TRANSACTION_STATES
             );

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -281,10 +281,10 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
                         'Attempting capture for open invoice payment.',
                         ['notification' => $notification->getVars()]
                     );
-                    $this->captureService->doOpenInvoiceCapture(
+                    $this->captureService->capture(
+                        $context,
                         $notification->getMerchantReference(),
-                        $notification->getAmountValue(),
-                        $context
+                        (int) $notification->getAmountValue()
                     );
                 } else {
                     $this->transactionStateHandler->paid($orderTransaction->getId(), $context);

--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -100,12 +100,12 @@ class CaptureService
     }
 
     /**
-     * Send capture request for open invoice payments
+     * Send capture request
      * @throws CaptureException
      */
-    public function doOpenInvoiceCapture(string $orderNumber, $captureAmount, Context $context)
+    public function capture(Context $context, string $orderNumber, int $captureAmount, bool $preparedPaymentFlow = false)
     {
-        if ($this->configurationService->isManualCaptureActive()) {
+        if ($preparedPaymentFlow || $this->configurationService->isManualCaptureActive()) {
             $this->logger->info('Capture for order_number ' . $orderNumber . ' start.');
             $order = $this->orderRepository->getOrderByOrderNumber(
                 $orderNumber,
@@ -144,7 +144,7 @@ class CaptureService
 
             $results = [];
             foreach ($deliveries as $delivery) {
-                if ($delivery->getStateMachineState()->getId() === $this->configurationService->getOrderState()) {
+                if ($preparedPaymentFlow || ($delivery->getStateMachineState()->getId() === $this->configurationService->getOrderState())) {
                     $lineItems = $order->getLineItems();
                     $lineItemsArray = $this->getLineItemsArray($lineItems, $order->getCurrency()->getIsoCode());
 

--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -103,7 +103,7 @@ class CaptureService
      * Send capture request
      * @throws CaptureException
      */
-    public function capture(Context $context, string $orderNumber, int $captureAmount, bool $preparedPaymentFlow = false)
+    public function capture(Context $context, string $orderNumber, int $amount, bool $preparedPaymentFlow = false)
     {
         if ($preparedPaymentFlow || $this->configurationService->isManualCaptureActive()) {
             $this->logger->info('Capture for order_number ' . $orderNumber . ' start.');
@@ -144,7 +144,10 @@ class CaptureService
 
             $results = [];
             foreach ($deliveries as $delivery) {
-                if ($preparedPaymentFlow || ($delivery->getStateMachineState()->getId() === $this->configurationService->getOrderState())) {
+                if (
+                    $preparedPaymentFlow ||
+                    ($delivery->getStateMachineState()->getId() === $this->configurationService->getOrderState())
+                ) {
                     $lineItems = $order->getLineItems();
                     $lineItemsArray = $this->getLineItemsArray($lineItems, $order->getCurrency()->getIsoCode());
 
@@ -155,7 +158,7 @@ class CaptureService
 
                     $request = $this->buildCaptureRequest(
                         $customFields[PaymentResponseHandler::ORIGINAL_PSP_REFERENCE],
-                        $captureAmount,
+                        $amount,
                         $currencyIso,
                         $additionalData
                     );
@@ -167,7 +170,7 @@ class CaptureService
                             $response['pspReference'],
                             PaymentCaptureEntity::SOURCE_SHOPWARE,
                             PaymentCaptureEntity::STATUS_PENDING_WEBHOOK,
-                            intval($captureAmount),
+                            intval($amount),
                             $context
                         );
                     }

--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -144,10 +144,8 @@ class CaptureService
 
             $results = [];
             foreach ($deliveries as $delivery) {
-                if (
-                    $preparedPaymentFlow ||
-                    ($delivery->getStateMachineState()->getId() === $this->configurationService->getOrderState())
-                ) {
+                if ($preparedPaymentFlow ||
+                    ($delivery->getStateMachineState()->getId() === $this->configurationService->getOrderState())) {
                     $lineItems = $order->getLineItems();
                     $lineItemsArray = $this->getLineItemsArray($lineItems, $order->getCurrency()->getIsoCode());
 

--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -119,7 +119,7 @@ class CaptureService
                 );
             }
             $orderTransaction = $this->orderTransactionRepository
-                ->getFirstAdyenOrderTransactionByStates($order->getId(), [OrderTransactionStates::STATE_AUTHORIZED]);
+                ->getFirstAdyenOrderTransaction($order->getId(), [OrderTransactionStates::STATE_AUTHORIZED]);
 
             if (!$orderTransaction) {
                 $error = 'Unable to find original authorized transaction.';

--- a/src/Service/ConfigurationService.php
+++ b/src/Service/ConfigurationService.php
@@ -222,4 +222,13 @@ class ConfigurationService
     {
         return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.orderState', $salesChannelId);
     }
+
+    /**
+     * @param string|null $salesChannelId
+     * @return array|bool|float|int|string|null
+     */
+    public function usesPreparedPaymentFlow(string $salesChannelId = null)
+    {
+        return $this->systemConfigService->get(self::BUNDLE_NAME . '.config.usePreparedPayment', $salesChannelId);
+    }
 }

--- a/src/Service/PaymentDetailsService.php
+++ b/src/Service/PaymentDetailsService.php
@@ -80,7 +80,7 @@ class PaymentDetailsService
                 $this->clientService->getClient($orderTransaction->getOrder()->getSalesChannelId())
             );
             $response = $checkoutService->paymentsDetails($requestData);
-            return $this->paymentResponseHandler->handlePaymentResponse($response, $orderTransaction);
+            return $this->paymentResponseHandler->handlePaymentResponse($response, $orderTransaction->getId());
         } catch (AdyenException $exception) {
             $this->logger->error($exception->getMessage());
             throw new PaymentFailedException($exception->getMessage());

--- a/src/Service/PaymentDetailsService.php
+++ b/src/Service/PaymentDetailsService.php
@@ -85,7 +85,8 @@ class PaymentDetailsService
                 $this->clientService->getClient($salesChannelId)
             );
             $response = $checkoutService->paymentsDetails($requestData);
-            return $this->paymentResponseHandler->handlePaymentResponse($response, $orderTransactionId, $paymentReference);
+            return $this->paymentResponseHandler
+                ->handlePaymentResponse($response, $orderTransactionId, $paymentReference);
         } catch (AdyenException $exception) {
             $this->logger->error($exception->getMessage());
             throw new PaymentFailedException($exception->getMessage());

--- a/src/Service/PaymentDetailsService.php
+++ b/src/Service/PaymentDetailsService.php
@@ -66,21 +66,26 @@ class PaymentDetailsService
 
     /**
      * @param array $requestData
-     * @param OrderTransactionEntity $orderTransaction
+     * @param string $salesChannelId
+     * @param string|null $orderTransactionId
+     * @param string|null $paymentReference
      * @return PaymentResponseHandlerResult
      * @throws PaymentFailedException
+     * @throws \Adyen\Shopware\Exception\ValidationException
      */
     public function getPaymentDetails(
         array $requestData,
-        OrderTransactionEntity $orderTransaction
+        string $salesChannelId,
+        string $orderTransactionId = null,
+        string $paymentReference = null
     ): PaymentResponseHandlerResult {
 
         try {
             $checkoutService = new CheckoutService(
-                $this->clientService->getClient($orderTransaction->getOrder()->getSalesChannelId())
+                $this->clientService->getClient($salesChannelId)
             );
             $response = $checkoutService->paymentsDetails($requestData);
-            return $this->paymentResponseHandler->handlePaymentResponse($response, $orderTransaction->getId());
+            return $this->paymentResponseHandler->handlePaymentResponse($response, $orderTransactionId, $paymentReference);
         } catch (AdyenException $exception) {
             $this->logger->error($exception->getMessage());
             throw new PaymentFailedException($exception->getMessage());

--- a/src/Service/PaymentMethodsService.php
+++ b/src/Service/PaymentMethodsService.php
@@ -120,37 +120,6 @@ class PaymentMethodsService
     }
 
     /**
-     * @param string $address
-     * @return array
-     */
-    public function getSplitStreetAddressHouseNumber(string $address): array
-    {
-        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/m';
-        $numberFirstRegex = '/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
-
-        preg_match($streetFirstRegex, $address, $streetFirstAddress);
-        preg_match($numberFirstRegex, $address, $numberFirstAddress);
-
-        if ($streetFirstAddress) {
-            return [
-                'street' => $streetFirstAddress['streetName'],
-                'houseNumber' => $streetFirstAddress['houseNumber']
-            ];
-        }
-        else if ($numberFirstAddress) {
-            return [
-                'street' => $numberFirstAddress['streetName'],
-                'houseNumber' => $numberFirstAddress['houseNumber']
-            ];
-        }
-
-        return [
-            'street' => $address,
-            'houseNumber' => 'N/A'
-        ];
-    }
-
-    /**
      * @param SalesChannelContext $context
      * @param string $orderId
      * @return array

--- a/src/Service/PaymentRequestService.php
+++ b/src/Service/PaymentRequestService.php
@@ -1,0 +1,416 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2022 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Service;
+
+use Adyen\AdyenException;
+use Adyen\Service\Builder\Address;
+use Adyen\Service\Builder\Browser;
+use Adyen\Service\Builder\Customer;
+use Adyen\Service\Builder\Payment;
+use Adyen\Service\Validator\CheckoutStateDataValidator;
+use Adyen\Shopware\Exception\CurrencyNotFoundException;
+use Adyen\Shopware\Handlers\AbstractPaymentMethodHandler;
+use Adyen\Shopware\Service\Repository\SalesChannelRepository;
+use Adyen\Shopware\Storefront\Controller\RedirectResultController;
+use Adyen\Util\Currency;
+use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\System\Currency\CurrencyCollection;
+use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class PaymentRequestService
+{
+    /**
+     * Error codes that are safe to display to the shopper.
+     * @see https://docs.adyen.com/development-resources/error-codes
+     */
+    const SAFE_ERROR_CODES = ['124'];
+    const PROMOTION = 'promotion';
+
+    private Session $session;
+    private EntityRepositoryInterface $currencyRepository;
+    private EntityRepositoryInterface $productRepository;
+    private Currency $currency;
+    private Browser $browserBuilder;
+    private Address $addressBuilder;
+    private Customer $customerBuilder;
+    private Payment $paymentBuilder;
+    private SalesChannelRepository $salesChannelRepository;
+    private ConfigurationService $configurationService;
+    private RouterInterface $router;
+    private CsrfTokenManagerInterface $csrfTokenManager;
+    private CheckoutStateDataValidator $checkoutStateDataValidator;
+
+    public function __construct(
+        Address $addressBuilder,
+        Browser $browserBuilder,
+        CheckoutStateDataValidator $checkoutStateDataValidator,
+        ConfigurationService $configurationService,
+        Currency $currency,
+        Customer $customerBuilder,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        EntityRepositoryInterface $currencyRepository,
+        EntityRepositoryInterface $productRepository,
+        Payment $paymentBuilder,
+        RouterInterface $router,
+        SalesChannelRepository $salesChannelRepository,
+        Session $session
+    ) {
+        $this->session = $session;
+        $this->currencyRepository = $currencyRepository;
+        $this->productRepository = $productRepository;
+        $this->browserBuilder = $browserBuilder;
+        $this->addressBuilder = $addressBuilder;
+        $this->customerBuilder = $customerBuilder;
+        $this->paymentBuilder = $paymentBuilder;
+        $this->currency = $currency;
+        $this->salesChannelRepository = $salesChannelRepository;
+        $this->configurationService = $configurationService;
+        $this->router = $router;
+        $this->csrfTokenManager = $csrfTokenManager;
+        $this->checkoutStateDataValidator = $checkoutStateDataValidator;
+    }
+
+    public function buildPaymentRequest(
+        array $request,
+        SalesChannelContext $salesChannelContext,
+        string $paymentMethodHandler,
+        float $totalPrice,
+        string $reference,
+        string $returnUrlQuery,
+        ?array $lineItems = null
+    ): array {
+        //Validate state.data for payment and build request object
+        $request = $this->checkoutStateDataValidator->getValidatedAdditionalData($request);
+
+        if (!empty($request['additionalData'])) {
+            $stateDataAdditionalData = $request['additionalData'];
+        }
+
+        /** @var AbstractPaymentMethodHandler $paymentMethodHandler */
+        if (empty($request['paymentMethod']['type'])) {
+            $paymentMethodType = $paymentMethodHandler::getPaymentMethodCode();
+        } else {
+            $paymentMethodType = $request['paymentMethod']['type'];
+        }
+
+        if ($paymentMethodHandler::$isGiftCard) {
+            $request['paymentMethod']['brand'] = $paymentMethodHandler::getBrand();
+        }
+
+        if (!empty($request['storePaymentMethod']) && $request['storePaymentMethod'] === true) {
+            $request['recurringProcessingModel'] = 'CardOnFile';
+            $request['shopperInteraction'] = 'Ecommerce';
+        }
+
+        //Setting browser info if not present in statedata
+        if (empty($request['browserInfo']['acceptHeader'])) {
+            $acceptHeader = $_SERVER['HTTP_ACCEPT'];
+        } else {
+            $acceptHeader = $request['browserInfo']['acceptHeader'];
+        }
+        if (empty($request['browserInfo']['userAgent'])) {
+            $userAgent = $_SERVER['HTTP_USER_AGENT'];
+        } else {
+            $userAgent = $request['browserInfo']['userAgent'];
+        }
+
+        //Setting delivery address info if not present in statedata
+        if (empty($request['deliveryAddress'])) {
+            if ($salesChannelContext->getShippingLocation()->getAddress()->getCountryState()) {
+                $shippingState = $salesChannelContext->getShippingLocation()
+                    ->getAddress()->getCountryState()->getShortCode();
+            } else {
+                $shippingState = '';
+            }
+
+            $shippingStreetAddress = $this->getSplitStreetAddressHouseNumber(
+                $salesChannelContext->getShippingLocation()->getAddress()->getStreet()
+            );
+            $request = $this->addressBuilder->buildDeliveryAddress(
+                $shippingStreetAddress['street'],
+                $shippingStreetAddress['houseNumber'],
+                $salesChannelContext->getShippingLocation()->getAddress()->getZipcode(),
+                $salesChannelContext->getShippingLocation()->getAddress()->getCity(),
+                $shippingState,
+                $salesChannelContext->getShippingLocation()->getAddress()->getCountry()->getIso(),
+                $request
+            );
+        }
+
+        //Setting billing address info if not present in statedata
+        if (empty($request['billingAddress'])) {
+            if ($salesChannelContext->getCustomer()->getActiveBillingAddress()->getCountryState()) {
+                $billingState = $salesChannelContext->getCustomer()
+                    ->getActiveBillingAddress()->getCountryState()->getShortCode();
+            } else {
+                $billingState = '';
+            }
+
+            $billingStreetAddress = $this->getSplitStreetAddressHouseNumber(
+                $salesChannelContext->getCustomer()->getActiveBillingAddress()->getStreet()
+            );
+            $request = $this->addressBuilder->buildBillingAddress(
+                $billingStreetAddress['street'],
+                $billingStreetAddress['houseNumber'],
+                $salesChannelContext->getCustomer()->getActiveBillingAddress()->getZipcode(),
+                $salesChannelContext->getCustomer()->getActiveBillingAddress()->getCity(),
+                $billingState,
+                $salesChannelContext->getCustomer()->getActiveBillingAddress()->getCountry()->getIso(),
+                $request
+            );
+        }
+
+        //Setting customer data if not present in statedata
+        if (empty($request['shopperName'])) {
+            $shopperFirstName = $salesChannelContext->getCustomer()->getFirstName();
+            $shopperLastName = $salesChannelContext->getCustomer()->getLastName();
+        } else {
+            $shopperFirstName = $request['shopperName']['firstName'];
+            $shopperLastName = $request['shopperName']['lastName'];
+        }
+
+        if (empty($request['shopperEmail'])) {
+            $shopperEmail = $salesChannelContext->getCustomer()->getEmail();
+        } else {
+            $shopperEmail = $request['shopperEmail'];
+        }
+
+        if (empty($request['paymentMethod']['personalDetails']['telephoneNumber'])) {
+            $shopperPhone = $salesChannelContext->getShippingLocation()->getAddress()->getPhoneNumber();
+        } else {
+            $shopperPhone = $request['paymentMethod']['personalDetails']['telephoneNumber'];
+        }
+
+        if (empty($request['paymentMethod']['personalDetails']['dateOfBirth'])) {
+            if ($salesChannelContext->getCustomer()->getBirthday()) {
+                $shopperDob = $salesChannelContext->getCustomer()->getBirthday()->format('Y-m-d');
+            } else {
+                $shopperDob = '';
+            }
+        } else {
+            $shopperDob = $request['paymentMethod']['personalDetails']['dateOfBirth'];
+        }
+
+        if (empty($request['shopperLocale'])) {
+            $shopperLocale = $this->salesChannelRepository->getSalesChannelAssocLocale($salesChannelContext)
+                ->getLanguage()->getLocale()->getCode();
+        } else {
+            $shopperLocale = $request['shopperLocale'];
+        }
+
+        if (empty($request['shopperIP'])) {
+            $shopperIp = $salesChannelContext->getCustomer()->getRemoteAddress();
+        } else {
+            $shopperIp = $request['shopperIP'];
+        }
+
+        if (empty($request['shopperReference'])) {
+            $shopperReference = $salesChannelContext->getCustomer()->getId();
+        } else {
+            $shopperReference = $request['shopperReference'];
+        }
+
+        if (empty($request['countryCode'])) {
+            $countryCode = $salesChannelContext->getCustomer()->getActiveBillingAddress()->getCountry()->getIso();
+        } else {
+            $countryCode = $request['countryCode'];
+        }
+
+        $request = $this->browserBuilder->buildBrowserData(
+            $userAgent,
+            $acceptHeader,
+            isset($request['browserInfo']['screenWidth']) ? $request['browserInfo']['screenWidth'] : null,
+            isset($request['browserInfo']['screenHeight']) ? $request['browserInfo']['screenHeight'] : null,
+            isset($request['browserInfo']['colorDepth']) ? $request['browserInfo']['colorDepth'] : null,
+            isset($request['browserInfo']['timeZoneOffset']) ? $request['browserInfo']['timeZoneOffset'] : null,
+            isset($request['browserInfo']['language']) ? $request['browserInfo']['language'] : null,
+            isset($request['browserInfo']['javaEnabled']) ? $request['browserInfo']['javaEnabled'] : null,
+            $request
+        );
+
+        $request = $this->customerBuilder->buildCustomerData(
+            false,
+            $shopperEmail,
+            $shopperPhone,
+            '',
+            $shopperDob,
+            $shopperFirstName,
+            $shopperLastName,
+            $countryCode,
+            $shopperLocale,
+            $shopperIp,
+            $shopperReference,
+            $request
+        );
+
+        //Building payment data
+        $request = $this->paymentBuilder->buildPaymentData(
+            $salesChannelContext->getCurrency()->getIsoCode(),
+            $this->currency->sanitize(
+                $totalPrice,
+                $salesChannelContext->getCurrency()->getIsoCode()
+            ),
+            $reference,
+            $this->configurationService->getMerchantAccount($salesChannelContext->getSalesChannel()->getId()),
+            $this->getAdyenReturnUrl($returnUrlQuery),
+            $request
+        );
+
+        $request = $this->paymentBuilder->buildAlternativePaymentMethodData(
+            $paymentMethodType,
+            '',
+            $request
+        );
+
+        if ($paymentMethodHandler::$isOpenInvoice) {
+            $request['lineItems'] = $lineItems;
+        }
+
+        //Setting info from statedata additionalData if present
+        if (!empty($stateDataAdditionalData['origin'])) {
+            $request['origin'] = $stateDataAdditionalData['origin'];
+        } else {
+            $request['origin'] = $this->salesChannelRepository->getSalesChannelUrl($salesChannelContext);
+        }
+
+        $request['additionalData']['allow3DS2'] = true;
+
+        $request['channel'] = 'web';
+
+        return $request;
+    }
+
+    /**
+     * Creates the Adyen Redirect Result URL with the same query as the original return URL
+     * Fixes the CSRF validation bug: https://issues.shopware.com/issues/NEXT-6356
+     *
+     * @param string $returnUrlQuery
+     * @return string
+     */
+    public function getAdyenReturnUrl(string $returnUrlQuery): string
+    {
+        // Generate the custom Adyen endpoint to receive the redirect from the issuer page
+        $adyenReturnUrl = $this->router->generate(
+            'payment.adyen.redirect_result',
+            [
+                RedirectResultController::CSRF_TOKEN => $this->csrfTokenManager->getToken(
+                    'payment.finalize.transaction'
+                )->getValue()
+            ],
+            RouterInterface::ABSOLUTE_URL
+        );
+
+        // Create the adyen redirect result URL with the same query as the original return URL
+        return $adyenReturnUrl . '&' . $returnUrlQuery;
+    }
+
+    /**
+     * @param string $address
+     * @return array
+     */
+    public function getSplitStreetAddressHouseNumber(string $address): array
+    {
+        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/m';
+        $numberFirstRegex = '/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
+
+        preg_match($streetFirstRegex, $address, $streetFirstAddress);
+        preg_match($numberFirstRegex, $address, $numberFirstAddress);
+
+        if ($streetFirstAddress) {
+            return [
+                'street' => $streetFirstAddress['streetName'],
+                'houseNumber' => $streetFirstAddress['houseNumber']
+            ];
+        }
+        else if ($numberFirstAddress) {
+            return [
+                'street' => $numberFirstAddress['streetName'],
+                'houseNumber' => $numberFirstAddress['houseNumber']
+            ];
+        }
+
+        return [
+            'street' => $address,
+            'houseNumber' => 'N/A'
+        ];
+    }
+
+    /**
+     * @param string $currencyId
+     * @param Context $context
+     * @return CurrencyEntity
+     */
+    public function getCurrency(string $currencyId, Context $context): CurrencyEntity
+    {
+        $criteria = new Criteria([$currencyId]);
+
+        /** @var CurrencyCollection $currencyCollection */
+        $currencyCollection = $this->currencyRepository->search($criteria, $context);
+
+        $currency = $currencyCollection->get($currencyId);
+        if ($currency === null) {
+            throw new CurrencyNotFoundException($currencyId);
+        }
+
+        return $currency;
+    }
+
+    /**
+     * @param string $productId
+     * @param Context $context
+     * @return ProductEntity
+     */
+    public function getProduct(string $productId, Context $context): ProductEntity
+    {
+        $criteria = new Criteria([$productId]);
+
+        /** @var ProductCollection $productCollection */
+        $productCollection = $this->productRepository->search($criteria, $context);
+
+        $product = $productCollection->get($productId);
+        if ($product === null) {
+            throw new ProductNotFoundException($productId);
+        }
+
+        return $product;
+    }
+
+    public function displaySafeErrorMessages(AdyenException $exception)
+    {
+        if ('validation' === $exception->getErrorType()
+            && in_array($exception->getAdyenErrorCode(), self::SAFE_ERROR_CODES)) {
+            $this->session->getFlashBag()->add('warning', $exception->getMessage());
+        }
+    }
+}

--- a/src/Service/PaymentRequestService.php
+++ b/src/Service/PaymentRequestService.php
@@ -392,8 +392,7 @@ class PaymentRequestService
                 'street' => $streetFirstAddress['streetName'],
                 'houseNumber' => $streetFirstAddress['houseNumber']
             ];
-        }
-        else if ($numberFirstAddress) {
+        } elseif ($numberFirstAddress) {
             return [
                 'street' => $numberFirstAddress['streetName'],
                 'houseNumber' => $numberFirstAddress['houseNumber']

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -24,7 +24,7 @@
 namespace Adyen\Shopware\Service;
 
 use Adyen\Shopware\Entity\PaymentResponse\PaymentResponseEntity;
-use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Adyen\Shopware\Handlers\PaymentResponseHandler;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -106,15 +106,21 @@ class PaymentResponseService
     }
 
     public function insertPaymentResponse(
-        array $paymentResponse,
-        string $orderTransactionId
+        array  $paymentResponse,
+        string $value,
+        string $identifier
     ): void {
-        $storedPaymentResponse = $this->getWithOrderTransaction($orderTransactionId);
+        if ($identifier === PaymentResponseHandler::ORDER_TRANSACTION_ID) {
+            $storedPaymentResponse = $this->getWithOrderTransaction($value);
+        } else {
+            $storedPaymentResponse = $this->getWithPspReference($value);
+        }
+
         if ($storedPaymentResponse) {
             $fields['id'] = $storedPaymentResponse->getId();
         }
 
-        $fields['orderTransactionId'] = $orderTransactionId;
+        $fields[$identifier] = $value;
         $fields['resultCode'] = $paymentResponse["resultCode"];
         $fields['response'] = json_encode($paymentResponse);
 

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -95,7 +95,7 @@ class PaymentResponseService
             ->first();
     }
 
-    public function getWithPaymentReference(string $paymentReference)
+    public function getWithPaymentReference(string $paymentReference): ?PaymentResponseEntity
     {
         return $this->repository
             ->search(

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -80,31 +80,41 @@ class PaymentResponseService
                 Context::createDefaultContext()
             )
             ->first();
-        return $this->getWithOrderTransaction($orderTransaction);
+        return $this->getWithOrderTransaction($orderTransaction->getId());
     }
 
-    public function getWithOrderTransaction(OrderTransactionEntity $orderTransaction): ?PaymentResponseEntity
+    public function getWithOrderTransaction(string $orderTransactionId): ?PaymentResponseEntity
     {
         return $this->repository
             ->search(
                 (new Criteria())
-                    ->addFilter(new EqualsFilter('orderTransactionId', $orderTransaction->getId()))
+                    ->addFilter(new EqualsFilter('orderTransactionId', $orderTransactionId))
                     ->addAssociation('orderTransaction.order'),
                 Context::createDefaultContext()
             )
             ->first();
     }
 
+    public function getWithPspReference(string $pspReference)
+    {
+        return $this->repository
+            ->search(
+                (new Criteria())
+                ->addFilter(new EqualsFilter('pspReference', $pspReference)),
+                Context::createDefaultContext()
+            )->first();
+    }
+
     public function insertPaymentResponse(
         array $paymentResponse,
-        OrderTransactionEntity $orderTransaction
+        string $orderTransactionId
     ): void {
-        $storedPaymentResponse = $this->getWithOrderTransaction($orderTransaction);
+        $storedPaymentResponse = $this->getWithOrderTransaction($orderTransactionId);
         if ($storedPaymentResponse) {
             $fields['id'] = $storedPaymentResponse->getId();
         }
 
-        $fields['orderTransactionId'] = $orderTransaction->getId();
+        $fields['orderTransactionId'] = $orderTransactionId;
         $fields['resultCode'] = $paymentResponse["resultCode"];
         $fields['response'] = json_encode($paymentResponse);
 

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -95,12 +95,12 @@ class PaymentResponseService
             ->first();
     }
 
-    public function getWithPspReference(string $pspReference)
+    public function getWithPaymentReference(string $paymentReference)
     {
         return $this->repository
             ->search(
                 (new Criteria())
-                ->addFilter(new EqualsFilter('pspReference', $pspReference)),
+                ->addFilter(new EqualsFilter('paymentReference', $paymentReference)),
                 Context::createDefaultContext()
             )->first();
     }
@@ -113,7 +113,7 @@ class PaymentResponseService
         if ($identifier === PaymentResponseHandler::ORDER_TRANSACTION_ID) {
             $storedPaymentResponse = $this->getWithOrderTransaction($value);
         } else {
-            $storedPaymentResponse = $this->getWithPspReference($value);
+            $storedPaymentResponse = $this->getWithPaymentReference($value);
         }
 
         if ($storedPaymentResponse) {

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -25,11 +25,11 @@ namespace Adyen\Shopware\Service;
 
 use Adyen\Shopware\Entity\PaymentResponse\PaymentResponseEntity;
 use Adyen\Shopware\Handlers\PaymentResponseHandler;
+use Adyen\Shopware\Service\Repository\OrderTransactionRepository;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 
 class PaymentResponseService
 {
@@ -39,22 +39,15 @@ class PaymentResponseService
     private $repository;
 
     /**
-     * @var EntityRepositoryInterface
-     */
-    private $orderRepository;
-
-    /**
-     * @var EntityRepositoryInterface
+     * @var OrderTransactionRepository
      */
     private $orderTransactionRepository;
 
     public function __construct(
         EntityRepositoryInterface $repository,
-        EntityRepositoryInterface $orderRepository,
-        EntityRepositoryInterface $orderTransactionRepository
+        OrderTransactionRepository $orderTransactionRepository
     ) {
         $this->repository = $repository;
-        $this->orderRepository = $orderRepository;
         $this->orderTransactionRepository = $orderTransactionRepository;
     }
 
@@ -72,14 +65,7 @@ class PaymentResponseService
     public function getWithOrderId(string $orderId): ?PaymentResponseEntity
     {
         $orderTransaction = $this->orderTransactionRepository
-            ->search(
-                (new Criteria())
-                    ->addFilter((new EqualsFilter('orderId', $orderId)))
-                    ->addAssociation('order')
-                ->addSorting(new FieldSorting('createdAt', FieldSorting::DESCENDING)),
-                Context::createDefaultContext()
-            )
-            ->first();
+            ->getFirstAdyenOrderTransaction($orderId);
         return $this->getWithOrderTransaction($orderTransaction->getId());
     }
 

--- a/src/Service/PaymentStatusService.php
+++ b/src/Service/PaymentStatusService.php
@@ -91,7 +91,7 @@ class PaymentStatusService
         if (empty($paymentResponse)) {
             throw new MissingDataException(
                 'Payment response cannot be found for payment: ' .
-                $paymentReference . '!'
+                $paymentReference
             );
         }
 
@@ -100,7 +100,7 @@ class PaymentStatusService
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new JsonException(
                 'Payment response is an invalid JSON for payment: ' .
-                $paymentReference . '!'
+                $paymentReference
             );
         }
 

--- a/src/Service/PaymentStatusService.php
+++ b/src/Service/PaymentStatusService.php
@@ -50,6 +50,7 @@ class PaymentStatusService
     }
 
     /**
+     * @deprecated
      * @param OrderTransactionEntity $orderTransaction
      * @return array
      * @throws MissingDataException
@@ -57,7 +58,7 @@ class PaymentStatusService
      */
     public function getPaymentStatusWithOrderTransaction(OrderTransactionEntity $orderTransaction): array
     {
-        $paymentResponse = $this->paymentResponseService->getWithOrderTransaction($orderTransaction);
+        $paymentResponse = $this->paymentResponseService->getWithOrderTransaction($orderTransaction->getId());
 
         if (empty($paymentResponse)) {
             throw new MissingDataException(
@@ -77,7 +78,7 @@ class PaymentStatusService
 
         $result = $this->paymentResponseHandler->handlePaymentResponse(
             $responseData,
-            $orderTransaction
+            $orderTransaction->getId()
         );
 
         return $this->paymentResponseHandler->handleAdyenApis($result);
@@ -104,7 +105,7 @@ class PaymentStatusService
 
         $result = $this->paymentResponseHandler->handlePaymentResponse(
             $responseData,
-            $paymentResponse->getOrderTransaction()
+            $paymentResponse->getOrderTransaction()->getId()
         );
 
         return $this->paymentResponseHandler->handleAdyenApis($result);

--- a/src/Service/PaymentStatusService.php
+++ b/src/Service/PaymentStatusService.php
@@ -84,6 +84,35 @@ class PaymentStatusService
         return $this->paymentResponseHandler->handleAdyenApis($result);
     }
 
+    public function getWithPaymentReference(string $paymentReference): array
+    {
+        $paymentResponse = $this->paymentResponseService->getWithPaymentReference($paymentReference);
+
+        if (empty($paymentResponse)) {
+            throw new MissingDataException(
+                'Payment response cannot be found for payment: ' .
+                $paymentReference . '!'
+            );
+        }
+
+        $responseData = json_decode($paymentResponse->getResponse(), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new JsonException(
+                'Payment response is an invalid JSON for payment: ' .
+                $paymentReference . '!'
+            );
+        }
+
+        $result = $this->paymentResponseHandler->handlePaymentResponse(
+            $responseData,
+            null,
+            $paymentReference
+        );
+
+        return $this->paymentResponseHandler->handleAdyenApis($result);
+    }
+
     public function getWithOrderId(string $orderId): array
     {
         $paymentResponse = $this->paymentResponseService->getWithOrderId($orderId);

--- a/src/Service/RefundService.php
+++ b/src/Service/RefundService.php
@@ -304,7 +304,7 @@ class RefundService
      */
     public function getAdyenOrderTransactionForRefund(OrderEntity $order, array $states): OrderTransactionEntity
     {
-        $orderTransaction = $this->transactionRepository->getFirstAdyenOrderTransactionByStates(
+        $orderTransaction = $this->transactionRepository->getFirstAdyenOrderTransaction(
             $order->getId(),
             $states
         );

--- a/src/Service/Repository/OrderTransactionRepository.php
+++ b/src/Service/Repository/OrderTransactionRepository.php
@@ -55,12 +55,12 @@ class OrderTransactionRepository
 
     /**
      * @param string $orderId
-     * @param array $states
+     * @param array $statesFilter
      * @return OrderTransactionEntity|null
      */
-    public function getFirstAdyenOrderTransactionByStates(
+    public function getFirstAdyenOrderTransaction(
         string $orderId,
-        array $states
+        array $statesFilter = []
     ): ?OrderTransactionEntity {
         $criteria = new Criteria();
         $criteria->addAssociation('stateMachineState');
@@ -69,9 +69,11 @@ class OrderTransactionRepository
         $criteria->addAssociation('paymentMethod');
         $criteria->addAssociation('paymentMethod.plugin');
         $criteria->addFilter(new EqualsFilter('order.id', $orderId));
-        $criteria->addFilter(
-            new EqualsAnyFilter('stateMachineState.technicalName', $states)
-        );
+        if (!empty($statesFilter)) {
+            $criteria->addFilter(
+                new EqualsAnyFilter('stateMachineState.technicalName', $statesFilter)
+            );
+        }
         $criteria->addFilter(
             new EqualsFilter('paymentMethod.plugin.name', ConfigurationService::BUNDLE_NAME)
         );

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -345,8 +345,12 @@ class PaymentSubscriber implements EventSubscriberInterface
                     'selectedPaymentMethodHandler' => $paymentMethod->getFormattedHandlerIdentifier(),
                     'selectedPaymentMethodPluginId' => $paymentMethod->getPluginId(),
                     'displaySaveCreditCardOption' => $displaySaveCreditCardOption,
-                    'billingAddressStreetHouse' => $this->paymentRequestService->getSplitStreetAddressHouseNumber($salesChannelContext->getCustomer()->getActiveBillingAddress()->getStreet()),
-                    'shippingAddressStreetHouse' => $this->paymentRequestService->getSplitStreetAddressHouseNumber($salesChannelContext->getCustomer()->getActiveShippingAddress()->getStreet()),
+                    'billingAddressStreetHouse' => $this->paymentRequestService->getSplitStreetAddressHouseNumber(
+                        $salesChannelContext->getCustomer()->getActiveBillingAddress()->getStreet()
+                    ),
+                    'shippingAddressStreetHouse' => $this->paymentRequestService->getSplitStreetAddressHouseNumber(
+                        $salesChannelContext->getCustomer()->getActiveShippingAddress()->getStreet()
+                    ),
                 ]
             )
         );

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -30,6 +30,7 @@ use Adyen\Shopware\Provider\AdyenPluginProvider;
 use Adyen\Shopware\Service\ConfigurationService;
 use Adyen\Shopware\Service\PaymentMethodsFilterService;
 use Adyen\Shopware\Service\PaymentMethodsService;
+use Adyen\Shopware\Service\PaymentRequestService;
 use Adyen\Shopware\Service\PaymentStateDataService;
 use Adyen\Shopware\Service\Repository\SalesChannelRepository;
 use Adyen\Util\Currency;
@@ -143,6 +144,7 @@ class PaymentSubscriber implements EventSubscriberInterface
      * @var AbstractSalesChannelContextFactory
      */
     private $salesChannelContextFactory;
+    private PaymentRequestService $paymentRequestService;
 
     /**
      * PaymentSubscriber constructor.
@@ -168,6 +170,7 @@ class PaymentSubscriber implements EventSubscriberInterface
         AdyenPluginProvider $adyenPluginProvider,
         PaymentMethodsFilterService $paymentMethodsFilterService,
         PaymentStateDataService $paymentStateDataService,
+        PaymentRequestService $paymentRequestService,
         RouterInterface $router,
         SalesChannelRepository $salesChannelRepository,
         ConfigurationService $configurationService,
@@ -198,6 +201,7 @@ class PaymentSubscriber implements EventSubscriberInterface
         $this->currency = $currency;
         $this->logger = $logger;
         $this->adyenPluginProvider = $adyenPluginProvider;
+        $this->paymentRequestService = $paymentRequestService;
     }
 
     /**
@@ -218,6 +222,7 @@ class PaymentSubscriber implements EventSubscriberInterface
      */
     public function onContextTokenUpdate(SalesChannelContextSwitchEvent $event)
     {
+        xdebug_break();
         // Clear state.data if payment method is updated
         if ($event->getRequestDataBag()->has('paymentMethodId')) {
             $this->removeCurrentStateData($event);
@@ -341,8 +346,8 @@ class PaymentSubscriber implements EventSubscriberInterface
                     'selectedPaymentMethodHandler' => $paymentMethod->getFormattedHandlerIdentifier(),
                     'selectedPaymentMethodPluginId' => $paymentMethod->getPluginId(),
                     'displaySaveCreditCardOption' => $displaySaveCreditCardOption,
-                    'billingAddressStreetHouse' => $this->paymentMethodsService->getSplitStreetAddressHouseNumber($salesChannelContext->getCustomer()->getActiveBillingAddress()->getStreet()),
-                    'shippingAddressStreetHouse' => $this->paymentMethodsService->getSplitStreetAddressHouseNumber($salesChannelContext->getCustomer()->getActiveShippingAddress()->getStreet()),
+                    'billingAddressStreetHouse' => $this->paymentRequestService->getSplitStreetAddressHouseNumber($salesChannelContext->getCustomer()->getActiveBillingAddress()->getStreet()),
+                    'shippingAddressStreetHouse' => $this->paymentRequestService->getSplitStreetAddressHouseNumber($salesChannelContext->getCustomer()->getActiveShippingAddress()->getStreet()),
                 ]
             )
         );

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -222,7 +222,6 @@ class PaymentSubscriber implements EventSubscriberInterface
      */
     public function onContextTokenUpdate(SalesChannelContextSwitchEvent $event)
     {
-        xdebug_break();
         // Clear state.data if payment method is updated
         if ($event->getRequestDataBag()->has('paymentMethodId')) {
             $this->removeCurrentStateData($event);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
1. Create new store-api endpoint for making `/payments` requests. Also create paymentDetails and paymentStatus endpoints for prepared payments
    - Reuse logic currently in `AbstractPaymentMethodHandler`
    - Generate unique reference for payment method request
    - Return pspReference and payment reference to the frontend to be sent in `createOrder` request
2. Update existing payment method handlers (only for those that support manual capture) to additionally implement [PreparedPaymentHandlerInterface](https://github.com/shopware/platform/blob/b47b01cab41f1f6d18262289140a7122ca1e70dc/src/Core/Checkout/Payment/Cart/PaymentHandler/PreparedPaymentHandlerInterface.php) and add the tag `<tag name="shopware.payment.method.prepared"/>` in `payment-methods.xml`

3. Create config option for merchants to choose between prepared/async flow
4. If prepared flow is selected in config, implement `validate` function of the handler
    -  Use `/payment/details` call to make sure payment is Authorized otherwise throw exception.
5.  If prepared flow is selected in config, implement `capture` function of the handler
    - do capture request and update order transaction
    - store payment reference in order transaction customFields
6. If async flow is selected then return early from `validate` and `capture` methods, and if prepared flow is selected then return early from `pay` and `finalize` methods.
6. Update all logic that relies on the merchant reference being the order number to instead fetch order by payment reference.
7. Display payment reference in order detail page and link to the payment in CA
![Screen Shot 2022-06-07 at 9 46 27 AM](https://user-images.githubusercontent.com/5240725/172325578-c3a5ce70-df55-4615-aea3-a50886045def.png)



## Tested scenarios
<!-- Description of tested scenarios -->
- Completed order using the payment flow for CC and CC 3DS2

**Fixed issue**:  <!-- #-prefixed issue number -->
