### PR TITLE
[PW-6820] - Prevent PayPal cancellation block the payment method change on checkout

### DIFF
--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -471,7 +471,8 @@ class StoreApiController
 
         $context->scope(
             Context::SYSTEM_SCOPE,
-            function () use ($order, $initialState, $orderId, $paymentMethodId, $context): void {if ($order->getTransactions() !== null && $order->getTransactions()->count() >= 1) {
+            function () use ($order, $initialState, $orderId, $paymentMethodId, $context): void {
+                if ($order->getTransactions() !== null && $order->getTransactions()->count() >= 1) {
                     foreach ($order->getTransactions() as $transaction) {
                         if ($transaction->getStateMachineState()->getTechnicalName()
                             !== OrderTransactionStates::STATE_CANCELLED) {
@@ -483,7 +484,7 @@ class StoreApiController
                             );
                         }
                     }
-                }
+            }
                 $transactionAmount = new CalculatedPrice(
                     $order->getPrice()->getTotalPrice(),
                     $order->getPrice()->getTotalPrice(),

--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -484,7 +484,7 @@ class StoreApiController
                             );
                         }
                     }
-            }
+                }
                 $transactionAmount = new CalculatedPrice(
                     $order->getPrice()->getTotalPrice(),
                     $order->getPrice()->getTotalPrice(),

--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -44,6 +44,7 @@ use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartCalculator;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
@@ -53,6 +54,7 @@ use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\StateMachine\StateMachineRegistry;
+use Shopware\Core\System\StateMachine\Transition;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -260,7 +262,6 @@ class StoreApiController
         Request $request,
         SalesChannelContext $context
     ): JsonResponse {
-
         $orderId = $request->request->get('orderId');
         $paymentResponse = $this->paymentResponseService->getWithOrderId($orderId);
         if (!$paymentResponse) {
@@ -470,8 +471,7 @@ class StoreApiController
 
         $context->scope(
             Context::SYSTEM_SCOPE,
-            function () use ($order, $initialState, $orderId, $paymentMethodId, $context): void {
-                if ($order->getTransactions() !== null && $order->getTransactions()->count() >= 1) {
+            function () use ($order, $initialState, $orderId, $paymentMethodId, $context): void {if ($order->getTransactions() !== null && $order->getTransactions()->count() >= 1) {
                     foreach ($order->getTransactions() as $transaction) {
                         if ($transaction->getStateMachineState()->getTechnicalName()
                             !== OrderTransactionStates::STATE_CANCELLED) {
@@ -503,5 +503,34 @@ class StoreApiController
                 ], $context);
             }
         );
+    }
+
+    /**
+     * @Route(
+     *     "/store-api/adyen/cancel-order-transaction",
+     *     name="store-api.action.adyen.cancel-order-transaction",
+     *     methods={"POST"}
+     * )
+     *
+     * @param Request $request
+     * @param SalesChannelContext $context
+     * @return JsonResponse
+     */
+    public function cancelOrderTransaction(
+        Request $request,
+        SalesChannelContext $salesChannelContext
+    ): JsonResponse {
+        $context = $salesChannelContext->getContext();
+        $orderId = $request->get('orderId');
+        $order = $this->orderRepository->getOrder($orderId, $context, ['transactions']);
+
+        $transaction = $order->getTransactions()->last();
+        $latestState = $order->getStateMachineState()->getTechnicalName();
+
+        if ($latestState === OrderTransactionStates::STATE_OPEN || $latestState === OrderTransactionStates::STATE_IN_PROGRESS)  {
+            $this->stateMachineRegistry->transition(new Transition(OrderTransactionDefinition::ENTITY_NAME, $transaction->getId(), 'cancel', 'stateId'), $context);
+        }
+
+        return new JsonResponse($this->paymentStatusService->getWithOrderId($orderId));
     }
 }

--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -527,10 +527,8 @@ class StoreApiController
         $transaction = $order->getTransactions()->last();
         $latestState = $order->getStateMachineState()->getTechnicalName();
 
-        if (
-            $latestState === OrderTransactionStates::STATE_OPEN ||
-            $latestState === OrderTransactionStates::STATE_IN_PROGRESS)
-        {
+        if ($latestState === OrderTransactionStates::STATE_OPEN ||
+            $latestState === OrderTransactionStates::STATE_IN_PROGRESS) {
             $this->stateMachineRegistry->transition(
                 new Transition(OrderTransactionDefinition::ENTITY_NAME, $transaction->getId(), 'cancel', 'stateId'),
                 $context

--- a/src/Controller/StoreApiController.php
+++ b/src/Controller/StoreApiController.php
@@ -527,8 +527,14 @@ class StoreApiController
         $transaction = $order->getTransactions()->last();
         $latestState = $order->getStateMachineState()->getTechnicalName();
 
-        if ($latestState === OrderTransactionStates::STATE_OPEN || $latestState === OrderTransactionStates::STATE_IN_PROGRESS)  {
-            $this->stateMachineRegistry->transition(new Transition(OrderTransactionDefinition::ENTITY_NAME, $transaction->getId(), 'cancel', 'stateId'), $context);
+        if (
+            $latestState === OrderTransactionStates::STATE_OPEN ||
+            $latestState === OrderTransactionStates::STATE_IN_PROGRESS)
+        {
+            $this->stateMachineRegistry->transition(
+                new Transition(OrderTransactionDefinition::ENTITY_NAME, $transaction->getId(), 'cancel', 'stateId'),
+                $context
+            );
         }
 
         return new JsonResponse($this->paymentStatusService->getWithOrderId($orderId));

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -333,6 +333,14 @@ export default class ConfirmOrderPlugin extends Plugin {
                 componentConfig.onCancel(data, component, this);
             },
             onError: (error, component) => {
+                if (component.props.name === 'PayPal' && error.name === 'CANCEL') {
+                    debugger;
+                    this._client.post(
+                        `${adyenCheckoutOptions.cancelOrderTransactionUrl}`,
+                        JSON.stringify({orderId: this.orderId})
+                    );
+                }
+
                 ElementLoadingIndicatorUtil.remove(document.body);
                 componentConfig.onError(error, component, this);
                 console.log(error);

--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -334,7 +334,6 @@ export default class ConfirmOrderPlugin extends Plugin {
             },
             onError: (error, component) => {
                 if (component.props.name === 'PayPal' && error.name === 'CANCEL') {
-                    debugger;
                     this._client.post(
                         `${adyenCheckoutOptions.cancelOrderTransactionUrl}`,
                         JSON.stringify({orderId: this.orderId})

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -43,6 +43,7 @@
              data-payment-finish-url="{{ adyenFrontendData.paymentFinishUrl }}"
              data-payment-error-url="{{ adyenFrontendData.paymentErrorUrl }}"
              data-update-payment-url="{{ adyenFrontendData.updatePaymentUrl }}"
+             data-cancel-order-transaction-url="{{ adyenFrontendData.cancelOrderTransactionUrl }}"
              data-order-id="{{ adyenFrontendData.orderId }}"
              data-currency="{{ adyenFrontendData.currency }}"
              data-amount="{{ adyenFrontendData.amount }}"

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -65,7 +65,7 @@ class PaymentResponseService
     public function getWithOrderId(string $orderId): ?PaymentResponseEntity
     {
         $orderTransaction = $this->orderTransactionRepository
-            ->getFirstAdyenOrderTransaction($orderId);
+            ->getRecentAdyenOrderTransaction($orderId);
         return $this->getWithOrderTransaction($orderTransaction->getId());
     }
 
@@ -78,7 +78,7 @@ class PaymentResponseService
                     ->addAssociation('orderTransaction.order'),
                 Context::createDefaultContext()
             )
-            ->first();
+            ->last();
     }
 
     public function getWithPaymentReference(string $paymentReference): ?PaymentResponseEntity

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -65,7 +65,7 @@ class PaymentResponseService
     public function getWithOrderId(string $orderId): ?PaymentResponseEntity
     {
         $orderTransaction = $this->orderTransactionRepository
-            ->getRecentAdyenOrderTransaction($orderId);
+            ->getFirstAdyenOrderTransaction($orderId);
         return $this->getWithOrderTransaction($orderTransaction->getId());
     }
 

--- a/src/Service/Repository/OrderTransactionRepository.php
+++ b/src/Service/Repository/OrderTransactionRepository.php
@@ -79,37 +79,6 @@ class OrderTransactionRepository
         );
 
         $criteria->setLimit(1);
-        $criteria->addSorting(new FieldSorting('createdAt', FieldSorting::ASCENDING));
-
-        return $this->repository->search($criteria, Context::createDefaultContext())->first();
-    }
-
-    /**
-     * @param string $orderId
-     * @param array $statesFilter
-     * @return OrderTransactionEntity|null
-     */
-    public function getRecentAdyenOrderTransaction(
-        string $orderId,
-        array $statesFilter = []
-    ): ?OrderTransactionEntity {
-        $criteria = new Criteria();
-        $criteria->addAssociation('stateMachineState');
-        $criteria->addAssociation('order');
-        $criteria->addAssociation('order.currency');
-        $criteria->addAssociation('paymentMethod');
-        $criteria->addAssociation('paymentMethod.plugin');
-        $criteria->addFilter(new EqualsFilter('order.id', $orderId));
-        if (!empty($statesFilter)) {
-            $criteria->addFilter(
-                new EqualsAnyFilter('stateMachineState.technicalName', $statesFilter)
-            );
-        }
-        $criteria->addFilter(
-            new EqualsFilter('paymentMethod.plugin.name', ConfigurationService::BUNDLE_NAME)
-        );
-
-        $criteria->setLimit(1);
         $criteria->addSorting(new FieldSorting('createdAt', FieldSorting::DESCENDING));
 
         return $this->repository->search($criteria, Context::createDefaultContext())->first();

--- a/src/Service/Repository/OrderTransactionRepository.php
+++ b/src/Service/Repository/OrderTransactionRepository.php
@@ -83,4 +83,35 @@ class OrderTransactionRepository
 
         return $this->repository->search($criteria, Context::createDefaultContext())->first();
     }
+
+    /**
+     * @param string $orderId
+     * @param array $statesFilter
+     * @return OrderTransactionEntity|null
+     */
+    public function getRecentAdyenOrderTransaction(
+        string $orderId,
+        array $statesFilter = []
+    ): ?OrderTransactionEntity {
+        $criteria = new Criteria();
+        $criteria->addAssociation('stateMachineState');
+        $criteria->addAssociation('order');
+        $criteria->addAssociation('order.currency');
+        $criteria->addAssociation('paymentMethod');
+        $criteria->addAssociation('paymentMethod.plugin');
+        $criteria->addFilter(new EqualsFilter('order.id', $orderId));
+        if (!empty($statesFilter)) {
+            $criteria->addFilter(
+                new EqualsAnyFilter('stateMachineState.technicalName', $statesFilter)
+            );
+        }
+        $criteria->addFilter(
+            new EqualsFilter('paymentMethod.plugin.name', ConfigurationService::BUNDLE_NAME)
+        );
+
+        $criteria->setLimit(1);
+        $criteria->addSorting(new FieldSorting('createdAt', FieldSorting::DESCENDING));
+
+        return $this->repository->search($criteria, Context::createDefaultContext())->first();
+    }
 }

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -330,6 +330,9 @@ class PaymentSubscriber implements EventSubscriberInterface
                     'updatePaymentUrl' => $this->router->generate(
                         'store-api.action.adyen.set-payment'
                     ),
+                    'cancelOrderTransactionUrl' => $this->router->generate(
+                        'store-api.action.adyen.cancel-order-transaction',
+                    ),
                     'languageId' => $salesChannelContext->getContext()->getLanguageId(),
                     'clientKey' => $this->configurationService->getClientKey($salesChannelId),
                     'locale' => $this->salesChannelRepository->getSalesChannelAssocLocale($salesChannelContext)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
PayPal pop-up cancellation was blocking the change of payment method on the checkout page.

## Tested scenarios
<!-- Description of tested scenarios -->
- PayPal (cancel) -> PayPal (auth)
- PayPal (cancel) -> CC 3ds2 (cancel on authentication) -> Klarna (auth)
- PayPal (cancel) -> PayPal (cancel) -> iDeal (auth)