### PR TITLE
Fix save payment details config

### DIFF
--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -273,6 +273,12 @@ class PaymentSubscriber implements EventSubscriberInterface
             }
         }
 
+        $displaySaveCreditCardOption = $this->paymentMethodsFilterService->isPaymentMethodInCollection(
+            $page->getPaymentMethods(),
+            OneClickPaymentMethodHandler::getPaymentMethodCode(),
+            $this->adyenPluginProvider->getAdyenPluginId(),
+        );
+
         $paymentMethodsResponse = $this->paymentMethodsService->getPaymentMethods($salesChannelContext, $orderId);
         $filteredPaymentMethods = $this->paymentMethodsFilterService->filterShopwarePaymentMethods(
             $page->getPaymentMethods(),
@@ -285,12 +291,6 @@ class PaymentSubscriber implements EventSubscriberInterface
 
         $stateDataIsStored = (bool)$this->paymentStateDataService->getPaymentStateDataFromContextToken(
             $salesChannelContext->getToken()
-        );
-
-        $displaySaveCreditCardOption = $this->paymentMethodsFilterService->isPaymentMethodInCollection(
-            $page->getPaymentMethods(),
-            OneClickPaymentMethodHandler::getPaymentMethodCode(),
-            $this->adyenPluginProvider->getAdyenPluginId(),
         );
 
         $salesChannelId = $salesChannelContext->getSalesChannel()->getId();


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This fixes an issue where the checkbox for saving card details was never displayed.
This was caused because we filtered out the oneclick payment method from the list of available payment methods based on `/paymentMethods` response before then checking for oneclick to determine if merchant has enabled it in the store. (🤯 I know)
Fix: check if oneclick is enabled before filtering based on paymentMethods response

## Tested scenarios
<!-- Description of tested scenarios -->
Save for next payment checkbox is displayed when oneclick is enabled


**Fixed issue**:  <!-- #-prefixed issue number -->
