### PR TITLE
allows to use custom line item types in cart & order

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -42,6 +42,7 @@ use Adyen\Shopware\Service\Repository\SalesChannelRepository;
 use Adyen\Shopware\Storefront\Controller\RedirectResultController;
 use Adyen\Util\Currency;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
@@ -564,8 +565,8 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
                 //Getting line price
                 $price = $orderLine->getPrice();
 
-                // Skip promotion line items.
-                if (empty($orderLine->getProductId()) && $orderLine->getType() === self::PROMOTION) {
+
+                if (empty($orderLine->getProductId()) || $orderLine->getType() !== LineItem::PRODUCT_LINE_ITEM_TYPE) {
                     continue;
                 }
 


### PR DESCRIPTION
## Summary
Allows to use custom line items in cart and order.  In the current case only products and promotions can use in a cart and order. If a custom entity will used, the payment process interrupt with an error.

## Tested scenarios
* create a custom line item with processor like a bonus coupon or voucher
* add a line item to the cart
* run checkout
