### PR TITLE
[PW-6992] Fix origin issue with multiple domain in one storefront

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -628,7 +628,16 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
         if (!empty($stateDataAdditionalData['origin'])) {
             $request['origin'] = $stateDataAdditionalData['origin'];
         } else {
-            $request['origin'] = $this->salesChannelRepository->getSalesChannelUrl($salesChannelContext);
+            // Use Hreflang default domain if set, otherwise get origin from the request
+            if (!empty($salesChannelContext->getSalesChannel()->getHreflangDefaultDomainId())) {
+                $origin = $this->salesChannelRepository->getHrefLangDomainUrl($salesChannelContext);
+            } else {
+                $originScheme = parse_url($transaction->getReturnUrl(), PHP_URL_SCHEME);
+                $originHost = parse_url($transaction->getReturnUrl(), PHP_URL_HOST);
+                $origin = $originScheme.'://'.$originHost;
+            }
+
+            $request['origin'] = $origin;
         }
 
         $request['additionalData']['allow3DS2'] = true;

--- a/src/Service/Repository/SalesChannelRepository.php
+++ b/src/Service/Repository/SalesChannelRepository.php
@@ -2,6 +2,7 @@
 
 namespace Adyen\Shopware\Service\Repository;
 
+use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Content\Newsletter\Exception\SalesChannelDomainNotFoundException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
@@ -39,17 +40,10 @@ class SalesChannelRepository
      * @param SalesChannelContext $context
      * @return string
      */
-    public function getSalesChannelUrl(SalesChannelContext $context): string
+    public function getHrefLangDomainUrl(SalesChannelContext $context): string
     {
         $criteria = new Criteria();
-
-        if (!empty($context->getSalesChannel()->getHreflangDefaultDomainId())) {
-            $criteria->addFilter(new EqualsFilter('id', $context->getSalesChannel()->getHreflangDefaultDomainId()));
-        } else {
-            $criteria->addFilter(new EqualsFilter('salesChannelId', $context->getSalesChannel()->getId()));
-            $criteria->setLimit(1);
-        }
-
+        $criteria->addFilter(new EqualsFilter('id', $context->getSalesChannel()->getHreflangDefaultDomainId()));
         $domainEntity = $this->domainRepository
             ->search($criteria, $context->getContext())
             ->first();

--- a/src/Service/Repository/SalesChannelRepository.php
+++ b/src/Service/Repository/SalesChannelRepository.php
@@ -6,6 +6,7 @@ use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Content\Newsletter\Exception\SalesChannelDomainNotFoundException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -40,10 +41,13 @@ class SalesChannelRepository
      * @param SalesChannelContext $context
      * @return string
      */
-    public function getHrefLangDomainUrl(SalesChannelContext $context): string
+    public function getCurrentDomainUrl(SalesChannelContext $context): string
     {
         $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('id', $context->getSalesChannel()->getHreflangDefaultDomainId()));
+
+        $domainId = $context->getSalesChannel()->getHreflangDefaultDomainId() ?: $context->getDomainId();
+        $criteria->addFilter(new EqualsFilter('id', $domainId));
+
         $domainEntity = $this->domainRepository
             ->search($criteria, $context->getContext())
             ->first();
@@ -58,7 +62,7 @@ class SalesChannelRepository
     /**
      * @param SalesChannelContext $context
      * @return SalesChannelEntity
-     * @throws \Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException
+     * @throws InconsistentCriteriaIdsException
      */
     public function getSalesChannelAssocLocale(SalesChannelContext $context): SalesChannelEntity
     {
@@ -66,7 +70,7 @@ class SalesChannelRepository
 
         return $this->salesChannelRepository->search(
             $salesChannelCriteria->addAssociation('language.locale'),
-            Context::createDefaultContext()
+            $context->getContext()
         )->first();
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
When more than one domain is set on the same sales channel, 3DS2 payments coming from the second..last domains always get stuck. This is happening because we set the origin value in the payment request by either using the hreflang default domain (if set) or else we simply get the first domain registered to the sales channel. This becomes an issue for merchants with multiple (sub-)domains e.g based on language es.example.com, de.example.com

To fix this, when making the payment request instead of getting the origin value by picking the first domain on the sales channel, use the origin from the base URL of the transaction request.

## Tested scenarios
<!-- Description of tested scenarios -->
- 3DS2 payments in multiple domains in the same sales channel

**Fixed issue**:  <!-- #-prefixed issue number -->
Fixes #267 