### PR TITLE
[PW-7212] Fix issue with custom payment methods

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -109,11 +109,6 @@
         <service id="Adyen\Shopware\Service\PaymentMethodsFilterService">
             <argument type="service" id="Adyen\Shopware\Service\PaymentMethodsService" />
         </service>
-        <!--Shopware Services wiring-->
-        <service id="Shopware\Core\Checkout\Payment\Cart\PaymentHandler\DefaultPayment">
-            <argument type="service"
-                      id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
-        </service>
         <!--Service decorators-->
         <service id="Adyen\Shopware\Framework\Cookie\AdyenCookieProvider"
                  decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
When a new payment method is created in the Shopware 6 admin section (Settings -> Payment Methods -> Add Payment Method) it is assigned the handler `Shopware\Core\Checkout\Payment\Cart\PaymentHandler\DefaultPayment` which is originally registered by Shopware in [payment.xml](https://github.com/shopware/platform/blob/trunk/src/Core/Checkout/DependencyInjection/payment.xml#L115).
By overriding this definition in our [services.xml](https://github.com/Adyen/adyen-shopware6/blob/02384c8f95456defc4b871b80750858b2481b692/src/Resources/config/services.xml) file and not including the `shopware.payment.method.sync` tag, we prevent Shopware from registering it as a payment handler in [PaymentHandlerRegistry](https://github.com/shopware/platform/blob/trunk/src/Core/Checkout/Payment/Cart/PaymentHandler/PaymentHandlerRegistry.php#L34)
The result is that when payment is made with the custom payment method, the payment handler is not found in [`PaymentHandlerRegistry::getPaymentMethodHandler`](https://github.com/shopware/platform/blob/trunk/src/Core/Checkout/Payment/Cart/PaymentHandler/PaymentHandlerRegistry.php#L131).

**Fix:** Remove overriding of DefaultPayment handler to enable custom payment methods to work with plugin installed.

## Tested scenarios
<!-- Description of tested scenarios -->
- Pay with custom payment method
- Pay with Adyen payment method

**Fixed issue**:  <!-- #-prefixed issue number -->
fixes #276 