### PR TITLE
[PW-7299] select first domain as fallback where domain ID is not set

### DIFF
--- a/src/Service/Repository/SalesChannelRepository.php
+++ b/src/Service/Repository/SalesChannelRepository.php
@@ -46,7 +46,12 @@ class SalesChannelRepository
         $criteria = new Criteria();
 
         $domainId = $context->getSalesChannel()->getHreflangDefaultDomainId() ?: $context->getDomainId();
-        $criteria->addFilter(new EqualsFilter('id', $domainId));
+        if ($domainId) {
+            $criteria->addFilter(new EqualsFilter('id', $domainId));
+        } else {
+            $criteria->addFilter(new EqualsFilter('salesChannelId', $context->getSalesChannel()->getId()));
+            $criteria->setLimit(1);
+        }
 
         $domainEntity = $this->domainRepository
             ->search($criteria, $context->getContext())


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
As a fallback for headless sales channel in which the context object has neither a `domainId` nor a `salesChannel.hreflangDefaultDomainId`, revert to fetching the first available domain assigned to the sales channel

## Tested scenarios
<!-- Description of tested scenarios -->
Payment request via postman with headless sales channel token

**Fixed issue**:  <!-- #-prefixed issue number -->
Resolves #302 
