### PR TITLE
[PW-7512] - Fix first failed payment overwrites second successful payment

### DIFF
--- a/src/ScheduledTask/Webhook/AuthorisationWebhookHandler.php
+++ b/src/ScheduledTask/Webhook/AuthorisationWebhookHandler.php
@@ -79,10 +79,12 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
         string $currentTransactionState,
         Context $context
     ): void {
-        if ($notificationEntity->isSuccess() && $state !== $currentTransactionState) {
-            $this->handleSuccessfulNotification($orderTransactionEntity, $notificationEntity, $context);
-        } else {
-            $this->handleFailedNotification($orderTransactionEntity, $context);
+        if ($state !== $currentTransactionState) {
+            if ($notificationEntity->isSuccess()) {
+                $this->handleSuccessfulNotification($orderTransactionEntity, $notificationEntity, $context);
+            } else {
+                $this->handleFailedNotification($orderTransactionEntity, $context);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Failed authorisation notification is overriding if there is any successful authorisation notification. 

State change check added to see before any transitional change.

## Tested scenarios
<!-- Description of tested scenarios -->
- 3DS failed + iDeal successful
- 3DS failed
- iDeal successfuk

Fixes #311