### PR TITLE
allow '-' in housenumber when splitting

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -741,8 +741,8 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
      */
     private function getSplitStreetAddressHouseNumber(string $address): array
     {
-        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/m';
-        $numberFirstRegex = '/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
+        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)$/m';
+        $numberFirstRegex = '/^(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
 
         preg_match($streetFirstRegex, $address, $streetFirstAddress);
         preg_match($numberFirstRegex, $address, $numberFirstAddress);

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -741,8 +741,8 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
      */
     private function getSplitStreetAddressHouseNumber(string $address): array
     {
-        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)$/m';
-        $numberFirstRegex = '/^(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
+        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>[\d-]{1,10}((\s)?\w{1,3})?)$/m';
+        $numberFirstRegex = '/^(?<houseNumber>[\d-]{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
 
         preg_match($streetFirstRegex, $address, $streetFirstAddress);
         preg_match($numberFirstRegex, $address, $numberFirstAddress);

--- a/src/Service/PaymentMethodsService.php
+++ b/src/Service/PaymentMethodsService.php
@@ -125,8 +125,8 @@ class PaymentMethodsService
      */
     public function getSplitStreetAddressHouseNumber(string $address): array
     {
-        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)$/m';
-        $numberFirstRegex = '/^(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
+        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>[\d-]{1,10}((\s)?\w{1,3})?)$/m';
+        $numberFirstRegex = '/^(?<houseNumber>[\d-]{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
 
         preg_match($streetFirstRegex, $address, $streetFirstAddress);
         preg_match($numberFirstRegex, $address, $numberFirstAddress);

--- a/src/Service/PaymentMethodsService.php
+++ b/src/Service/PaymentMethodsService.php
@@ -125,8 +125,8 @@ class PaymentMethodsService
      */
     public function getSplitStreetAddressHouseNumber(string $address): array
     {
-        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/m';
-        $numberFirstRegex = '/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
+        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)$/m';
+        $numberFirstRegex = '/^(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
 
         preg_match($streetFirstRegex, $address, $streetFirstAddress);
         preg_match($numberFirstRegex, $address, $numberFirstAddress);

--- a/src/Service/PaymentRequestService.php
+++ b/src/Service/PaymentRequestService.php
@@ -395,8 +395,8 @@ class PaymentRequestService
      */
     public function getSplitStreetAddressHouseNumber(string $address): array
     {
-        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)$/m';
-        $numberFirstRegex = '/^(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
+        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>[\d-]{1,10}((\s)?\w{1,3})?)$/m';
+        $numberFirstRegex = '/^(?<houseNumber>[\d-]{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
 
         preg_match($streetFirstRegex, $address, $streetFirstAddress);
         preg_match($numberFirstRegex, $address, $numberFirstAddress);

--- a/src/Service/PaymentRequestService.php
+++ b/src/Service/PaymentRequestService.php
@@ -395,8 +395,8 @@ class PaymentRequestService
      */
     public function getSplitStreetAddressHouseNumber(string $address): array
     {
-        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/m';
-        $numberFirstRegex = '/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
+        $streetFirstRegex = '/(?<streetName>[\w\W]+)\s+(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)$/m';
+        $numberFirstRegex = '/^(?<houseNumber>(\d|\-)+((\s)?\w{1,3})?)\s+(?<streetName>[\w\W]+)/m';
 
         preg_match($streetFirstRegex, $address, $streetFirstAddress);
         preg_match($numberFirstRegex, $address, $numberFirstAddress);


### PR DESCRIPTION
## Summary
Solves issue https://github.com/Adyen/adyen-shopware6/issues/308
When housenumber includes '-' it wasn't splitted from street by the old RegEx. This was used by customers to give a suite number. The new RegEx allows this.

## Tested scenarios
Using "106-19 Dallas Road" in street field


**Fixed issue**:  308