### PR TITLE
[PW-7528] change block in which payment component is rendered

### DIFF
--- a/src/Resources/views/storefront/component/payment/payment-method.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-method.html.twig
@@ -12,7 +12,7 @@
            class="{{ formCheckInputClass }} payment-method-input {% if 'handler_adyen_' in payment.formattedHandlerIdentifier %}adyen-payment-method-input-radio{% endif %}">
 {% endblock %}
 
-{% block component_payment_method_description_text %}
+{% block component_payment_method_description %}
     {{ parent() }}
     {% if payment.id is same as(selectedPaymentMethodId) and 'handler_adyen_' in payment.formattedHandlerIdentifier %}
         {% sw_include '@AdyenPaymentShopware6/storefront/component/payment/payment-component.html.twig' %}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Shopware does not load the `component_payment_method_description_text` block if payment method description is missing, see [here](https://github.com/shopware/platform/blob/trunk/src/Storefront/Resources/views/storefront/component/payment/payment-method.html.twig#L40), and this results in our component not being loaded and therefor payments fail with the error `Payment details are missing.`
Extend the parent block `component_payment_method_description` instead to load our plugin component.



## Tested scenarios
<!-- Description of tested scenarios -->
Pay with component when the payment method has no description
Test for Wallet payment method, Paypal

