### PR TITLE
[PW-7981] Change productUrl builder for line items

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -606,10 +606,13 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
                     $this->getProduct($orderLine->getProductId(), $salesChannelContext->getContext()) :
                     null;
 
-                if (isset($product) && !is_null($product->getSeoUrls())) {
-                    $hostname = $salesChannelContext->getSalesChannel()->getDomains()->first()->getUrl();
-                    $productPath = $product->getSeoUrls()->first()->getPathInfo();
-                    $productUrl = str_replace('//', '/', $hostname . $productPath);
+                // Add url for only real product and not for the custom cart items.
+                if (!is_null($product->getId())) {
+                    $productUrl = sprintf(
+                        "%s/detail/%s",
+                        $salesChannelContext->getSalesChannel()->getDomains()->first()->getUrl(),
+                        $product->getId()
+                    );
                 } else {
                     $productUrl = null;
                 }
@@ -741,7 +744,6 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
     {
         $criteria = new Criteria([$productId]);
 
-        $criteria->addAssociation('seoUrls');
         $criteria->addAssociation('cover');
         $criteria->addAssociation('categories');
 

--- a/src/Service/PaymentRequestService.php
+++ b/src/Service/PaymentRequestService.php
@@ -375,11 +375,13 @@ class PaymentRequestService
                 $item['imageUrl'] = $product->getCover()->getMedia()->getUrl();
             }
 
-            if (!is_null($product->getSeoUrls())) {
-                $hostname = $salesChannelContext->getSalesChannel()->getDomains()->first()->getUrl();
-                $productPath = $product->getSeoUrls()->first()->getPathInfo();
-
-                $item['productUrl'] = str_replace('//', '/', $hostname . $productPath);
+            // Add url for only real product and not for the custom cart items.
+            if (!is_null($product->getId())) {
+                $item['productUrl'] = sprintf(
+                    "%s/detail/%s",
+                    $salesChannelContext->getSalesChannel()->getDomains()->first()->getUrl(),
+                    $product->getId()
+                );
             }
 
             //Building open invoice line
@@ -448,7 +450,6 @@ class PaymentRequestService
     {
         $criteria = new Criteria([$productId]);
 
-        $criteria->addAssociation('seoUrls');
         $criteria->addAssociation('cover');
 
         /** @var ProductCollection $productCollection */


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
`productUrl` parameter builder updated in the line item builders since the `getSeoUrls()` can be null and not reliable for product URL generation.

## Tested scenarios
<!-- Description of tested scenarios -->
- Klarna payment
- Manual capture

Fixes #344
