### PR TITLE
[PW-8180] Fix wrong language on checkout component

### DIFF
--- a/src/Resources/config/services/repositories.xml
+++ b/src/Resources/config/services/repositories.xml
@@ -7,6 +7,8 @@
         <service id="Adyen\Shopware\Service\Repository\SalesChannelRepository" autowire="true">
             <argument type="service" id="sales_channel_domain.repository"/>
             <argument type="service" id="sales_channel.repository"/>
+            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
+            <argument type="service" id="language.repository"/>
         </service>
         <service id="Adyen\Shopware\Service\Repository\OrderRepository" autowire="true">
             <argument type="service" id="order.repository"/>

--- a/src/Service/Repository/SalesChannelRepository.php
+++ b/src/Service/Repository/SalesChannelRepository.php
@@ -2,11 +2,8 @@
 
 namespace Adyen\Shopware\Service\Repository;
 
-use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Content\Newsletter\Exception\SalesChannelDomainNotFoundException;
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
-use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -31,19 +28,27 @@ class SalesChannelRepository
     private $configurationService;
 
     /**
+     * @var EntityRepositoryInterface
+     */
+    private $languageRepository;
+
+    /**
      * SalesChannelRepository constructor.
      * @param EntityRepositoryInterface $domainRepository
      * @param EntityRepositoryInterface $salesChannelRepository
      * @param ConfigurationService $configurationService
+     * @param EntityRepositoryInterface $languageRepository
      */
     public function __construct(
         EntityRepositoryInterface $domainRepository,
         EntityRepositoryInterface $salesChannelRepository,
-        ConfigurationService $configurationService
+        ConfigurationService $configurationService,
+        EntityRepositoryInterface $languageRepository
     ) {
         $this->domainRepository = $domainRepository;
         $this->salesChannelRepository = $salesChannelRepository;
         $this->configurationService = $configurationService;
+        $this->languageRepository = $languageRepository;
     }
 
     /**
@@ -92,5 +97,21 @@ class SalesChannelRepository
         }
 
         return $this->salesChannelRepository->search($criteria, $context->getContext())->first();
+    }
+
+    /**
+     * @param SalesChannelContext $salesChannelContext
+     * @return string
+     */
+    public function getSalesChannelLocale(SalesChannelContext $salesChannelContext): string
+    {
+        $criteria = new Criteria();
+
+        $criteria->addFilter(new EqualsFilter('id', $salesChannelContext->getLanguageId()));
+        $criteria->addAssociation('locale');
+
+        $languageEntity = $this->languageRepository->search($criteria, $salesChannelContext->getContext())->first();
+
+        return $languageEntity->getLocale()->getCode();
     }
 }

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -189,9 +189,7 @@ class PaymentSubscriber extends StorefrontSubscriber implements EventSubscriberI
 
         return [
             'clientKey' => $this->configurationService->getClientKey($salesChannelId),
-            'locale' => $this->salesChannelRepository
-                ->getSalesChannelAssoc($salesChannelContext, ['language.locale'])
-                ->getLanguage()->getLocale()->getCode(),
+            'locale' => $this->salesChannelRepository->getSalesChannelLocale($salesChannelContext),
             'environment' => $this->configurationService->getEnvironment($salesChannelId),
         ];
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Obtaining locale from the sales channel repository was being resulted in getting the default locale value even if the selected language was different. That behaviour caused wrong locale was being sent to the Adyen Web components configuration.

Instead of fetching the locale from DB according to the sales channel default values, now it is being fetched from sales channel context. 

## Tested scenarios
<!-- Description of tested scenarios -->
- Different language setups on the store with correct component language setup