### PR TITLE
[PW-8262] Fix invalid redirect url

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -373,8 +373,14 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
             $salesChannelContext
         );
 
+        $action = $response[PaymentResponseHandler::ACTION] ?? [];
+        $redirectUrl = ($action['type'] ?? null) === 'redirect' ?
+            $action['url'] ?? null :
+            null;
+
         // Payment had no error, continue the process
-        return new RedirectResponse($this->getAdyenReturnUrl($transaction, $salesChannelContext));
+        return new RedirectResponse($redirectUrl ?? $this->getAdyenReturnUrl($transaction, $salesChannelContext));
+
     }
 
     /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

If the payment response type is has the action type redirect the redirect url of the method `AbstractPaymentMethodHandler::pay` should be the url of the PSP, like Klarna for example, instead of the `payment.adyen.redirect_result` route which should be the target after visiting the PSP page.

## Tested scenarios

Use Klarna for example within a headless context.
