### PR TITLE
[PW-8261] Make use of larger runners for E2E pipeline

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -6,7 +6,9 @@ on: [pull_request]
 jobs:
   e2e:
     name: Shopware 6 E2E
-    runs-on: ubuntu-latest
+    runs-on:
+      group: larger-runners
+      labels: ubuntu-latest-8-cores
     timeout-minutes: 20
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Make use of 8 core runners for E2E tests