### PR TITLE
fix extra leading slash in return URL

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -735,7 +735,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
         );
 
         // Create the adyen redirect result URL with the same query as the original return URL
-        return $baseUrl . $adyenReturnPath . '&' . $returnUrlQuery;
+        return rtrim($baseUrl, '/') . $adyenReturnPath . '&' . $returnUrlQuery;
     }
 
     /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
When the storefront domain URL has a trailing slash, the return URL generated contains 2 consecutive slashes. e.g. `https://example.com//adyen/redirect-result`

This fix trims the trailing slash from the domain if it exists

