### PR TITLE
[PW-8295] Fix giftcard capture mode for adyen_payment table

### DIFF
--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -27,6 +27,42 @@ namespace Adyen\Shopware\Handlers;
 
 class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
+    const SCHEME = 'scheme';
+    const CARD_BRANDS = [
+        'mc',
+        'visa',
+        'amex',
+        'discover',
+        'maestro',
+        'mcstandarddebit',
+        'jcb',
+        'diners',
+        'cup',
+        'bcmc',
+        'hipercard',
+        'elo',
+        'troy',
+        'dankort',
+        'cartebancaire',
+        'korean_local_card',
+        'amex_applepay',
+        'discover_applepay',
+        'electron_applepay',
+        'elo_applepay',
+        'elodebit_applepay',
+        'interac_applepay',
+        'jcb_applepay',
+        'maestro_applepay',
+        'mc_applepay',
+        'visa_applepay',
+        'girocard_applepay'
+    ];
+
+    public static function isSchemePayment(string $brand)
+    {
+        return in_array($brand, self::CARD_BRANDS);
+    }
+
     public static function getPaymentMethodCode()
     {
         return 'scheme';

--- a/src/Handlers/CardsPaymentMethodHandler.php
+++ b/src/Handlers/CardsPaymentMethodHandler.php
@@ -27,42 +27,6 @@ namespace Adyen\Shopware\Handlers;
 
 class CardsPaymentMethodHandler extends AbstractPaymentMethodHandler
 {
-    const SCHEME = 'scheme';
-    const CARD_BRANDS = [
-        'mc',
-        'visa',
-        'amex',
-        'discover',
-        'maestro',
-        'mcstandarddebit',
-        'jcb',
-        'diners',
-        'cup',
-        'bcmc',
-        'hipercard',
-        'elo',
-        'troy',
-        'dankort',
-        'cartebancaire',
-        'korean_local_card',
-        'amex_applepay',
-        'discover_applepay',
-        'electron_applepay',
-        'elo_applepay',
-        'elodebit_applepay',
-        'interac_applepay',
-        'jcb_applepay',
-        'maestro_applepay',
-        'mc_applepay',
-        'visa_applepay',
-        'girocard_applepay'
-    ];
-
-    public static function isSchemePayment(string $brand)
-    {
-        return in_array($brand, self::CARD_BRANDS);
-    }
-
     public static function getPaymentMethodCode()
     {
         return 'scheme';

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -161,12 +161,10 @@ class PaymentResponseHandler
          * payment response contains `order` object.
          */
         $isGiftcardOrderResponse = false;
-        if (
-            !empty($response['paymentMethod']) &&
+        if (!empty($response['paymentMethod']) &&
             !empty($response['paymentMethod']['type']) &&
             $response['paymentMethod']['type'] === 'giftcard' &&
-            array_key_exists('order', $response)
-        ) {
+            array_key_exists('order', $response)) {
             $isGiftcardOrderResponse = true;
         }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -71,6 +71,7 @@
             <argument type="service" id="Adyen\Shopware\Service\RefundService"/>
             <argument type="service"
                       id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
+            <argument type="service" id="Adyen\Shopware\Service\PluginPaymentMethodsService"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
         </service>
         <service id="Adyen\Shopware\Service\PaymentMethodsBalanceService">
@@ -82,22 +83,11 @@
             <argument type="service" id="Adyen\Shopware\Service\PaymentMethodsService" />
             <argument type="service" id="Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute" />
         </service>
-        <service id="Adyen\Shopware\Service\OrdersService" autowire="true">
-        </service>
-        <service id="Adyen\Shopware\Service\OrdersCancelService" autowire="true">
-        </service>
+        <service id="Adyen\Shopware\Service\OrdersService" autowire="true"></service>
+        <service id="Adyen\Shopware\Service\OrdersCancelService" autowire="true"></service>
+        <service id="Adyen\Shopware\Service\PluginPaymentMethodsService" autowire="true"></service>
         <service id="Adyen\Shopware\Service\AdyenPaymentService">
             <argument type="service" id="Adyen\Shopware\Service\Repository\AdyenPaymentRepository"/>
-        </service>
-
-        <!--Commands-->
-        <service id="Adyen\Shopware\Command\FetchPaymentMethodLogosCommand">
-            <argument type="service" id="Adyen\Shopware\ScheduledTask\FetchPaymentMethodLogosHandler"/>
-            <tag name="console.command"/>
-        </service>
-        <service id="Adyen\Shopware\Command\ProcessWebhooksCommand">
-            <argument type="service" id="Adyen\Shopware\ScheduledTask\ProcessNotificationsHandler"/>
-            <tag name="console.command"/>
         </service>
 
         <!--Service decorators-->

--- a/src/ScheduledTask/Webhook/AuthorisationWebhookHandler.php
+++ b/src/ScheduledTask/Webhook/AuthorisationWebhookHandler.php
@@ -104,7 +104,6 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
      * @param NotificationEntity $notification
      * @param Context $context
      * @return void
-     * @throws AdyenException
      * @throws CaptureException
      */
     private function handleSuccessfulNotification(
@@ -112,9 +111,13 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
         NotificationEntity $notification,
         Context $context
     ): void {
-        $paymentMethodHandler = $this->pluginPaymentMethodsService->getHandlerIdentifierFromTxVariant(
+        $paymentMethodHandler = $this->pluginPaymentMethodsService->getGiftcardHandlerIdentifierFromTxVariant(
             $notification->getPaymentMethod()
         );
+
+        if (is_null($paymentMethodHandler)) {
+            $paymentMethodHandler = $orderTransaction->getPaymentMethod()->getHandlerIdentifier();
+        }
 
         $isManualCapture = $this->captureService->requiresManualCapture($paymentMethodHandler);
         $currencyUtil = new Currency();

--- a/src/ScheduledTask/Webhook/AuthorisationWebhookHandler.php
+++ b/src/ScheduledTask/Webhook/AuthorisationWebhookHandler.php
@@ -24,9 +24,12 @@
 
 namespace Adyen\Shopware\ScheduledTask\Webhook;
 
+use Adyen\AdyenException;
 use Adyen\Shopware\Entity\Notification\NotificationEntity;
+use Adyen\Shopware\Exception\CaptureException;
 use Adyen\Shopware\Service\CaptureService;
 use Adyen\Shopware\Service\AdyenPaymentService;
+use Adyen\Shopware\Service\PluginPaymentMethodsService;
 use Adyen\Util\Currency;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
@@ -35,40 +38,39 @@ use Shopware\Core\Framework\Context;
 
 class AuthorisationWebhookHandler implements WebhookHandlerInterface
 {
-    /**
-     * @var LoggerInterface
-     */
+    /** @var LoggerInterface */
     private $logger;
 
-    /**
-     * @var CaptureService
-     */
+    /** @var CaptureService */
     private $captureService;
 
-    /**
-     * @var AdyenPaymentService
-     */
+    /** @var AdyenPaymentService */
     private $adyenPaymentService;
 
-    /**
-     * @var OrderTransactionStateHandler
-     */
+    /** @var OrderTransactionStateHandler */
     private $orderTransactionStateHandler;
+
+    /** @var PluginPaymentMethodsService */
+    private $pluginPaymentMethodsService;
 
     /**
      * @param CaptureService $captureService
+     * @param AdyenPaymentService $adyenPaymentService
      * @param OrderTransactionStateHandler $orderTransactionStateHandler
+     * @param PluginPaymentMethodsService $pluginPaymentMethodsService
      * @param LoggerInterface $logger
      */
     public function __construct(
         CaptureService $captureService,
         AdyenPaymentService $adyenPaymentService,
         OrderTransactionStateHandler $orderTransactionStateHandler,
+        PluginPaymentMethodsService $pluginPaymentMethodsService,
         LoggerInterface $logger
     ) {
         $this->captureService = $captureService;
         $this->adyenPaymentService = $adyenPaymentService;
         $this->orderTransactionStateHandler = $orderTransactionStateHandler;
+        $this->pluginPaymentMethodsService = $pluginPaymentMethodsService;
         $this->logger = $logger;
     }
 
@@ -79,7 +81,7 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
      * @param string $currentTransactionState
      * @param Context $context
      * @return void
-     * @throws \Adyen\Shopware\Exception\CaptureException
+     * @throws CaptureException|AdyenException
      */
     public function handleWebhook(
         OrderTransactionEntity $orderTransactionEntity,
@@ -102,14 +104,18 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
      * @param NotificationEntity $notification
      * @param Context $context
      * @return void
-     * @throws \Adyen\Shopware\Exception\CaptureException
+     * @throws AdyenException
+     * @throws CaptureException
      */
     private function handleSuccessfulNotification(
         OrderTransactionEntity $orderTransaction,
         NotificationEntity $notification,
         Context $context
     ): void {
-        $paymentMethodHandler = $orderTransaction->getPaymentMethod()->getHandlerIdentifier();
+        $paymentMethodHandler = $this->pluginPaymentMethodsService->getHandlerIdentifierFromTxVariant(
+            $notification->getPaymentMethod()
+        );
+
         $isManualCapture = $this->captureService->requiresManualCapture($paymentMethodHandler);
         $currencyUtil = new Currency();
         $totalPrice = $orderTransaction->getAmount()->getTotalPrice();

--- a/src/ScheduledTask/Webhook/WebhookHandlerFactory.php
+++ b/src/ScheduledTask/Webhook/WebhookHandlerFactory.php
@@ -25,9 +25,9 @@
 namespace Adyen\Shopware\ScheduledTask\Webhook;
 
 use Adyen\Shopware\Service\CaptureService;
+use Adyen\Shopware\Service\PluginPaymentMethodsService;
 use Adyen\Shopware\Service\RefundService;
 use Adyen\Shopware\Service\AdyenPaymentService;
-use Adyen\Shopware\Service\Repository\AdyenPaymentRepository;
 use Adyen\Webhook\EventCodes;
 use Adyen\Webhook\Exception\InvalidDataException;
 use Psr\Log\LoggerInterface;
@@ -35,36 +35,30 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStat
 
 class WebhookHandlerFactory
 {
-    /**
-     * @var LoggerInterface
-     */
+    /** @var LoggerInterface */
     private static $logger;
 
-    /**
-     * @var CaptureService
-     */
+    /** @var CaptureService */
     private static $captureService;
 
-    /**
-     * @var RefundService
-     */
+    /** @var RefundService */
     private static $refundService;
 
-    /**
-     * @var AdyenPaymentService
-     */
+    /** @var AdyenPaymentService */
     private static $adyenPaymentService;
 
-    /**
-     * @var OrderTransactionStateHandler
-     */
+    /** @var OrderTransactionStateHandler */
     private static $orderTransactionStateHandler;
+
+    /** @var PluginPaymentMethodsService */
+    private static $pluginPaymentMethodsService;
 
     /**
      * @param CaptureService $captureService
-     * @param OrderTransactionStateHandler $orderTransactionStateHandler
-     * @param RefundService $refundService
      * @param AdyenPaymentService $adyenPaymentService
+     * @param RefundService $refundService
+     * @param OrderTransactionStateHandler $orderTransactionStateHandler
+     * @param PluginPaymentMethodsService $pluginPaymentMethodsService
      * @param LoggerInterface $logger
      */
     public function __construct(
@@ -72,12 +66,14 @@ class WebhookHandlerFactory
         AdyenPaymentService $adyenPaymentService,
         RefundService $refundService,
         OrderTransactionStateHandler $orderTransactionStateHandler,
+        PluginPaymentMethodsService $pluginPaymentMethodsService,
         LoggerInterface $logger
     ) {
         self::$captureService = $captureService;
         self::$adyenPaymentService = $adyenPaymentService;
         self::$refundService = $refundService;
         self::$orderTransactionStateHandler = $orderTransactionStateHandler;
+        self::$pluginPaymentMethodsService = $pluginPaymentMethodsService;
         self::$logger = $logger;
     }
 
@@ -93,6 +89,7 @@ class WebhookHandlerFactory
                     self::$captureService,
                     self::$adyenPaymentService,
                     self::$orderTransactionStateHandler,
+                    self::$pluginPaymentMethodsService,
                     self::$logger
                 );
                 break;

--- a/src/Service/PluginPaymentMethodsService.php
+++ b/src/Service/PluginPaymentMethodsService.php
@@ -78,7 +78,6 @@ class PluginPaymentMethodsService
         foreach ($pluginPaymentMethods as $pluginPaymentMethod) {
             if ($pluginPaymentMethod->getHandlerIdentifier()::getPaymentMethodCode() === 'giftcard' &&
                 $pluginPaymentMethod->getHandlerIdentifier()::getBrand() === $paymentMethod) {
-
                 return $pluginPaymentMethod->getHandlerIdentifier();
             }
         }

--- a/src/Service/PluginPaymentMethodsService.php
+++ b/src/Service/PluginPaymentMethodsService.php
@@ -69,25 +69,20 @@ class PluginPaymentMethodsService
 
     /**
      * @param string $paymentMethod
-     * @return string
-     * @throws AdyenException
+     * @return string|null
      */
-    public function getHandlerIdentifierFromTxVariant(string $paymentMethod): string
+    public function getGiftcardHandlerIdentifierFromTxVariant(string $paymentMethod): ?string
     {
-        if (CardsPaymentMethodHandler::isSchemePayment($paymentMethod)) {
-            return CardsPaymentMethodHandler::class;
-        } else {
-            $pluginPaymentMethods = $this->getPluginPaymentMethods();
+        $pluginPaymentMethods = $this->getPluginPaymentMethods();
 
-            foreach ($pluginPaymentMethods as $pluginPaymentMethod) {
-                if (($pluginPaymentMethod->getHandlerIdentifier()::getPaymentMethodCode() === 'giftcard' &&
-                    $pluginPaymentMethod->getHandlerIdentifier()::getBrand() === $paymentMethod) ||
-                    $pluginPaymentMethod->getHandlerIdentifier()::getPaymentMethodCode() === $paymentMethod) {
-                    return $pluginPaymentMethod->getHandlerIdentifier();
-                }
+        foreach ($pluginPaymentMethods as $pluginPaymentMethod) {
+            if ($pluginPaymentMethod->getHandlerIdentifier()::getPaymentMethodCode() === 'giftcard' &&
+                $pluginPaymentMethod->getHandlerIdentifier()::getBrand() === $paymentMethod) {
+
+                return $pluginPaymentMethod->getHandlerIdentifier();
             }
         }
 
-        throw new AdyenException(sprintf("Payment method %s not found!", $paymentMethod));
+        return null;
     }
 }

--- a/src/Service/PluginPaymentMethodsService.php
+++ b/src/Service/PluginPaymentMethodsService.php
@@ -80,12 +80,9 @@ class PluginPaymentMethodsService
             $pluginPaymentMethods = $this->getPluginPaymentMethods();
 
             foreach ($pluginPaymentMethods as $pluginPaymentMethod) {
-
-                if (
-                    ($pluginPaymentMethod->getHandlerIdentifier()::getPaymentMethodCode() === 'giftcard' &&
+                if (($pluginPaymentMethod->getHandlerIdentifier()::getPaymentMethodCode() === 'giftcard' &&
                     $pluginPaymentMethod->getHandlerIdentifier()::getBrand() === $paymentMethod) ||
-                    $pluginPaymentMethod->getHandlerIdentifier()::getPaymentMethodCode() === $paymentMethod
-                ) {
+                    $pluginPaymentMethod->getHandlerIdentifier()::getPaymentMethodCode() === $paymentMethod) {
                     return $pluginPaymentMethod->getHandlerIdentifier();
                 }
             }

--- a/src/Service/PluginPaymentMethodsService.php
+++ b/src/Service/PluginPaymentMethodsService.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2023 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ */
+
+namespace Adyen\Shopware\Service;
+
+use Adyen\AdyenException;
+use Adyen\Shopware\Handlers\CardsPaymentMethodHandler;
+use Adyen\Shopware\Provider\AdyenPluginProvider;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+
+class PluginPaymentMethodsService
+{
+    /** @var AdyenPluginProvider */
+    protected $adyenPluginProvider;
+
+    /** @var EntityRepositoryInterface */
+    protected $paymentMethodRepository;
+
+    public function __construct(
+        AdyenPluginProvider $adyenPluginProvider,
+        EntityRepositoryInterface $paymentMethodRepository
+    ) {
+        $this->adyenPluginProvider = $adyenPluginProvider;
+        $this->paymentMethodRepository = $paymentMethodRepository;
+    }
+
+    public function getPluginPaymentMethods(string $identifier = null): array
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(
+            new EqualsFilter('pluginId', $this->adyenPluginProvider->getAdyenPluginId())
+        );
+
+        if (isset($identifier)) {
+            $criteria->addFilter(
+                new EqualsFilter('pluginId', $this->adyenPluginProvider->getAdyenPluginId())
+            );
+        }
+
+        $paymentMethods = $this->paymentMethodRepository
+            ->search($criteria, Context::createDefaultContext())
+            ->getEntities();
+
+        return $paymentMethods->getElements();
+    }
+
+    /**
+     * @param string $paymentMethod
+     * @return string
+     * @throws AdyenException
+     */
+    public function getHandlerIdentifierFromTxVariant(string $paymentMethod): string
+    {
+        if (CardsPaymentMethodHandler::isSchemePayment($paymentMethod)) {
+            return CardsPaymentMethodHandler::class;
+        } else {
+            $pluginPaymentMethods = $this->getPluginPaymentMethods();
+
+            foreach ($pluginPaymentMethods as $pluginPaymentMethod) {
+
+                if (
+                    ($pluginPaymentMethod->getHandlerIdentifier()::getPaymentMethodCode() === 'giftcard' &&
+                    $pluginPaymentMethod->getHandlerIdentifier()::getBrand() === $paymentMethod) ||
+                    $pluginPaymentMethod->getHandlerIdentifier()::getPaymentMethodCode() === $paymentMethod
+                ) {
+                    return $pluginPaymentMethod->getHandlerIdentifier();
+                }
+            }
+        }
+
+        throw new AdyenException(sprintf("Payment method %s not found!", $paymentMethod));
+    }
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Method identifier is being obtained from the webhook's `paymentMethod` object instead of `orderTransaction`. That allows setting different capture modes for partial payments.

## Tested scenarios
<!-- Description of tested scenarios -->
- Giftcard payments
- Giftcard + Klarna payments