### PR TITLE
[PW-8294] Fix manual capture flow for giftcards

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -267,10 +267,9 @@ class AdminController
     public function isCaptureAllowed(string $orderId)
     {
         $orderTransaction = $this->orderTransactionRepository->getFirstAdyenOrderTransactionByStates(
-            $orderId, [
-                OrderTransactionStates::STATE_AUTHORIZED,
-                OrderTransactionStates::STATE_IN_PROGRESS
-            ]);
+            $orderId,
+            [OrderTransactionStates::STATE_AUTHORIZED, OrderTransactionStates::STATE_IN_PROGRESS]
+        );
 
         if (isset($orderTransaction)) {
             $isFullAmountAuthorised = $this->adyenPaymentService->isFullAmountAuthorized($orderTransaction);

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -266,13 +266,11 @@ class AdminController
      */
     public function isCaptureAllowed(string $orderId)
     {
-        $orderTransaction = $this->orderTransactionRepository
-            ->getFirstAdyenOrderTransactionByStates($orderId,
-                [
-                    OrderTransactionStates::STATE_AUTHORIZED,
-                    OrderTransactionStates::STATE_IN_PROGRESS
-                ]
-            );
+        $orderTransaction = $this->orderTransactionRepository->getFirstAdyenOrderTransactionByStates(
+            $orderId, [
+                OrderTransactionStates::STATE_AUTHORIZED,
+                OrderTransactionStates::STATE_IN_PROGRESS
+            ]);
 
         if (isset($orderTransaction)) {
             $isFullAmountAuthorised = $this->adyenPaymentService->isFullAmountAuthorized($orderTransaction);

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -34,13 +34,14 @@ use Adyen\Shopware\Service\AdyenPaymentService;
 use Adyen\Shopware\Service\CaptureService;
 use Adyen\Shopware\Service\ConfigurationService;
 use Adyen\Shopware\Service\NotificationService;
-use Adyen\Shopware\Service\PaymentResponseService;
 use Adyen\Shopware\Service\RefundService;
 use Adyen\Shopware\Service\Repository\AdyenPaymentCaptureRepository;
 use Adyen\Shopware\Service\Repository\AdyenRefundRepository;
 use Adyen\Shopware\Service\Repository\OrderRepository;
+use Adyen\Shopware\Service\Repository\OrderTransactionRepository;
 use Adyen\Util\Currency;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
@@ -94,6 +95,9 @@ class AdminController
     /** @var AdyenPaymentService */
     private $adyenPaymentService;
 
+    /** @var OrderTransactionRepository */
+    private $orderTransactionRepository;
+
     /**
      * AdminController constructor.
      *
@@ -108,6 +112,7 @@ class AdminController
      * @param Currency $currencyUtil
      * @param ConfigurationService $configurationService
      * @param AdyenPaymentService $adyenPaymentService
+     * @param OrderTransactionRepository $orderTransactionRepository
      */
     public function __construct(
         LoggerInterface $logger,
@@ -120,7 +125,8 @@ class AdminController
         CurrencyFormatter $currencyFormatter,
         Currency $currencyUtil,
         ConfigurationService $configurationService,
-        AdyenPaymentService $adyenPaymentService
+        AdyenPaymentService $adyenPaymentService,
+        OrderTransactionRepository $orderTransactionRepository
     ) {
         $this->logger = $logger;
         $this->orderRepository = $orderRepository;
@@ -133,6 +139,7 @@ class AdminController
         $this->currencyUtil = $currencyUtil;
         $this->configurationService = $configurationService;
         $this->adyenPaymentService = $adyenPaymentService;
+        $this->orderTransactionRepository = $orderTransactionRepository;
     }
 
     /**
@@ -204,7 +211,14 @@ class AdminController
         }
 
         $currencyIso = $order->getCurrency()->getIsoCode();
-        $amountInMinorUnit = $this->currencyUtil->sanitize($order->getAmountTotal(), $currencyIso);
+        $adyenPayments = $this->adyenPaymentService->getAdyenPayments($orderId);
+
+        if (isset($adyenPayments)) {
+            // This line assumes there can be only one manual capture partial payment in an order.
+            $amountInMinorUnit = $this->captureService->getRequiredCaptureAmount($orderId);
+        } else {
+            $amountInMinorUnit = $this->currencyUtil->sanitize($order->getAmountTotal(), $currencyIso);
+        }
 
         try {
             $results = $this->captureService
@@ -237,6 +251,46 @@ class AdminController
         $captureRequests = $this->adyenPaymentCaptureRepository->getCaptureRequestsByOrderId($orderId);
 
         return new JsonResponse($this->buildResponseData($captureRequests->getElements()));
+    }
+
+    /**
+     * Get payment capture requests by order
+     *
+     * @Route(
+     *     "/api/adyen/orders/{orderId}/is-capture-allowed",
+     *     name="api.adyen_payment_capture_allowed.get",
+     *     methods={"GET"}
+     * )
+     * @param string $orderId
+     * @return JsonResponse
+     */
+    public function isCaptureAllowed(string $orderId)
+    {
+        $orderTransaction = $this->orderTransactionRepository
+            ->getFirstAdyenOrderTransactionByStates($orderId,
+                [
+                    OrderTransactionStates::STATE_AUTHORIZED,
+                    OrderTransactionStates::STATE_IN_PROGRESS
+                ]
+            );
+
+        if (isset($orderTransaction)) {
+            $isFullAmountAuthorised = $this->adyenPaymentService->isFullAmountAuthorized($orderTransaction);
+            $isRequiredAmountCaptured = $this->captureService->isRequiredAmountCaptured($orderTransaction);
+            $isPaymentMethodSupportsManualCapture = $this->captureService->requiresManualCapture(
+                $orderTransaction->getPaymentMethod()->getHandlerIdentifier()
+            );
+
+            if ($isPaymentMethodSupportsManualCapture && $isFullAmountAuthorised && !$isRequiredAmountCaptured) {
+                $isCaptureAllowed = true;
+            } else {
+                $isCaptureAllowed = false;
+            }
+        } else {
+            $isCaptureAllowed = false;
+        }
+
+        return new JsonResponse($isCaptureAllowed);
     }
 
     /**

--- a/src/Resources/app/administration/src/component/adyen-payment-capture/index.js
+++ b/src/Resources/app/administration/src/component/adyen-payment-capture/index.js
@@ -51,7 +51,7 @@ Component.register('adyen-payment-capture', {
             ],
             showModal: false,
             captureRequests: [],
-            allowCapture: true,
+            allowCapture: false,
             captureEnabled: false,
             errorOccurred: false,
             isLoading: true,
@@ -121,20 +121,14 @@ Component.register('adyen-payment-capture', {
         },
 
         isCaptureAllowed() {
-            let capturableTransactions = this.getAuthorizedAdyenOrderTransaction();
-            let capturePending = this.captureRequests.filter(request => {
-                return "Pending Webhook" === request.status;
-            });
-
-            this.allowCapture = capturableTransactions.length > 0 && capturePending.length === 0;
-        },
-
-        getAuthorizedAdyenOrderTransaction() {
-            return this.order.transactions.filter(transaction => {
-                const isAdyenPayment = 'originalPspReference' in transaction.customFields;
-                const isAuthorized = 'Authorized' === transaction.stateMachineState.name;
-
-                return isAdyenPayment && isAuthorized;
+            this.isLoading = true;
+            this.adyenService.isCaptureAllowed(this.order.id).then((res) => {
+                this.allowCapture = res;
+            }).catch(() => {
+                this.errorOccurred = true;
+                this.allowCapture = false;
+            }).finally(() => {
+                this.isLoading = false;
             });
         }
     },

--- a/src/Resources/app/administration/src/service/adyenService.js
+++ b/src/Resources/app/administration/src/service/adyenService.js
@@ -69,6 +69,21 @@ class ApiClient extends ApiService {
             });
     }
 
+    isCaptureAllowed(orderId) {
+        const headers = this.getBasicHeaders({});
+
+        return this.httpClient
+            .get(this.getApiBasePath() + '/orders/' + orderId + '/is-capture-allowed', {
+                headers
+            })
+            .then((response) => {
+                return ApiService.handleResponse(response);
+            }).catch((error) => {
+                console.error('An error occurred during is-capture-allowed request: ' + error.message);
+                throw error;
+            });
+    }
+
     getRefunds(orderId) {
         const headers = this.getBasicHeaders({});
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -57,6 +57,7 @@
             <argument type="service" id="Adyen\Shopware\Service\Repository\AdyenPaymentCaptureRepository"/>
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="Adyen\Shopware\Service\ClientService"/>
+            <argument type="service" id="Adyen\Shopware\Service\AdyenPaymentService"/>
             <call method="setLogger">
                 <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
             </call>

--- a/src/Resources/config/services/notification-processing.xml
+++ b/src/Resources/config/services/notification-processing.xml
@@ -28,7 +28,7 @@
             <argument type="service" id="Adyen\Shopware\Service\Repository\OrderRepository"/>
             <argument type="service" id="payment_method.repository"/>
             <argument type="service" id="Adyen\Shopware\Service\Repository\OrderTransactionRepository"/>
-            <argument type="service" id="Adyen\Shopware\Service\Repository\AdyenPaymentRepository"/>
+            <argument type="service" id="Adyen\Shopware\Service\AdyenPaymentService"/>
             <argument type="service" id="Adyen\Shopware\Service\CaptureService"/>
             <argument type="service" id="Adyen\Shopware\ScheduledTask\Webhook\WebhookHandlerFactory"/>
             <tag name="messenger.message_handler"/>

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -349,7 +349,9 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
         if ($notification->getEventCode() === EventCodes::ORDER_CLOSED) {
             // get merchant reference from adyen_payment table
             $merchantOrderReference = $notification->getMerchantReference();
-            $merchantReference = $this->adyenPaymentService->getMerchantReferenceFromOrderReference($merchantOrderReference);
+            $merchantReference = $this->adyenPaymentService->getMerchantReferenceFromOrderReference(
+                $merchantOrderReference
+            );
         } else {
             // otherwise get the merchant reference from the notification
             $merchantReference = $notification->getMerchantReference();

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -27,11 +27,11 @@ namespace Adyen\Shopware\ScheduledTask;
 use Adyen\Shopware\Entity\Notification\NotificationEntity;
 use Adyen\Shopware\Exception\CaptureException;
 use Adyen\Shopware\ScheduledTask\Webhook\WebhookHandlerFactory;
+use Adyen\Shopware\Service\AdyenPaymentService;
 use Adyen\Shopware\Service\CaptureService;
 use Adyen\Shopware\Service\NotificationService;
 use Adyen\Shopware\Service\Repository\OrderRepository;
 use Adyen\Shopware\Service\Repository\OrderTransactionRepository;
-use Adyen\Shopware\Service\Repository\AdyenPaymentRepository;
 use Adyen\Webhook\Exception\InvalidDataException;
 use Adyen\Webhook\Notification;
 use Adyen\Webhook\PaymentStates;
@@ -88,9 +88,9 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
     private OrderTransactionRepository $orderTransactionRepository;
 
     /**
-     * @var AdyenPaymentRepository
+     * @var AdyenPaymentService
      */
-    private AdyenPaymentRepository $adyenPaymentRepository;
+    private AdyenPaymentService $adyenPaymentService;
 
     /**
      * @var CaptureService
@@ -121,7 +121,7 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
      * @param OrderRepository $orderRepository
      * @param EntityRepositoryInterface $paymentMethodRepository
      * @param OrderTransactionRepository $orderTransactionRepository
-     * @param AdyenPaymentRepository $adyenPaymentRepository
+     * @param AdyenPaymentService $adyenPaymentService
      * @param CaptureService $captureService
      * @param WebhookHandlerFactory $webhookHandlerFactory
      */
@@ -131,7 +131,7 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
         OrderRepository $orderRepository,
         EntityRepositoryInterface $paymentMethodRepository,
         OrderTransactionRepository $orderTransactionRepository,
-        AdyenPaymentRepository $adyenPaymentRepository,
+        AdyenPaymentService $adyenPaymentService,
         CaptureService $captureService,
         WebhookHandlerFactory $webhookHandlerFactory
     ) {
@@ -140,7 +140,7 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
         $this->orderRepository = $orderRepository;
         $this->paymentMethodRepository = $paymentMethodRepository;
         $this->orderTransactionRepository = $orderTransactionRepository;
-        $this->adyenPaymentRepository = $adyenPaymentRepository;
+        $this->adyenPaymentService = $adyenPaymentService;
         $this->captureService = $captureService;
         self::$webhookHandlerFactory = $webhookHandlerFactory;
     }
@@ -348,8 +348,7 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
         if ($notification->getEventCode() === EventCodes::ORDER_CLOSED) {
             // get merchant reference from adyen_payment table
             $merchantOrderReference = $notification->getMerchantReference();
-            $merchantReference = $this->adyenPaymentRepository
-                ->getMerchantReferenceByMerchantOrderReference($merchantOrderReference);
+            $merchantReference = $this->adyenPaymentService->getMerchantReferenceFromOrderReference($merchantOrderReference);
         } else {
             // otherwise get the merchant reference from the notification
             $merchantReference = $notification->getMerchantReference();

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -204,7 +204,8 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
             } catch (CaptureException $exception) {
                 $this->logger->warning($exception->getMessage(), ['code' => $exception->getCode()]);
                 $scheduledProcessingTime = $this->captureService->getRescheduleNotificationTime();
-                if (CaptureService::REASON_DELIVERY_STATE_MISMATCH === $exception->reason) {
+                if (CaptureService::REASON_DELIVERY_STATE_MISMATCH === $exception->reason ||
+                    CaptureService::REASON_WAITING_AUTH_WEBHOOK === $exception->reason) {
                     $this->rescheduleNotification(
                         $notification->getId(),
                         $notification->getMerchantReference(),

--- a/src/ScheduledTask/Webhook/OrderClosedWebhookHandler.php
+++ b/src/ScheduledTask/Webhook/OrderClosedWebhookHandler.php
@@ -107,9 +107,11 @@ class OrderClosedWebhookHandler implements WebhookHandlerInterface
                 );
 
                 if ($requiredCaptureAmount === 0) {
-                    throw new CaptureException(
+                    $exception = new CaptureException(
                         'There is no adyen payment. Waiting for the authorisation webhook to be processed.'
                     );
+                    $exception->reason = CaptureService::REASON_WAITING_AUTH_WEBHOOK;
+                    throw $exception;
                 }
 
                 $this->captureService->doOpenInvoiceCapture(

--- a/src/Service/AdyenPaymentService.php
+++ b/src/Service/AdyenPaymentService.php
@@ -106,7 +106,8 @@ class AdyenPaymentService
             ->getElements();
     }
 
-    public function isFullAmountAuthorized(OrderTransactionEntity $orderTransactionEntity): bool {
+    public function isFullAmountAuthorized(OrderTransactionEntity $orderTransactionEntity): bool
+    {
         $amountSum = 0;
         $adyenPaymentOrders = $this->adyenPaymentRepository
             ->getAdyenPaymentsByOrderTransaction($orderTransactionEntity->getId());

--- a/src/Service/AdyenPaymentService.php
+++ b/src/Service/AdyenPaymentService.php
@@ -74,6 +74,15 @@ class AdyenPaymentService
         );
     }
 
+    /**
+     * @param string $orderReference
+     * @return string|null
+     */
+    public function getMerchantReferenceFromOrderReference(string $orderReference): ?string
+    {
+        return $this->adyenPaymentRepository->getMerchantReferenceByMerchantOrderReference($orderReference);
+    }
+
     public function getAdyenPayments(string $orderId): array
     {
         $orderTransaction = $this->orderTransactionRepository
@@ -97,13 +106,10 @@ class AdyenPaymentService
             ->getElements();
     }
 
-    public function isFullAmountAuthorized(
-        string $merchantOrderReference,
-        OrderTransactionEntity $orderTransactionEntity
-    ): bool {
+    public function isFullAmountAuthorized(OrderTransactionEntity $orderTransactionEntity): bool {
         $amountSum = 0;
         $adyenPaymentOrders = $this->adyenPaymentRepository
-            ->getAdyenPaymentsByMerchantOrderReference($merchantOrderReference);
+            ->getAdyenPaymentsByOrderTransaction($orderTransactionEntity->getId());
 
         foreach ($adyenPaymentOrders as $adyenPaymentOrder) {
             $amountSum += $adyenPaymentOrder->getAmountValue();

--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -291,7 +291,7 @@ class CaptureService
 
     private function getLineItemsArray(
         ?OrderLineItemCollection $lineItems,
-                                 $currencyCode
+        string $currencyCode
     ): array {
         $lineItemsArray = [];
         $lineIndex = 0;
@@ -317,7 +317,7 @@ class CaptureService
 
     private function buildCaptureRequest(
         string $originalReference,
-               $captureAmountInMinorUnits,
+        $captureAmountInMinorUnits,
         string $currency,
         string $salesChannelId,
         ?array $additionalData = null

--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -31,6 +31,7 @@ use Adyen\Shopware\Entity\AdyenPayment\AdyenPaymentEntity;
 use Adyen\Shopware\Entity\Notification\NotificationEntity;
 use Adyen\Shopware\Entity\PaymentCapture\PaymentCaptureEntity;
 use Adyen\Shopware\Exception\CaptureException;
+use Adyen\Shopware\Handlers\AbstractPaymentMethodHandler;
 use Adyen\Shopware\Handlers\PaymentResponseHandler;
 use Adyen\Shopware\Service\Repository\AdyenPaymentCaptureRepository;
 use Adyen\Shopware\Service\Repository\OrderRepository;
@@ -297,7 +298,7 @@ class CaptureService
         $lineIndex = 0;
         foreach ($lineItems as $lineItem) {
             // Skip non-product line items.
-            if (empty($lineItem->getProductId()) || $lineItem->getType() !== LineItem::PRODUCT_LINE_ITEM_TYPE) {
+            if (!in_array($lineItem->getType(), AbstractPaymentMethodHandler::ALLOWED_LINE_ITEM_TYPES)) {
                 continue;
             }
 

--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -50,6 +50,7 @@ class CaptureService
     use LoggerAwareTrait;
 
     const REASON_DELIVERY_STATE_MISMATCH = 'DELIVERY_STATE_MISMATCH';
+    const REASON_WAITING_AUTH_WEBHOOK = 'WAITING_AUTH_WEBHOOK';
 
     private OrderRepository $orderRepository;
     private OrderTransactionRepository $orderTransactionRepository;
@@ -305,7 +306,8 @@ class CaptureService
             $lineItemsArray[$key . '.itemVatPercentage'] = $lineItem->getPrice()->getTaxRules()
                     ->highestRate()->getPercentage() * 10;
             $lineItemsArray[$key . '.description'] = $lineItem->getLabel();
-            $lineItemsArray[$key . '.itemVatAmount'] = $lineItem->getPrice()->getCalculatedTaxes()->getAmount() * 100;
+            $lineItemsArray[$key . '.itemVatAmount'] =
+                intval($lineItem->getPrice()->getCalculatedTaxes()->getAmount() * 100);
             $lineItemsArray[$key . '.currencyCode'] = $currencyCode;
             $lineItemsArray[$key . '.numberOfItems'] = $lineItem->getQuantity();
         }

--- a/src/Service/Repository/AdyenPaymentCaptureRepository.php
+++ b/src/Service/Repository/AdyenPaymentCaptureRepository.php
@@ -24,6 +24,7 @@
 
 namespace Adyen\Shopware\Service\Repository;
 
+use Adyen\Shopware\Entity\PaymentCapture\PaymentCaptureEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
@@ -52,15 +53,20 @@ class AdyenPaymentCaptureRepository
      * Get all captures linked to an order, based on the order id
      *
      * @param string $orderId
+     * @param bool|null $isOnlySuccess
      * @return EntityCollection
      */
-    public function getCaptureRequestsByOrderId(string $orderId): EntityCollection
+    public function getCaptureRequestsByOrderId(string $orderId, bool $isOnlySuccess = null): EntityCollection
     {
         $criteria = new Criteria();
         $criteria->addAssociation('orderTransaction');
         $criteria->addAssociation('orderTransaction.order');
         $criteria->addAssociation('orderTransaction.order.currency');
         $criteria->addFilter(new EqualsFilter('orderTransaction.order.id', $orderId));
+
+        if ($isOnlySuccess === true) {
+            $criteria->addFilter(new EqualsFilter('status', PaymentCaptureEntity::STATUS_SUCCESS));
+        }
 
         return $this->repository->search($criteria, Context::createDefaultContext());
     }

--- a/src/Service/Repository/AdyenPaymentRepository.php
+++ b/src/Service/Repository/AdyenPaymentRepository.php
@@ -62,13 +62,13 @@ class AdyenPaymentRepository
     }
 
     /**
-     * @param string $merchantReference
+     * @param string $orderTransactionId
      * @return EntityCollection
      */
-    public function getAdyenPaymentsByMerchantOrderReference(string $merchantOrderReference): EntityCollection
+    public function getAdyenPaymentsByOrderTransaction(string $orderTransactionId): EntityCollection
     {
         $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('merchantOrderReference', $merchantOrderReference));
+        $criteria->addFilter(new EqualsFilter('orderTransactionId', $orderTransactionId));
 
         return $this->repository->search($criteria, Context::createDefaultContext());
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

1. In order to capture a payment, full amount should be authorised first.
2. Capture request can be sent from admin order details if only the payment method supports manual capture, full amount is authorised and required amount is not captured yet.
3. If full amount has not been captured successfully (failed capture webhook), sequential capture requests can be sent.
4. Only `requiredCaptureAmount` can be captured for an order. This `requiredCaptureAmount` is obtained from `AdyenPaymentEntity` with manual capture mode payments only.
5. ORDER_CLOSED webhook was fixed for manual capture to use correct merchant reference and capture amount based on the`requiredCaptureAmount` for that transaction.

Notes
1. Manual capture requires the correct shipment state. If that state isn’t satisfied,
 - Capture attempt from admin order detail page will fail.
 - `AUTHORISATION` notification will be re-scheduled to time according to the `capture_delay` config value. But, order status will be marked as `AUTHORISED`.
 - `ORDER_CLOSED` notification will be re-scheduled to time according to the `capture_delay` config value.
 - `Authorisation` and `ORDER_CLOSED` webhooks are being rescheduled for triggering capture again.
2. Plugin assumes giftcards can’t be captured manually.
3. If capture mode is manual, `AUTHORISATION` notification won’t change the payment state to `PAID` but it will trigger a capture request. Capture webhook will update the payment state.

## Tested scenarios
<!-- Description of tested scenarios -->
- Auto capture payments (Cards)
- Manual capture payments (Klarna and Klarna + giftcard)
