### PR TITLE
[PW-8339] Add unique constraint pspreference to adyen_payment table

### DIFF
--- a/src/Migration/Migration1681716164AlterAdyenPayment.php
+++ b/src/Migration/Migration1681716164AlterAdyenPayment.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Adyen\Shopware\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1681716164AlterAdyenPayment extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1681716164;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $query = <<<SQL
+            ALTER TABLE `adyen_payment` ADD CONSTRAINT `UQ_ADYEN_PAYMENT_PSPREFERENCE` UNIQUE (`pspreference`)
+        SQL;
+
+        $connection->executeUpdate($query);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/ScheduledTask/Webhook/AuthorisationWebhookHandler.php
+++ b/src/ScheduledTask/Webhook/AuthorisationWebhookHandler.php
@@ -31,7 +31,6 @@ use Adyen\Shopware\Service\CaptureService;
 use Adyen\Shopware\Service\AdyenPaymentService;
 use Adyen\Shopware\Service\PluginPaymentMethodsService;
 use Adyen\Util\Currency;
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;

--- a/src/Service/AdyenPaymentService.php
+++ b/src/Service/AdyenPaymentService.php
@@ -24,6 +24,7 @@
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\Shopware\Entity\AdyenPayment\AdyenPaymentEntity;
 use Adyen\Shopware\Entity\Notification\NotificationEntity;
 use Adyen\Shopware\Service\Repository\AdyenPaymentRepository;
 use Adyen\Util\Currency;
@@ -104,6 +105,20 @@ class AdyenPaymentService
                 Context::createDefaultContext()
             )
             ->getElements();
+    }
+
+    /**
+     * @param string $pspreference
+     * @return AdyenPaymentEntity|null
+     */
+    public function getAdyenPayment(string $pspreference): ?AdyenPaymentEntity
+    {
+        return $this->adyenPaymentRepository->getRepository()
+            ->search(
+                (new Criteria())->addFilter(new EqualsFilter('pspreference', $pspreference)),
+                Context::createDefaultContext()
+            )
+            ->first();
     }
 
     public function isFullAmountAuthorized(OrderTransactionEntity $orderTransactionEntity): bool


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Unique constraint added to `adyen_payment` table to block duplicate entries for the same (partial or normal) payment.

`AuthorisationWebhookHandler` updated regarding to this requirement.

## Tested scenarios
<!-- Description of tested scenarios -->
- Authorisation webhook processing
- Delayed capture after shipment