### PR TITLE
[PW-8325] Allow re-selecting giftcard payment method

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -25,7 +25,7 @@ jobs:
           docker pull dockware/dev:6.4.20.1
           docker run --rm -p 443:443 --name shopware6 \
             --mount type=bind,source="$(pwd)",target=/data/extensions/workdir \
-            --env PHP_VERSION=7.4 -d dockware/dev:latest
+            --env PHP_VERSION=7.4 -d dockware/dev:6.4.20.1
           sleep 30
           docker logs shopware6
           docker exec shopware6 bash -c "mysql -u root -proot shopware -e \"UPDATE sales_channel_domain SET url='https://local.shopware.shop' WHERE url NOT LIKE 'default.%';\""

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Initiate Dockware
         run: |
-          docker pull dockware/dev:latest
+          docker pull dockware/dev:6.4.20.1
           docker run --rm -p 443:443 --name shopware6 \
             --mount type=bind,source="$(pwd)",target=/data/extensions/workdir \
             --env PHP_VERSION=7.4 -d dockware/dev:latest

--- a/src/Service/PaymentMethodsFilterService.php
+++ b/src/Service/PaymentMethodsFilterService.php
@@ -68,7 +68,7 @@ class PaymentMethodsFilterService
         SalesChannelContext $salesChannelContext,
         string $adyenPluginId,
         array $adyenPaymentMethods = [],
-        string $giftcardSelected = null
+        string $giftcardId = null
     ): PaymentMethodCollection {
         if (empty($adyenPaymentMethods)) {
             // Get Adyen /paymentMethods response
@@ -98,8 +98,8 @@ class PaymentMethodsFilterService
                         $originalPaymentMethods->remove($paymentMethodEntity->getId());
                     }
                 } elseif ($pmHandlerIdentifier::$isGiftCard) {
-                    if (isset($giftcardSelected) &&
-                        $giftcardSelected !== $paymentMethodEntity->getId()) {
+                    if (isset($giftcardId) &&
+                        $giftcardId !== $paymentMethodEntity->getId()) {
                         $originalPaymentMethods->remove($paymentMethodEntity->getId());
                     }
                     // Remove ApplePay PM if the browser is not Safari

--- a/src/Service/PaymentMethodsFilterService.php
+++ b/src/Service/PaymentMethodsFilterService.php
@@ -68,7 +68,7 @@ class PaymentMethodsFilterService
         SalesChannelContext $salesChannelContext,
         string $adyenPluginId,
         array $adyenPaymentMethods = [],
-        bool $giftcardSelected = false
+        string $giftcardSelected = null
     ): PaymentMethodCollection {
         if (empty($adyenPaymentMethods)) {
             // Get Adyen /paymentMethods response
@@ -98,9 +98,8 @@ class PaymentMethodsFilterService
                         $originalPaymentMethods->remove($paymentMethodEntity->getId());
                     }
                 } elseif ($pmHandlerIdentifier::$isGiftCard) {
-                    // Remove giftcards from checkout list, except the selected giftcard
-                    if (!$giftcardSelected ||
-                        $salesChannelContext->getPaymentMethod()->getId() !== $paymentMethodEntity->getId()) {
+                    if (isset($giftcardSelected) &&
+                        $giftcardSelected !== $paymentMethodEntity->getId()) {
                         $originalPaymentMethods->remove($paymentMethodEntity->getId());
                     }
                     // Remove ApplePay PM if the browser is not Safari

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -341,7 +341,7 @@ class PaymentSubscriber extends StorefrontSubscriber implements EventSubscriberI
             $giftcardSelectedId
         );
 
-        if (is_null($giftcardSelectedId) && $adyenGiftcardSelected) {
+        if (!isset($giftcardSelectedId) && $adyenGiftcardSelected) {
             $selectedPaymentMethod = $filteredPaymentMethods->first();
             $this->contextSwitchRoute->switchContext(
                 new RequestDataBag(

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -323,14 +323,14 @@ class PaymentSubscriber extends StorefrontSubscriber implements EventSubscriberI
         $giftcardData = $this->paymentStateDataService
             ->getPaymentStateDataFromContextToken($salesChannelContext->getToken());
         $giftcardDiscount = 0;
-        $payInFullWithGiftcard = false;
+        $giftcardSelectedId = null;
         $adyenGiftcardSelected = ($selectedPaymentMethod->getPluginId() === $adyenPluginId)
             && $selectedPaymentMethod->getHandlerIdentifier()::$isGiftCard;
         if ($giftcardData) {
             $stateData = $giftcardData->getStateData();
             $giftcardDiscount = json_decode($stateData, true)['additionalData']['amount'] ?? 0;
             if ($giftcardDiscount >= $amount) {
-                $payInFullWithGiftcard = true;
+                $giftcardSelectedId = json_decode($stateData, true)['additionalData']['paymentMethodId'];
             }
         }
         $filteredPaymentMethods = $this->paymentMethodsFilterService->filterShopwarePaymentMethods(
@@ -338,10 +338,10 @@ class PaymentSubscriber extends StorefrontSubscriber implements EventSubscriberI
             $salesChannelContext,
             $adyenPluginId,
             $paymentMethodsResponse,
-            $payInFullWithGiftcard
+            $giftcardSelectedId
         );
 
-        if (!$payInFullWithGiftcard && $adyenGiftcardSelected) {
+        if (is_null($giftcardSelectedId) && $adyenGiftcardSelected) {
             $selectedPaymentMethod = $filteredPaymentMethods->first();
             $this->contextSwitchRoute->switchContext(
                 new RequestDataBag(
@@ -396,7 +396,7 @@ class PaymentSubscriber extends StorefrontSubscriber implements EventSubscriberI
                         'totalPrice' => $totalPrice,
                         'giftcardDiscount' => $giftcardDiscount,
                         'currencySymbol' => $currencySymbol,
-                        'payInFullWithGiftcard' => (int) $payInFullWithGiftcard,
+                        'payInFullWithGiftcard' => (int) isset($giftcardSelectedId),
                         'adyenGiftcardSelected' => (int) $adyenGiftcardSelected,
                         'storedPaymentMethods' => $paymentMethodsResponse['storedPaymentMethods'] ?? [],
                         'selectedPaymentMethodHandler' => $selectedPaymentMethod->getFormattedHandlerIdentifier(),


### PR DESCRIPTION
## Summary
In the current flow of the Shopware 6 giftcard implementation, if the full amount is covered by a giftcard, this giftcard payment method appears on the checkout as pre-selected and the shopper can complete the payment.

However, if the shopper selects another payment method, this giftcard payment method disappears from the checkout due to our filtering and it is not possible to select that giftcard payment method again, although the state data is still in the database.

This PR fixes the above so when the shopper selects another payment method in the checkout page, the redeemed giftcard is still shown in the list of payment methods on the mentioned page.

## Tested scenarios
- redeem a giftcard, proceed to the checkout page
- select another payment method and observe the redeemed giftcard still listen in the payment method options of the checkout page
