### PR TITLE
[PW-8365] Check if updatedAt exists before formatting in AdminController

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -545,7 +545,8 @@ class AdminController
                 $this->notificationService->changeNotificationState(
                     $notification->getId(),
                     'processing',
-                    false);
+                    false
+                );
             }
             $this->notificationService->setNotificationSchedule($notification->getId(), $scheduledProcessingTime);
         }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -442,7 +442,9 @@ class AdminController
                     ? NotificationEntity::NOTIFICATION_STATUS_PROCESSED
                     : NotificationEntity::NOTIFICATION_STATUS_PENDING,
                 'createdAt' => $notification->getCreatedAt()->format(self::ADMIN_DATETIME_FORMAT),
-                'updatedAt' => $notification->getUpdatedAt() ? $notification->getUpdatedAt()->format(self::ADMIN_DATETIME_FORMAT) : '',
+                'updatedAt' => $notification->getUpdatedAt()
+                    ? $notification->getUpdatedAt()->format(self::ADMIN_DATETIME_FORMAT)
+                    : '',
                 'notificationId' => $notification->getId(),
                 'canBeRescheduled' => $this->notificationService->canBeRescheduled($notification),
                 'errorCount' => $notification->getErrorCount(),
@@ -540,7 +542,10 @@ class AdminController
             );
             // If notification was stuck in state Processing=true, reset the state and reschedule.
             if ($notification->getProcessing()) {
-                $this->notificationService->changeNotificationState($notification->getId(), 'processing', false);
+                $this->notificationService->changeNotificationState(
+                    $notification->getId(),
+                    'processing',
+                    false);
             }
             $this->notificationService->setNotificationSchedule($notification->getId(), $scheduledProcessingTime);
         }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -442,7 +442,7 @@ class AdminController
                     ? NotificationEntity::NOTIFICATION_STATUS_PROCESSED
                     : NotificationEntity::NOTIFICATION_STATUS_PENDING,
                 'createdAt' => $notification->getCreatedAt()->format(self::ADMIN_DATETIME_FORMAT),
-                'updatedAt' => $notification->getUpdatedAt()->format(self::ADMIN_DATETIME_FORMAT),
+                'updatedAt' => $notification->getUpdatedAt() ? $notification->getUpdatedAt()->format(self::ADMIN_DATETIME_FORMAT) : '',
                 'notificationId' => $notification->getId(),
                 'canBeRescheduled' => $this->notificationService->canBeRescheduled($notification),
                 'errorCount' => $notification->getErrorCount(),


### PR DESCRIPTION
## Summary
In cases where the value of `updatedAt` field in the `adyen_notification` db table was null or undefined, this would cause an exception being thrown. The issue is fixed with this PR using a null-coalescing operator, as null-safe operator doesn't work prior to PHP v8.0.

## Tested scenarios
- manually remove the content of the `updatedAt` field of the `adyen_notification` db table and refresh the order review page of the admin panel. Make sure no errors/exceptions are thrown

Fixes #270 
