### PR TITLE
[PW-8325] remove all giftcards from checkout when no giftcard is saved

### DIFF
--- a/src/Service/PaymentMethodsFilterService.php
+++ b/src/Service/PaymentMethodsFilterService.php
@@ -98,8 +98,7 @@ class PaymentMethodsFilterService
                         $originalPaymentMethods->remove($paymentMethodEntity->getId());
                     }
                 } elseif ($pmHandlerIdentifier::$isGiftCard) {
-                    if (isset($giftcardId) &&
-                        $giftcardId !== $paymentMethodEntity->getId()) {
+                    if ($giftcardId !== $paymentMethodEntity->getId()) {
                         $originalPaymentMethods->remove($paymentMethodEntity->getId());
                     }
                     // Remove ApplePay PM if the browser is not Safari


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This is a minor update to our fix in #378. After this fix, all giftcard PMs are shown in checkout when the shopper doesn't apply any giftcard.
This fix removes all giftcard payment methods from the checkout and only shows the applicable giftcard when one exists for the shopper's session.



