### PR TITLE
[ECP-8363] Support Click-to-Pay

### DIFF
--- a/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
+++ b/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js
@@ -82,7 +82,7 @@ export default class ConfirmOrderPlugin extends Plugin {
     }
 
     async initializeCheckoutComponent () {
-        const { locale, clientKey, environment } = adyenCheckoutConfiguration;
+        const { locale, clientKey, environment, merchantAccount } = adyenCheckoutConfiguration;
         const paymentMethodsResponse = adyenCheckoutOptions.paymentMethodsResponse;
         const ADYEN_CHECKOUT_CONFIG = {
             locale,
@@ -96,9 +96,14 @@ export default class ConfirmOrderPlugin extends Plugin {
             paymentMethodsConfiguration: {
                 card: {
                     hasHolderName: true,
+                    clickToPayConfiguration: {
+                        merchantDisplayName: merchantAccount,
+                        shopperEmail: shopperDetails.shopperEmail
+                    }
                 }
             },
         };
+
         this.adyenCheckout = await AdyenCheckout(ADYEN_CHECKOUT_CONFIG);
     }
 

--- a/src/Resources/views/storefront/component/adyencheckout.html.twig
+++ b/src/Resources/views/storefront/component/adyencheckout.html.twig
@@ -4,6 +4,7 @@
              data-locale="{{ adyenFrontendData.locale }}"
              data-client-key="{{ adyenFrontendData.clientKey }}"
              data-environment="{{ adyenFrontendData.environment }}"
+             data-merchant-account="{{ adyenFrontendData.merchantAccount }}"
         ></div>
         {# Load checkout web component v5.19.0 #}
         <link rel="stylesheet" href="{{ asset('bundles/adyenpaymentshopware6/css/adyen.css', 'asset') }}">

--- a/src/Subscriber/PaymentSubscriber.php
+++ b/src/Subscriber/PaymentSubscriber.php
@@ -193,6 +193,7 @@ class PaymentSubscriber extends StorefrontSubscriber implements EventSubscriberI
             'clientKey' => $this->configurationService->getClientKey($salesChannelId),
             'locale' => $this->salesChannelRepository->getSalesChannelLocale($salesChannelContext),
             'environment' => $this->configurationService->getEnvironment($salesChannelId),
+            'merchantAccount' => $this->configurationService->getMerchantAccount($salesChannelId)
         ];
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
An implementation of Click-to-pay feature on storefront, which automatically grabs the visa/mastercard token (if it exists) for the current shopper, avoiding the shopper having to manually enter the card details. 

## Tested scenarios

1. Tested with a shopper id that has existing card token
2. Tested with a shopper id that does not
