### PR TITLE
[ECP-8452] Update maximum giftcard discount allowed to transaction limit

### DIFF
--- a/src/Resources/app/storefront/src/cart/cart.plugin.js
+++ b/src/Resources/app/storefront/src/cart/cart.plugin.js
@@ -137,12 +137,7 @@ export default class CartPlugin extends Plugin {
                     reject(response.resultCode);
                 } else {
                     // 0. compare balance to total amount to be paid
-                    if (response.transactionLimit) {
-                        const consumableBalance = parseFloat(response.transactionLimit.value);
-                    } else {
-                        const consumableBalance = parseFloat(response.balance.value);
-                    }
-
+                    const consumableBalance = response.transactionLimit ? parseFloat(response.transactionLimit.value) : parseFloat(response.balance.value);
                     let remainingGiftcardBalanceMinorUnits = (consumableBalance - adyenGiftcardsConfiguration.totalInMinorUnits);
                     if (consumableBalance >= adyenGiftcardsConfiguration.totalInMinorUnits) {
                         this.remainingGiftcardBalance = (remainingGiftcardBalanceMinorUnits / this.minorUnitsQuotient).toFixed(2);

--- a/src/Resources/app/storefront/src/cart/cart.plugin.js
+++ b/src/Resources/app/storefront/src/cart/cart.plugin.js
@@ -137,14 +137,19 @@ export default class CartPlugin extends Plugin {
                     reject(response.resultCode);
                 } else {
                     // 0. compare balance to total amount to be paid
-                    const balance = parseFloat(response.balance.value);
-                    let remainingGiftcardBalanceMinorUnits = (balance - adyenGiftcardsConfiguration.totalInMinorUnits);
-                    if (balance >= adyenGiftcardsConfiguration.totalInMinorUnits) {
+                    if (response.transactionLimit) {
+                        const consumableBalance = parseFloat(response.transactionLimit.value);
+                    } else {
+                        const consumableBalance = parseFloat(response.balance.value);
+                    }
+
+                    let remainingGiftcardBalanceMinorUnits = (consumableBalance - adyenGiftcardsConfiguration.totalInMinorUnits);
+                    if (consumableBalance >= adyenGiftcardsConfiguration.totalInMinorUnits) {
                         this.remainingGiftcardBalance = (remainingGiftcardBalanceMinorUnits / this.minorUnitsQuotient).toFixed(2);
                         this.setGiftcardAsPaymentMethod(data, remainingGiftcardBalanceMinorUnits);
                     } else {
-                        this.remainingAmount = ((adyenGiftcardsConfiguration.totalInMinorUnits - balance) / this.minorUnitsQuotient).toFixed(2);
-                        this.saveGiftcardStateData(data, balance.toString(), 0, this.selectedGiftcard.id);
+                        this.remainingAmount = ((adyenGiftcardsConfiguration.totalInMinorUnits - consumableBalance) / this.minorUnitsQuotient).toFixed(2);
+                        this.saveGiftcardStateData(data, consumableBalance.toString(), 0, this.selectedGiftcard.id);
                     }
 
                     this.remainingBalanceField.style.display = 'block';


### PR DESCRIPTION
## Summary
For when redeeming giftcards during checkout, If there is a transaction limit specified, use that as a balance amount instead of the actual balance on the gift card.

## Tested scenarios
1. When product price is less than the transaction limit
2. When product price is greater than the transaction limit
3. When the transaction limit is same as balance 

