### PR TITLE
[ECP-8561] Move API logging functionality to plugin

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -26,6 +26,7 @@
 namespace Adyen\Shopware\Handlers;
 
 use Adyen\AdyenException;
+use Adyen\Client;
 use Adyen\Service\Builder\Address;
 use Adyen\Service\Builder\Browser;
 use Adyen\Service\Builder\Customer;
@@ -324,7 +325,19 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
         }
 
         try {
+            $this->clientService->logRequest(
+                $request,
+                Client::API_CHECKOUT_VERSION,
+                '/payments',
+                $salesChannelContext->getSalesChannelId()
+            );
+
             $response = $this->checkoutService->payments($request);
+
+            $this->clientService->logResponse(
+                $response,
+                $salesChannelContext->getSalesChannelId()
+            );
         } catch (AdyenException $exception) {
             $message = sprintf(
                 "There was an error with the /payments request. Order number %s: %s",

--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -149,7 +149,20 @@ class CaptureService
                     $additionalData
                 );
 
+                $this->clientService->logRequest(
+                    $request,
+                    Client::API_PAYMENT_VERSION,
+                    '/pal/servlet/Payment/{version}/capture',
+                    $order->getSalesChannelId()
+                );
+
                 $response = $this->sendCaptureRequest($client, $request);
+
+                $this->clientService->logResponse(
+                    $response,
+                    $order->getSalesChannelId()
+                );
+
                 if ('[capture-received]' === $response['response']) {
                     $this->saveCaptureRequest(
                         $orderTransaction,

--- a/src/Service/ClientService.php
+++ b/src/Service/ClientService.php
@@ -208,7 +208,7 @@ class ClientService
      */
     private function filterReferences(array $data): array
     {
-        return array_filter($data, function($value, $key) {
+        return array_filter($data, function ($value, $key) {
             // Keep only reference keys, e.g. reference, pspReference, merchantReference etc.
             return false !== strpos(strtolower($key), 'reference');
         }, ARRAY_FILTER_USE_BOTH);

--- a/src/Service/ClientService.php
+++ b/src/Service/ClientService.php
@@ -24,6 +24,7 @@
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\AdyenException;
 use Adyen\Client;
 use Adyen\Environment;
 use Psr\Log\LoggerInterface;
@@ -96,11 +97,14 @@ class ClientService
         $this->shopwareVersion = $shopwareVersion;
     }
 
+    /**
+     * @throws AdyenException
+     */
     public function getClient($salesChannelId)
     {
         try {
             if (empty($salesChannelId)) {
-                throw new \Adyen\AdyenException('The sales channel ID has not been configured.');
+                throw new AdyenException('The sales channel ID has not been configured.');
             }
             $environment = $this->configurationService->getEnvironment($salesChannelId);
             $apiKey = $this->configurationService->getApiKey($salesChannelId);
@@ -111,8 +115,6 @@ class ClientService
             $client->setMerchantApplication(self::MERCHANT_APPLICATION_NAME, $this->getModuleVersion());
             $client->setExternalPlatform(self::EXTERNAL_PLATFORM_NAME, $this->shopwareVersion);
             $client->setEnvironment($environment, $liveEndpointUrlPrefix);
-
-            $client->setLogger($this->apiLogger);
 
             return $client;
         } catch (\Exception $e) {
@@ -157,5 +159,58 @@ class ClientService
         }
 
         return $pluginVersion;
+    }
+
+    /**
+     * @param array $request
+     * @param string $apiVersion
+     * @param string $endpoint
+     * @param string $salesChannelId
+     * @return void
+     */
+    public function logRequest(array $request, string $apiVersion, string $endpoint, string $salesChannelId)
+    {
+        $environment = $this->configurationService->getEnvironment($salesChannelId);
+        $context = ['apiVersion' => $apiVersion];
+
+        if ($environment === Environment::TEST) {
+            $context['body'] = $request;
+        } else {
+            $context['livePrefix'] = $this->configurationService->getLiveEndpointUrlPrefix($salesChannelId);
+            $context['body'] = $this->filterReferences($request);
+        }
+
+        $this->apiLogger->info('Request to Adyen API ' . $endpoint, $context);
+    }
+
+    /**
+     * @param array $response
+     * @param string $salesChannelId
+     * @return void
+     */
+    public function logResponse(array $response, string $salesChannelId)
+    {
+        $environment = $this->configurationService->getEnvironment($salesChannelId);
+        $context = [];
+
+        if ($environment === Environment::TEST) {
+            $context['body'] = $response;
+        } else {
+            $context['body'] = $this->filterReferences($response);
+        }
+
+        $this->apiLogger->info('Response from Adyen API', $context);
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    private function filterReferences(array $data): array
+    {
+        return array_filter($data, function($value, $key) {
+            // Keep only reference keys, e.g. reference, pspReference, merchantReference etc.
+            return false !== strpos(strtolower($key), 'reference');
+        }, ARRAY_FILTER_USE_BOTH);
     }
 }

--- a/src/Service/DonationService.php
+++ b/src/Service/DonationService.php
@@ -23,6 +23,7 @@
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\Client;
 use Adyen\Shopware\Handlers\AbstractPaymentMethodHandler;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -101,7 +102,20 @@ class DonationService
             $checkoutService = new CheckoutService(
                 $this->clientService->getClient($context->getSalesChannel()->getId())
             );
+
+            $this->clientService->logRequest(
+                $requestData,
+                Client::API_CHECKOUT_VERSION,
+                '/donations',
+                $context->getSalesChannelId()
+            );
+
             $responseData = $checkoutService->donations($requestData);
+
+            $this->clientService->logResponse(
+                $responseData,
+                $context->getSalesChannelId()
+            );
         }
 
         return $responseData;

--- a/src/Service/OrdersCancelService.php
+++ b/src/Service/OrdersCancelService.php
@@ -23,6 +23,7 @@
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\Client;
 use Adyen\Shopware\Service\Repository\OrderRepository;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -70,7 +71,20 @@ class OrdersCancelService
             $checkoutService = new CheckoutService(
                 $this->clientService->getClient($context->getSalesChannel()->getId())
             );
+
+            $this->clientService->logRequest(
+                $requestData,
+                Client::API_CHECKOUT_VERSION,
+                '/orders/cancel',
+                $context->getSalesChannelId()
+            );
+
             $responseData = $checkoutService->ordersCancel($requestData);
+
+            $this->clientService->logResponse(
+                $responseData,
+                $context->getSalesChannelId()
+            );
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/Service/OrdersService.php
+++ b/src/Service/OrdersService.php
@@ -23,6 +23,7 @@
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\Client;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -62,7 +63,20 @@ class OrdersService
             $checkoutService = new CheckoutService(
                 $this->clientService->getClient($context->getSalesChannel()->getId())
             );
+
+            $this->clientService->logRequest(
+                $requestData,
+                Client::API_CHECKOUT_VERSION,
+                '/orders',
+                $context->getSalesChannelId()
+            );
+
             $responseData = $checkoutService->orders($requestData);
+
+            $this->clientService->logResponse(
+                $responseData,
+                $context->getSalesChannelId()
+            );
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/Service/PaymentDetailsService.php
+++ b/src/Service/PaymentDetailsService.php
@@ -24,6 +24,7 @@
 namespace Adyen\Shopware\Service;
 
 use Adyen\AdyenException;
+use Adyen\Client;
 use Adyen\Shopware\Exception\PaymentFailedException;
 use Adyen\Shopware\Handlers\PaymentResponseHandler;
 use Adyen\Shopware\Handlers\PaymentResponseHandlerResult;
@@ -79,7 +80,21 @@ class PaymentDetailsService
             $checkoutService = new CheckoutService(
                 $this->clientService->getClient($orderTransaction->getOrder()->getSalesChannelId())
             );
+
+            $this->clientService->logRequest(
+                $requestData,
+                Client::API_CHECKOUT_VERSION,
+                '/payments/details',
+                $orderTransaction->getOrder()->getSalesChannelId()
+            );
+
             $response = $checkoutService->paymentsDetails($requestData);
+
+            $this->clientService->logResponse(
+                $response,
+                $orderTransaction->getOrder()->getSalesChannelId()
+            );
+
             return $this->paymentResponseHandler->handlePaymentResponse($response, $orderTransaction);
         } catch (AdyenException $exception) {
             $this->logger->error($exception->getMessage());

--- a/src/Service/PaymentMethodsBalanceService.php
+++ b/src/Service/PaymentMethodsBalanceService.php
@@ -23,6 +23,7 @@
 
 namespace Adyen\Shopware\Service;
 
+use Adyen\Client;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Psr\Log\LoggerInterface;
 
@@ -65,7 +66,20 @@ class PaymentMethodsBalanceService
             $checkoutService = new CheckoutService(
                 $this->clientService->getClient($context->getSalesChannel()->getId())
             );
+
+            $this->clientService->logRequest(
+                $requestData,
+                Client::API_CHECKOUT_VERSION,
+                '/paymentMethods/balance',
+                $context->getSalesChannelId()
+            );
+
             $responseData = $checkoutService->paymentMethodsBalance($requestData);
+
+            $this->clientService->logResponse(
+                $responseData,
+                $context->getSalesChannelId()
+            );
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/Service/PaymentMethodsService.php
+++ b/src/Service/PaymentMethodsService.php
@@ -24,6 +24,7 @@
 namespace Adyen\Shopware\Service;
 
 use Adyen\AdyenException;
+use Adyen\Client;
 use Adyen\Shopware\Service\Repository\OrderRepository;
 use Adyen\Shopware\Service\Repository\SalesChannelRepository;
 use Adyen\Util\Currency;
@@ -129,7 +130,20 @@ class PaymentMethodsService
             $checkoutService = new CheckoutService(
                 $this->clientService->getClient($context->getSalesChannelId())
             );
+
+            $this->clientService->logRequest(
+                $requestData,
+                Client::API_CHECKOUT_VERSION,
+                '/paymentMethods',
+                $context->getSalesChannelId()
+            );
+
             $responseData = $checkoutService->paymentMethods($requestData);
+
+            $this->clientService->logResponse(
+                $responseData,
+                $context->getSalesChannelId()
+            );
 
             $paymentMethodsResponseCache->set(CacheValueCompressor::compress($responseData));
             $this->cache->save($paymentMethodsResponseCache);

--- a/src/Service/RefundService.php
+++ b/src/Service/RefundService.php
@@ -23,6 +23,7 @@
 namespace Adyen\Shopware\Service;
 
 use Adyen\AdyenException;
+use Adyen\Client;
 use Adyen\Service\Modification;
 use Adyen\Shopware\Entity\Notification\NotificationEntity;
 use Adyen\Shopware\Entity\Refund\RefundEntity;
@@ -153,7 +154,21 @@ class RefundService
                 $this->clientService->getClient($order->getSalesChannelId())
             );
 
-            return $modificationService->refund($params, ['idempotencyKey' => $idempotencyKey]);
+            $this->clientService->logRequest(
+                $params,
+                Client::API_PAYMENT_VERSION,
+                '/pal/servlet/Payment/{version}/refund',
+                $order->getSalesChannelId()
+            );
+
+            $response = $modificationService->refund($params, ['idempotencyKey' => $idempotencyKey]);
+
+            $this->clientService->logResponse(
+                $response,
+                $order->getSalesChannelId()
+            );
+
+            return $response;
         } catch (AdyenException $e) {
             $this->logger->error($e->getMessage());
             throw $e;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Logging functionality was removed completely from Adyen PHP API Library. Shopware 6 plugin used to use the logger in the library to log requests and responses. 

API logging functionality migrated to application and library logging dependency removed.