### PR TITLE
[ECP-8574] Remove deprecated CANCELLED webhook event

### DIFF
--- a/src/ScheduledTask/Webhook/WebhookHandlerFactory.php
+++ b/src/ScheduledTask/Webhook/WebhookHandlerFactory.php
@@ -136,7 +136,6 @@ class WebhookHandlerFactory
             case EventCodes::OFFER_CLOSED:
                 $handler = new OfferClosedWebhookHandler(self::$orderTransactionStateHandler);
                 break;
-            case EventCodes::CANCELLED:
             case EventCodes::CANCELLATION:
                 $handler = new CancellationWebhookHandler(self::$orderTransactionStateHandler);
                 break;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
`CANCELLED` webhook event removed from the plugin due the deprecation in webhook module. Detailed information on event codes can be found on [docs](https://docs.adyen.com/development-resources/webhooks/webhook-types/).

## Tested scenarios
<!-- Description of tested scenarios -->
- Webhook processing