### PR TITLE
Prevent PHP error if response is missing data.

### DIFF
--- a/src/Service/PaymentMethodsFilterService.php
+++ b/src/Service/PaymentMethodsFilterService.php
@@ -211,7 +211,7 @@ class PaymentMethodsFilterService
 
     public function filterAdyenPaymentMethodsByType(array $paymentMethodsResponse, string $type): array
     {
-        return array_filter($paymentMethodsResponse['paymentMethods'], function ($item) use ($type) {
+        return array_filter($paymentMethodsResponse['paymentMethods'] ?? [], function ($item) use ($type) {
             return $item['type'] === $type;
         });
     }


### PR DESCRIPTION
This changes prevents a PHP error if the response does not have the array key requested. This is in my opinion necessary as in other places, the code explicitly checks if $adyenPaymentMethods['paymentMethods'] is empty or not.