### PR TITLE
[ECP-8333] Fix disappearing giftcard discount data after login

### DIFF
--- a/src/Resources/config/services/subscribers.xml
+++ b/src/Resources/config/services/subscribers.xml
@@ -32,6 +32,10 @@
         <service id="Adyen\Shopware\Subscriber\ContextSubscriber">
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="Adyen\Shopware\Service\PaymentStateDataService"/>
+            <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\CartPersister"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\CartCalculator"/>
+            <argument type="service" id="Adyen\Util\Currency"/>
             <tag name="kernel.event_subscriber"/>
         </service>
         <service id="Adyen\Shopware\Subscriber\Response\PaymentMethodRouteResponseSubscriber">

--- a/src/Subscriber/ContextSubscriber.php
+++ b/src/Subscriber/ContextSubscriber.php
@@ -24,42 +24,71 @@
 
 namespace Adyen\Shopware\Subscriber;
 
+use Adyen\Shopware\Entity\PaymentStateData\PaymentStateDataEntity;
 use Adyen\Shopware\Service\ConfigurationService;
 use Adyen\Shopware\Service\PaymentStateDataService;
 use Adyen\Shopware\Struct\AdyenContextDataStruct;
+use Adyen\Util\Currency;
+use Shopware\Core\Checkout\Cart\AbstractCartPersister;
+use Shopware\Core\Checkout\Cart\CartCalculator;
+use Shopware\Core\Checkout\Cart\Exception\CartTokenNotFoundException;
 use Shopware\Core\Framework\Routing\Event\SalesChannelContextResolvedEvent;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\Event\SalesChannelContextRestoredEvent;
 use Shopware\Core\System\SalesChannel\Event\SalesChannelContextTokenChangeEvent;
+use Shopware\Core\System\SalesChannel\SalesChannel\AbstractContextSwitchRoute;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ContextSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var ConfigurationService
-     */
-    private $configurationService;
-
-    /**
-     * @var PaymentStateDataService
-     */
-    private $paymentStateDataService;
+    private ConfigurationService $configurationService;
+    private PaymentStateDataService $paymentStateDataService;
+    private AbstractContextSwitchRoute $contextSwitchRoute;
+    private AbstractCartPersister $cartPersister;
+    private CartCalculator $cartCalculator;
+    private Currency $currency;
 
     public function __construct(
         ConfigurationService $configurationService,
-        PaymentStateDataService $paymentStateDataService
+        PaymentStateDataService $paymentStateDataService,
+        AbstractContextSwitchRoute $contextSwitchRoute,
+        AbstractCartPersister $cartPersister,
+        CartCalculator $cartCalculator,
+        Currency $currency
     ) {
         $this->configurationService = $configurationService;
         $this->paymentStateDataService = $paymentStateDataService;
+        $this->contextSwitchRoute = $contextSwitchRoute;
+        $this->cartPersister = $cartPersister;
+        $this->cartCalculator = $cartCalculator;
+        $this->currency = $currency;
     }
 
     public static function getSubscribedEvents()
     {
         return [
             SalesChannelContextResolvedEvent::class => 'addAdyenData',
-            SalesChannelContextTokenChangeEvent::class => 'onContextTokenChange'
+            SalesChannelContextTokenChangeEvent::class => 'onContextTokenChange',
+            SalesChannelContextRestoredEvent::class => 'onContextRestored'
         ];
     }
 
-    public function onContextTokenChange(SalesChannelContextTokenChangeEvent $event)
+    public function onContextRestored(SalesChannelContextRestoredEvent $event): void
+    {
+        $token = $event->getRestoredSalesChannelContext()->getToken();
+        $oldToken = $event->getCurrentSalesChannelContext()->getToken();
+
+        $stateData = $this->paymentStateDataService->getPaymentStateDataFromContextToken($oldToken);
+
+        if ($stateData) {
+            $this->paymentStateDataService->updateStateDataContextToken($stateData, $token);
+            $this->setGiftcardPaymentMethodAfterContextRestored($event->getRestoredSalesChannelContext(), $stateData);
+        }
+    }
+
+    public function onContextTokenChange(SalesChannelContextTokenChangeEvent $event): void
     {
         $token = $event->getCurrentToken();
         $oldToken = $event->getPreviousToken();
@@ -84,5 +113,38 @@ class ContextSubscriber implements EventSubscriberInterface
 
         $data = $this->paymentStateDataService->getPaymentStateDataFromContextToken($context->getToken());
         $extension->setHasPaymentStateData(!empty($data));
+    }
+
+    private function setGiftcardPaymentMethodAfterContextRestored(
+        SalesChannelContext $context,
+        PaymentStateDataEntity $stateData,
+    ): void {
+        $currency = $context->getCurrency()->getIsoCode();
+        $decodedStateData = json_decode($stateData->getStateData(), true);
+
+        try {
+            $cart = $this->cartCalculator->calculate(
+                $this->cartPersister->load($context->getToken(), $context),
+                $context
+            );
+            $totalPrice = $cart->getPrice()->getTotalPrice();
+        } catch (CartTokenNotFoundException $exception) {
+            // No cart information found.
+            return;
+        }
+
+        $amount = $this->currency->sanitize($totalPrice, $currency);
+        $giftcardDiscount = $decodedStateData['additionalData']['amount'] ?? 0;
+
+        if ($giftcardDiscount >= $amount) {
+            $this->contextSwitchRoute->switchContext(
+                new RequestDataBag(
+                    [
+                        SalesChannelContextService::PAYMENT_METHOD_ID => $decodedStateData['additionalData']['paymentMethodId']
+                    ]
+                ),
+                $context
+            );
+        }
     }
 }

--- a/src/Subscriber/ContextSubscriber.php
+++ b/src/Subscriber/ContextSubscriber.php
@@ -117,7 +117,7 @@ class ContextSubscriber implements EventSubscriberInterface
 
     private function setGiftcardPaymentMethodAfterContextRestored(
         SalesChannelContext $context,
-        PaymentStateDataEntity $stateData,
+        PaymentStateDataEntity $stateData
     ): void {
         $currency = $context->getCurrency()->getIsoCode();
         $decodedStateData = json_decode($stateData->getStateData(), true);

--- a/src/Subscriber/ContextSubscriber.php
+++ b/src/Subscriber/ContextSubscriber.php
@@ -140,7 +140,8 @@ class ContextSubscriber implements EventSubscriberInterface
             $this->contextSwitchRoute->switchContext(
                 new RequestDataBag(
                     [
-                        SalesChannelContextService::PAYMENT_METHOD_ID => $decodedStateData['additionalData']['paymentMethodId']
+                        SalesChannelContextService::PAYMENT_METHOD_ID =>
+                            $decodedStateData['additionalData']['paymentMethodId']
                     ]
                 ),
                 $context


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
After login Shopware triggers `SalesChannelContextRestoredEvent` event to update the cart and remove the guest shopper cart. An event listener was created for this event to change the context token in `adyen_payment_state_data` table. Additional function was added to set the payment method to selected Adyen giftcard as this data disappears as well after the login due to context token change.

## Tested scenarios
<!-- Description of tested scenarios -->
- Giftcard payments for guest/logged-in shoppers