### PR TITLE
[ECP-8821] SW6 Tasks remaining in queued and logos not loading in Checkout

### DIFF
--- a/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
@@ -51,7 +51,7 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
      */
     private $paymentMethodRepository;
     /**
-     * @var EntityRepository
+     * @var EntityRepository|\Shopware\Core\Content\Media\DataAbstractionLayer\MediaRepositoryDecorator
      */
     private $mediaRepository;
     /**
@@ -63,7 +63,7 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
         EntityRepository $scheduledTaskRepository,
         MediaService $mediaService,
         EntityRepository $paymentMethodRepository,
-        EntityRepository $mediaRepository,
+        $mediaRepository,
         bool $enableUrlUploadFeature = true
     ) {
         parent::__construct($scheduledTaskRepository);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
 Merchant is on shopware 6.14.2 and they are having an issue where 2 tasks are remaining in queued. This PR solves one of the main issue where fetch_payment_method_logos task is remaining in queued, the logos are not being displayed at checkout. 
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
