### PR TITLE
[ECP-8812] Fix failed authorisation webhook overrides successful payment

### DIFF
--- a/src/Entity/PaymentResponse/PaymentResponseEntity.php
+++ b/src/Entity/PaymentResponse/PaymentResponseEntity.php
@@ -67,6 +67,11 @@ class PaymentResponseEntity extends Entity
     protected $createdAt;
 
     /**
+     * @var string
+     */
+    protected $pspreference;
+
+    /**
      * @return string
      */
     public function getOrderTransactionId(): string
@@ -160,5 +165,21 @@ class PaymentResponseEntity extends Entity
     public function setResponse(string $response): void
     {
         $this->response = $response;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPspreference(): string
+    {
+        return $this->pspreference;
+    }
+
+    /**
+     * @param string $pspreference
+     */
+    public function setPspreference(string $pspreference): void
+    {
+        $this->pspreference = $pspreference;
     }
 }

--- a/src/Entity/PaymentResponse/PaymentResponseEntity.php
+++ b/src/Entity/PaymentResponse/PaymentResponseEntity.php
@@ -168,17 +168,17 @@ class PaymentResponseEntity extends Entity
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getPspreference(): string
+    public function getPspreference(): ?string
     {
         return $this->pspreference;
     }
 
     /**
-     * @param string $pspreference
+     * @param string|null $pspreference
      */
-    public function setPspreference(string $pspreference): void
+    public function setPspreference(?string $pspreference): void
     {
         $this->pspreference = $pspreference;
     }

--- a/src/Entity/PaymentResponse/PaymentResponseEntityDefinition.php
+++ b/src/Entity/PaymentResponse/PaymentResponseEntityDefinition.php
@@ -32,8 +32,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
@@ -67,6 +65,7 @@ class PaymentResponseEntityDefinition extends EntityDefinition
                 OrderTransactionDefinition::class
             ))->addFlags(new Required()),
             new StringField('result_code', 'resultCode'),
+            new StringField('pspreference', 'pspreference'),
             new LongTextField('response', 'response'),
             new CreatedAtField(),
             new UpdatedAtField(),

--- a/src/Migration/Migration1705588547AlterAdyenPaymentResponse.php
+++ b/src/Migration/Migration1705588547AlterAdyenPaymentResponse.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Adyen\Shopware\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1705588547AlterAdyenPaymentResponse extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1705588547;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(<<<SQL
+            ALTER TABLE `adyen_payment_response` ADD COLUMN `pspreference` varchar(255);
+        SQL);
+
+        $connection->executeStatement(<<<SQL
+            ALTER TABLE `adyen_payment_response`
+                ADD CONSTRAINT `UQ_ADYEN_PAYMENT_RESPONSE_PSPREFERENCE` 
+                    UNIQUE (`pspreference`);
+        SQL);
+
+        $connection->executeStatement(<<<SQL
+            CREATE INDEX `ADYEN_PAYMENT_RESPONSE_PSPREFERENCE`
+                ON `adyen_payment_response` (`pspreference`);
+        SQL);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/Resources/config/services/notification-processing.xml
+++ b/src/Resources/config/services/notification-processing.xml
@@ -31,6 +31,7 @@
             <argument type="service" id="Adyen\Shopware\Service\AdyenPaymentService"/>
             <argument type="service" id="Adyen\Shopware\Service\CaptureService"/>
             <argument type="service" id="Adyen\Shopware\ScheduledTask\Webhook\WebhookHandlerFactory"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentResponseService"/>
             <tag name="messenger.message_handler"/>
             <call method="setLogger">
                 <argument key="$logger" type="service" id="monolog.logger.adyen_notification"/>

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -112,7 +112,7 @@ class PaymentResponseService
         $fields['orderTransactionId'] = $orderTransaction->getId();
         $fields['resultCode'] = $paymentResponse["resultCode"];
         $fields['response'] = json_encode($paymentResponse);
-        $fields['pspreference'] = $paymentResponse["pspReference"];
+        $fields['pspreference'] = $paymentResponse["pspReference"] ?? null;
 
         $this->repository->upsert(
             [$fields],

--- a/src/Service/PaymentResponseService.php
+++ b/src/Service/PaymentResponseService.php
@@ -76,6 +76,16 @@ class PaymentResponseService
         return $this->getWithOrderTransaction($orderTransaction);
     }
 
+    public function getWithPspreference(string $pspreference): ?PaymentResponseEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter((new EqualsFilter('pspreference', $pspreference)));
+
+        return $this->repository
+            ->search($criteria, Context::createDefaultContext())
+            ->first();
+    }
+
     public function getWithOrderTransaction(OrderTransactionEntity $orderTransaction): ?PaymentResponseEntity
     {
         return $this->repository
@@ -102,6 +112,7 @@ class PaymentResponseService
         $fields['orderTransactionId'] = $orderTransaction->getId();
         $fields['resultCode'] = $paymentResponse["resultCode"];
         $fields['response'] = json_encode($paymentResponse);
+        $fields['pspreference'] = $paymentResponse["pspReference"];
 
         $this->repository->upsert(
             [$fields],

--- a/src/Service/Repository/OrderTransactionRepository.php
+++ b/src/Service/Repository/OrderTransactionRepository.php
@@ -100,4 +100,20 @@ class OrderTransactionRepository
 
         return $this->repository->search($criteria, Context::createDefaultContext())->first();
     }
+
+    /**
+     * @param string $orderTransactionId
+     * @return OrderTransactionEntity|null
+     */
+    public function getWithId(string $orderTransactionId): ?OrderTransactionEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addAssociation('order');
+        $criteria->addAssociation('order.currency');
+        $criteria->addAssociation('paymentMethod');
+        $criteria->addAssociation('paymentMethod.plugin');
+        $criteria->addFilter(new EqualsFilter('id', $orderTransactionId));
+
+        return $this->repository->search($criteria, Context::createDefaultContext())->first();
+    }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
`Authorisation` webhook for a failed payment attempt is intentionally being processed after 30 minutes after arrival. During this time, order has not been cancelled and expects a successful payment. However, webhook for failed payment attempt overrides the successful authorisation after 30 minutes.

This PR introduces a fix to this issue by fetching the correct `order_transaction` entity for the failed payment attempt. Therefore, successful payment's `order_transaction` is not affected.

## Tested scenarios
<!-- Description of tested scenarios -->
- Happy and unhappy flows of card payments with webhook processing
- Processing capture webhook