### PR TITLE
add schedule webhook command

### DIFF
--- a/src/Command/DisablePaymentMethodCommand.php
+++ b/src/Command/DisablePaymentMethodCommand.php
@@ -45,7 +45,7 @@ class DisablePaymentMethodCommand extends Command
         $this->handler = $handler;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDescription('Finds the payment method according to given PM handler and disables it');
 
@@ -64,7 +64,7 @@ class DisablePaymentMethodCommand extends Command
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $isAllSelected = $input->getOption('all');
@@ -81,6 +81,6 @@ class DisablePaymentMethodCommand extends Command
         }
 
         $output->writeln($message);
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/EnablePaymentMethodCommand.php
+++ b/src/Command/EnablePaymentMethodCommand.php
@@ -45,7 +45,7 @@ class EnablePaymentMethodCommand extends Command
         $this->handler = $handler;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDescription('Finds the payment method according to given PM handler and enables it');
 
@@ -64,7 +64,7 @@ class EnablePaymentMethodCommand extends Command
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $isAllSelected = $input->getOption('all');
@@ -81,6 +81,6 @@ class EnablePaymentMethodCommand extends Command
         }
 
         $output->writeln($message);
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/FetchPaymentMethodLogosCommand.php
+++ b/src/Command/FetchPaymentMethodLogosCommand.php
@@ -44,15 +44,15 @@ class FetchPaymentMethodLogosCommand extends Command
         $this->handler = $handler;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDescription('Fetch and update logos for Adyen payment methods.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->handler->run();
         $output->writeln('All available logos have been updated.');
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ProcessWebhooksCommand.php
+++ b/src/Command/ProcessWebhooksCommand.php
@@ -44,15 +44,15 @@ class ProcessWebhooksCommand extends Command
         $this->handler = $handler;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
-        $this->setDescription('Process webhook notifications.');
+        $this->setDescription('Process webhook notifications');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->handler->run();
-        $output->writeln('Webhook notifications have been processed.');
-        return 0;
+        $output->writeln('Webhook notifications have been processed');
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ScheduleWebhooksCommand.php
+++ b/src/Command/ScheduleWebhooksCommand.php
@@ -24,7 +24,6 @@
 
 namespace Adyen\Shopware\Command;
 
-use Adyen\Shopware\ScheduledTask\ProcessNotificationsHandler;
 use Adyen\Shopware\ScheduledTask\ScheduleNotificationsHandler;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,7 +34,7 @@ class ScheduleWebhooksCommand extends Command
     protected static $defaultName = 'adyen:schedule-webhooks';
 
     /**
-     * @var ProcessNotificationsHandler
+     * @var ScheduleNotificationsHandler
      */
     protected $handler;
 
@@ -45,15 +44,15 @@ class ScheduleWebhooksCommand extends Command
         $this->handler = $handler;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
-        $this->setDescription('Schedule webhook notifications.');
+        $this->setDescription('Schedule webhook notifications');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->handler->run();
-        $output->writeln('Webhook notifications have been scheduled.');
-        return 0;
+        $output->writeln('Webhook notifications have been scheduled');
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ScheduleWebhooksCommand.php
+++ b/src/Command/ScheduleWebhooksCommand.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2022 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Command;
+
+use Adyen\Shopware\ScheduledTask\ProcessNotificationsHandler;
+use Adyen\Shopware\ScheduledTask\ScheduleNotificationsHandler;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ScheduleWebhooksCommand extends Command
+{
+    protected static $defaultName = 'adyen:schedule-webhooks';
+
+    /**
+     * @var ProcessNotificationsHandler
+     */
+    protected $handler;
+
+    public function __construct(ScheduleNotificationsHandler $handler)
+    {
+        parent::__construct();
+        $this->handler = $handler;
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Schedule webhook notifications.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->handler->run();
+        $output->writeln('Webhook notifications have been scheduled.');
+        return 0;
+    }
+}

--- a/src/Resources/config/services/commands.xml
+++ b/src/Resources/config/services/commands.xml
@@ -34,6 +34,10 @@
             <argument type="service" id="Adyen\Shopware\ScheduledTask\ProcessNotificationsHandler"/>
             <tag name="console.command"/>
         </service>
+        <service id="Adyen\Shopware\Command\ScheduleWebhooksCommand">
+            <argument type="service" id="Adyen\Shopware\ScheduledTask\ScheduleNotificationsHandler"/>
+            <tag name="console.command"/>
+        </service>
         <service id="Adyen\Shopware\Command\EnablePaymentMethodCommand">
             <argument type="service" id="Adyen\Shopware\Handlers\Command\EnablePaymentMethodHandler"/>
             <tag name="console.command"/>


### PR DESCRIPTION
The PR add a new command to process schedule webhooks.

In some scenarios Shopware scheduled tasks stops running after restarting php-fpm.
By using console commands via crontab this can be prevented.

Example crontab:
```
* * * * * php bin/console adyen:process-webhooks
* * * * * php bin/console adyen:schedule-webhooks
```