### PR TITLE
ECP-8856 Shopware 6 - Compatibility Error on Update

### DIFF
--- a/src/Controller/StoreApi/Donate/DonateController.php
+++ b/src/Controller/StoreApi/Donate/DonateController.php
@@ -33,6 +33,7 @@ use Adyen\Shopware\Service\Repository\OrderTransactionRepository;
 use Adyen\Util\Currency;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -50,7 +51,9 @@ class DonateController
      * @var OrderTransactionRepository
      */
     private $adyenOrderTransactionRepository;
-
+    /**
+     * @var EntityRepository
+     */
     private $orderTransactionRepository;
     /**
      * @var DonationService
@@ -76,14 +79,14 @@ class DonateController
      *
      * @param DonationService $donationService
      * @param OrderTransactionRepository $adyenOrderTransactionRepository
-     * @param $orderTransactionRepository
+     * @param EntityRepository $orderTransactionRepository
      * @param ConfigurationService $configurationService
      * @param LoggerInterface $logger
      */
     public function __construct(
         DonationService $donationService,
         OrderTransactionRepository $adyenOrderTransactionRepository,
-        $orderTransactionRepository,
+        EntityRepository $orderTransactionRepository,
         ConfigurationService $configurationService,
         Currency $currency,
         LoggerInterface $logger

--- a/src/Controller/StoreApi/Donate/DonateController.php
+++ b/src/Controller/StoreApi/Donate/DonateController.php
@@ -33,7 +33,6 @@ use Adyen\Shopware\Service\Repository\OrderTransactionRepository;
 use Adyen\Util\Currency;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -51,9 +50,7 @@ class DonateController
      * @var OrderTransactionRepository
      */
     private $adyenOrderTransactionRepository;
-    /**
-     * @var EntityRepository
-     */
+
     private $orderTransactionRepository;
     /**
      * @var DonationService
@@ -79,14 +76,14 @@ class DonateController
      *
      * @param DonationService $donationService
      * @param OrderTransactionRepository $adyenOrderTransactionRepository
-     * @param EntityRepository $orderTransactionRepository
+     * @param $orderTransactionRepository
      * @param ConfigurationService $configurationService
      * @param LoggerInterface $logger
      */
     public function __construct(
         DonationService $donationService,
         OrderTransactionRepository $adyenOrderTransactionRepository,
-        EntityRepository $orderTransactionRepository,
+        $orderTransactionRepository,
         ConfigurationService $configurationService,
         Currency $currency,
         LoggerInterface $logger

--- a/src/Controller/StoreApi/Payment/PaymentController.php
+++ b/src/Controller/StoreApi/Payment/PaymentController.php
@@ -149,7 +149,7 @@ class PaymentController
         EntityRepository $orderTransactionRepository,
         ConfigurationService $configurationService,
         OrderTransactionStateHandler $orderTransactionStateHandler,
-        LoggerInterface $logger,
+        LoggerInterface $logger
     ) {
         $this->paymentMethodsService = $paymentMethodsService;
         $this->paymentDetailsService = $paymentDetailsService;

--- a/src/Controller/StoreApi/Payment/PaymentController.php
+++ b/src/Controller/StoreApi/Payment/PaymentController.php
@@ -130,10 +130,10 @@ class PaymentController
      * @param OrderService $orderService
      * @param StateMachineRegistry $stateMachineRegistry
      * @param InitialStateIdLoader $initialStateIdLoader
-     * @param LoggerInterface $logger
      * @param EntityRepository $orderTransactionRepository
      * @param ConfigurationService $configurationService
      * @param OrderTransactionStateHandler $orderTransactionStateHandler
+     * @param LoggerInterface $logger
      */
     public function __construct(
         PaymentMethodsService $paymentMethodsService,
@@ -146,10 +146,10 @@ class PaymentController
         OrderService $orderService,
         StateMachineRegistry $stateMachineRegistry,
         InitialStateIdLoader $initialStateIdLoader,
-        LoggerInterface $logger,
         EntityRepository $orderTransactionRepository,
         ConfigurationService $configurationService,
-        OrderTransactionStateHandler $orderTransactionStateHandler
+        OrderTransactionStateHandler $orderTransactionStateHandler,
+        LoggerInterface $logger,
     ) {
         $this->paymentMethodsService = $paymentMethodsService;
         $this->paymentDetailsService = $paymentDetailsService;
@@ -160,11 +160,11 @@ class PaymentController
         $this->orderRepository = $orderRepository;
         $this->orderService = $orderService;
         $this->stateMachineRegistry = $stateMachineRegistry;
-        $this->logger = $logger;
         $this->orderTransactionRepository = $orderTransactionRepository;
         $this->configurationService = $configurationService;
         $this->orderTransactionStateHandler = $orderTransactionStateHandler;
         $this->initialStateIdLoader = $initialStateIdLoader;
+        $this->logger = $logger;
     }
 
     /**

--- a/src/Controller/StoreApi/Payment/PaymentController.php
+++ b/src/Controller/StoreApi/Payment/PaymentController.php
@@ -42,6 +42,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
 use Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRouteResponse;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
@@ -91,8 +92,10 @@ class PaymentController
      * @var OrderService
      */
     private $orderService;
-
-    private $orderTransactionRepository;
+    /**
+     * @var EntityRepository
+     */
+    private EntityRepository $orderTransactionRepository;
     /**
      * @var StateMachineRegistry
      */
@@ -128,7 +131,7 @@ class PaymentController
      * @param StateMachineRegistry $stateMachineRegistry
      * @param InitialStateIdLoader $initialStateIdLoader
      * @param LoggerInterface $logger
-     * @param $orderTransactionRepository
+     * @param EntityRepository $orderTransactionRepository
      * @param ConfigurationService $configurationService
      * @param OrderTransactionStateHandler $orderTransactionStateHandler
      */
@@ -144,7 +147,7 @@ class PaymentController
         StateMachineRegistry $stateMachineRegistry,
         InitialStateIdLoader $initialStateIdLoader,
         LoggerInterface $logger,
-        $orderTransactionRepository,
+        EntityRepository $orderTransactionRepository,
         ConfigurationService $configurationService,
         OrderTransactionStateHandler $orderTransactionStateHandler
     ) {

--- a/src/Controller/StoreApi/Payment/PaymentController.php
+++ b/src/Controller/StoreApi/Payment/PaymentController.php
@@ -42,7 +42,6 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
 use Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRouteResponse;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
@@ -92,9 +91,7 @@ class PaymentController
      * @var OrderService
      */
     private $orderService;
-    /**
-     * @var EntityRepository
-     */
+
     private $orderTransactionRepository;
     /**
      * @var StateMachineRegistry
@@ -131,7 +128,7 @@ class PaymentController
      * @param StateMachineRegistry $stateMachineRegistry
      * @param InitialStateIdLoader $initialStateIdLoader
      * @param LoggerInterface $logger
-     * @param EntityRepository $orderTransactionRepository
+     * @param $orderTransactionRepository
      * @param ConfigurationService $configurationService
      * @param OrderTransactionStateHandler $orderTransactionStateHandler
      */
@@ -147,7 +144,7 @@ class PaymentController
         StateMachineRegistry $stateMachineRegistry,
         InitialStateIdLoader $initialStateIdLoader,
         LoggerInterface $logger,
-        EntityRepository $orderTransactionRepository,
+        $orderTransactionRepository,
         ConfigurationService $configurationService,
         OrderTransactionStateHandler $orderTransactionStateHandler
     ) {

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -200,8 +200,8 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
     /**
      * AbstractPaymentMethodHandler constructor.
      *
-     * @param ConfigurationService $configurationService
      * @param ClientService $clientService
+     * @param ConfigurationService $configurationService
      * @param Browser $browserBuilder
      * @param Address $addressBuilder
      * @param Payment $paymentBuilder
@@ -243,26 +243,26 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
         AbstractContextSwitchRoute $contextSwitchRoute,
         LoggerInterface $logger
     ) {
-        $this->configurationService = $configurationService;
         $this->clientService = $clientService;
         $this->browserBuilder = $browserBuilder;
         $this->addressBuilder = $addressBuilder;
-        $this->paymentBuilder = $paymentBuilder;
         $this->openInvoiceBuilder = $openInvoiceBuilder;
         $this->currency = $currency;
+        $this->configurationService = $configurationService;
         $this->customerBuilder = $customerBuilder;
+        $this->paymentBuilder = $paymentBuilder;
         $this->checkoutStateDataValidator = $checkoutStateDataValidator;
         $this->paymentStateDataService = $paymentStateDataService;
         $this->salesChannelRepository = $salesChannelRepository;
         $this->paymentResponseHandler = $paymentResponseHandler;
         $this->resultHandler = $resultHandler;
+        $this->logger = $logger;
         $this->orderTransactionStateHandler = $orderTransactionStateHandler;
         $this->symfonyRouter = $symfonyRouter;
         $this->requestStack = $requestStack;
         $this->currencyRepository = $currencyRepository;
         $this->productRepository = $productRepository;
         $this->contextSwitchRoute = $contextSwitchRoute;
-        $this->logger = $logger;
     }
 
     abstract public static function getPaymentMethodCode();

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -218,8 +218,8 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
      * @param RequestStack $requestStack
      * @param EntityRepository $currencyRepository
      * @param EntityRepository $productRepository
-     * @param LoggerInterface $logger
      * @param AbstractContextSwitchRoute $contextSwitchRoute
+     * @param LoggerInterface $logger
      */
     public function __construct(
         ConfigurationService $configurationService,
@@ -243,26 +243,26 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
         AbstractContextSwitchRoute $contextSwitchRoute,
         LoggerInterface $logger
     ) {
+        $this->configurationService = $configurationService;
         $this->clientService = $clientService;
         $this->browserBuilder = $browserBuilder;
         $this->addressBuilder = $addressBuilder;
+        $this->paymentBuilder = $paymentBuilder;
         $this->openInvoiceBuilder = $openInvoiceBuilder;
         $this->currency = $currency;
-        $this->configurationService = $configurationService;
         $this->customerBuilder = $customerBuilder;
-        $this->paymentBuilder = $paymentBuilder;
         $this->checkoutStateDataValidator = $checkoutStateDataValidator;
         $this->paymentStateDataService = $paymentStateDataService;
         $this->salesChannelRepository = $salesChannelRepository;
         $this->paymentResponseHandler = $paymentResponseHandler;
         $this->resultHandler = $resultHandler;
-        $this->logger = $logger;
         $this->orderTransactionStateHandler = $orderTransactionStateHandler;
         $this->symfonyRouter = $symfonyRouter;
         $this->requestStack = $requestStack;
         $this->currencyRepository = $currencyRepository;
         $this->productRepository = $productRepository;
         $this->contextSwitchRoute = $contextSwitchRoute;
+        $this->logger = $logger;
     }
 
     abstract public static function getPaymentMethodCode();

--- a/src/Handlers/Command/DisablePaymentMethodHandler.php
+++ b/src/Handlers/Command/DisablePaymentMethodHandler.php
@@ -26,7 +26,6 @@ namespace Adyen\Shopware\Handlers\Command;
 
 use Adyen\Shopware\Provider\AdyenPluginProvider;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -38,9 +37,6 @@ class DisablePaymentMethodHandler
      */
     private $adyenPluginProvider;
 
-    /**
-     * @var EntityRepository
-     */
     private $paymentMethodRepository;
 
     /**
@@ -55,7 +51,7 @@ class DisablePaymentMethodHandler
 
     public function __construct(
         AdyenPluginProvider $adyenPluginProvider,
-        EntityRepository $paymentMethodRepository,
+        $paymentMethodRepository,
         EntityRepository $salesChannelRepository,
         EntityRepository $salesChannelPaymentMethodRepository
     ) {

--- a/src/Handlers/Command/EnablePaymentMethodHandler.php
+++ b/src/Handlers/Command/EnablePaymentMethodHandler.php
@@ -38,9 +38,6 @@ class EnablePaymentMethodHandler
      */
     private $adyenPluginProvider;
 
-    /**
-     * @var EntityRepository
-     */
     private $paymentMethodRepository;
 
     /**
@@ -55,7 +52,7 @@ class EnablePaymentMethodHandler
 
     public function __construct(
         AdyenPluginProvider $adyenPluginProvider,
-        EntityRepository $paymentMethodRepository,
+        $paymentMethodRepository,
         EntityRepository $salesChannelRepository,
         EntityRepository $salesChannelPaymentMethodRepository
     ) {

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -79,9 +79,6 @@ class PaymentResponseHandler
      */
     private $transactionStateHandler;
 
-    /**
-     * @var EntityRepository
-     */
     private $orderTransactionRepository;
 
     /**
@@ -98,7 +95,7 @@ class PaymentResponseHandler
      * @param LoggerInterface $logger
      * @param PaymentResponseService $paymentResponseService
      * @param OrderTransactionStateHandler $transactionStateHandler
-     * @param EntityRepository $orderTransactionRepository
+     * @param $orderTransactionRepository
      * @param CaptureService $captureService
      * @param ConfigurationService $configurationService
      */
@@ -106,7 +103,7 @@ class PaymentResponseHandler
         LoggerInterface $logger,
         PaymentResponseService $paymentResponseService,
         OrderTransactionStateHandler $transactionStateHandler,
-        EntityRepository $orderTransactionRepository,
+        $orderTransactionRepository,
         CaptureService $captureService,
         ConfigurationService $configurationService
     ) {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -88,6 +88,7 @@
         <service id="Adyen\Shopware\Service\OrdersService" autowire="true"></service>
         <service id="Adyen\Shopware\Service\OrdersCancelService" autowire="true"></service>
         <service id="Adyen\Shopware\Service\PluginPaymentMethodsService" autowire="true">
+            <argument type="service" id="Adyen\Shopware\Provider\AdyenPluginProvider"/>
             <argument type="service" id="payment_method.repository"/>
         </service>
         <service id="Adyen\Shopware\Service\AdyenPaymentService">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -87,7 +87,9 @@
         </service>
         <service id="Adyen\Shopware\Service\OrdersService" autowire="true"></service>
         <service id="Adyen\Shopware\Service\OrdersCancelService" autowire="true"></service>
-        <service id="Adyen\Shopware\Service\PluginPaymentMethodsService" autowire="true"></service>
+        <service id="Adyen\Shopware\Service\PluginPaymentMethodsService" autowire="true">
+            <argument type="service" id="payment_method.repository"/>
+        </service>
         <service id="Adyen\Shopware\Service\AdyenPaymentService">
             <argument type="service" id="Adyen\Shopware\Service\Repository\AdyenPaymentRepository"/>
             <argument type="service" id="order_transaction.repository"/>

--- a/src/Resources/config/services/controllers.xml
+++ b/src/Resources/config/services/controllers.xml
@@ -5,6 +5,20 @@
         https://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Adyen\Shopware\Controller\StoreApi\Payment\PaymentController" autowire="true">
+            <argument type="service" id="Adyen\Shopware\Service\PaymentMethodsService"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentDetailsService"/>
+            <argument type="service" id="Adyen\Service\Validator\CheckoutStateDataValidator"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentStatusService"/>
+            <argument type="service" id="Adyen\Shopware\Handlers\PaymentResponseHandler"/>
+            <argument type="service" id="Adyen\Shopware\Service\PaymentResponseService"/>
+            <argument type="service" id="Adyen\Shopware\Service\Repository\OrderRepository"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\OrderService"/>
+            <argument type="service" id="Shopware\Core\System\StateMachine\StateMachineRegistry"/>
+            <argument type="service" id="Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader"/>
+            <argument type="service" id="order_transaction.repository"/>
+            <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
+            <argument type="service"
+                      id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
             <tag name="controller.service_arguments"/>
         </service>

--- a/src/Resources/config/services/controllers.xml
+++ b/src/Resources/config/services/controllers.xml
@@ -5,7 +5,6 @@
         https://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Adyen\Shopware\Controller\StoreApi\Payment\PaymentController" autowire="true">
-            <argument type="service" id="order_transaction.repository"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
             <tag name="controller.service_arguments"/>
         </service>

--- a/src/Resources/config/services/controllers.xml
+++ b/src/Resources/config/services/controllers.xml
@@ -5,6 +5,7 @@
         https://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Adyen\Shopware\Controller\StoreApi\Payment\PaymentController" autowire="true">
+            <argument type="service" id="order_transaction.repository"/>
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
             <tag name="controller.service_arguments"/>
         </service>

--- a/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
@@ -46,13 +46,9 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
      * @var MediaService
      */
     private $mediaService;
-    /**
-     * @var EntityRepository
-     */
+
     private $paymentMethodRepository;
-    /**
-     * @var EntityRepository|\Shopware\Core\Content\Media\DataAbstractionLayer\MediaRepositoryDecorator
-     */
+
     private $mediaRepository;
     /**
      * @var bool

--- a/src/ScheduledTask/ProcessNotificationsHandler.php
+++ b/src/ScheduledTask/ProcessNotificationsHandler.php
@@ -73,10 +73,7 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
      */
     private OrderRepository $orderRepository;
 
-    /**
-     * @var EntityRepository
-     */
-    private EntityRepository $paymentMethodRepository;
+    private $paymentMethodRepository;
 
     /**
      * @var array|null
@@ -125,7 +122,7 @@ class ProcessNotificationsHandler extends ScheduledTaskHandler
      * @param EntityRepository $scheduledTaskRepository
      * @param NotificationService $notificationService
      * @param OrderRepository $orderRepository
-     * @param EntityRepository $paymentMethodRepository
+     * @param $paymentMethodRepository
      * @param OrderTransactionRepository $orderTransactionRepository
      * @param AdyenPaymentService $adyenPaymentService
      * @param CaptureService $captureService

--- a/src/Service/PluginPaymentMethodsService.php
+++ b/src/Service/PluginPaymentMethodsService.php
@@ -25,7 +25,6 @@ namespace Adyen\Shopware\Service;
 
 use Adyen\Shopware\Provider\AdyenPluginProvider;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 
@@ -34,12 +33,11 @@ class PluginPaymentMethodsService
     /** @var AdyenPluginProvider */
     protected $adyenPluginProvider;
 
-    /** @var EntityRepository */
     protected $paymentMethodRepository;
 
     public function __construct(
         AdyenPluginProvider $adyenPluginProvider,
-        EntityRepository $paymentMethodRepository
+        $paymentMethodRepository
     ) {
         $this->adyenPluginProvider = $adyenPluginProvider;
         $this->paymentMethodRepository = $paymentMethodRepository;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Removing EntityRepository Decorator from everywhere, where it is deprecated
Source of truth: [Shopware6.4](https://github.com/shopware/shopware/blob/trunk/UPGRADE-6.4.md#removed-repository-decorators)
[Shopware6.5](https://github.com/shopware/shopware/blob/trunk/UPGRADE-6.5.md#removed-repository-decorators)
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
