### PR TITLE
Fix recursion error for checkout order route

### DIFF
--- a/src/Storefront/Controller/FrontendProxyController.php
+++ b/src/Storefront/Controller/FrontendProxyController.php
@@ -101,7 +101,9 @@ class FrontendProxyController extends StorefrontController
     public function checkoutOrder(RequestDataBag $data, SalesChannelContext $salesChannelContext): JsonResponse
     {
         $cart = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
-        return new JsonResponse($this->cartOrderRoute->order($cart, $salesChannelContext, $data)->getOrder());
+        $order = $this->cartOrderRoute->order($cart, $salesChannelContext, $data)->getOrder();
+
+        return new JsonResponse(['id' => $order->getId()]);
     }
 
     /**


### PR DESCRIPTION
## Summary
In the `FrontendProxyController::checkoutOrder()` the whole order entity is being put in a `JsonResponse`. If that order has bidirectional associations (for example transactions which also have a reference back to the order, and thus back to the transactions and back to the order etc...) then the `JsonResponse` object will throw an error: "_Recursion detected_"

## Tested scenarios
Just load an order with some bidirectional associations in some subscriber that's triggered on checkout. 

**Fixed issue**:  No issue has been made

## Solution
The [JS success callback](https://github.com/Adyen/adyen-shopware6/blob/develop/src/Resources/app/storefront/src/checkout/confirm-order.plugin.js#L261-L267) that uses the checkout route response only used the id, so no need to send the whole entity. Just send the id, and that's it.