### PR TITLE
Added PrePaymentDataBuildEvent and implemented dispatch in the abstra…

### DIFF
--- a/src/Event/PrePaymentDataBuildEvent.php
+++ b/src/Event/PrePaymentDataBuildEvent.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adyen\Shopware\Event;
+
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+final class PrePaymentDataBuildEvent
+{
+    /**
+     * @var int
+     */
+    private $amount;
+
+    /**
+     * @var AsyncPaymentTransactionStruct
+     */
+    private $transaction;
+
+    /**
+     * @var SalesChannelContext
+     */
+    private $salesChannelContext;
+
+    public function __construct(
+        int $amount,
+        AsyncPaymentTransactionStruct $transaction,
+        SalesChannelContext $salesChannelContext
+    ) {
+        $this->amount = $amount;
+        $this->transaction = $transaction;
+        $this->salesChannelContext = $salesChannelContext;
+    }
+
+    public function amount(): int
+    {
+        return $this->amount;
+    }
+
+    public function changeAmount(int $amount): void
+    {
+        $this->amount = $amount;
+    }
+
+    public function transaction(): AsyncPaymentTransactionStruct
+    {
+        return $this->transaction;
+    }
+
+    public function order(): OrderEntity
+    {
+        return $this->transaction->getOrder();
+    }
+
+    public function salesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+}

--- a/src/Resources/config/services/payment-handlers.xml
+++ b/src/Resources/config/services/payment-handlers.xml
@@ -5,6 +5,7 @@
         https://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler" abstract="true">
+            <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface"/>
             <argument type="service" id="Adyen\Shopware\Service\ConfigurationService"/>
             <argument type="service" id="Adyen\Shopware\Service\ClientService"/>
             <argument type="service" id="Adyen\Service\Builder\Browser"/>


### PR DESCRIPTION
…ctPaymentMethodHandler

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
There's a possibility in Shopware to have a custom crediting system, be it a rewards program, customer balance or other things that affect the remaining amount of an order.
When using the adyen plugin at the time of writing, it's impossible to apply this to  the payment as Adyen always sends either the full amount or the partial amount (defined by adyen plugin).

In order to make the above scenario possible, I introduced an event so that a developer can use this hook to make changes accordingly.

## Tested scenarios
- Without changes: orders still work as intended - nothing has changed
- Subscribed to the event and changed the amount: only that amount has to be paid through Adyen
