### PR TITLE
[ECP-9027-v3] Add missing dependency definition

### DIFF
--- a/src/Handlers/Command/DisablePaymentMethodHandler.php
+++ b/src/Handlers/Command/DisablePaymentMethodHandler.php
@@ -26,6 +26,7 @@ namespace Adyen\Shopware\Handlers\Command;
 
 use Adyen\Shopware\Provider\AdyenPluginProvider;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -37,7 +37,6 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStat
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class PaymentResponseHandler

--- a/src/Resources/config/services/controllers.xml
+++ b/src/Resources/config/services/controllers.xml
@@ -28,6 +28,7 @@
         </service>
         <service id="Adyen\Shopware\Controller\StoreApi\Donate\DonateController" autowire="true">
             <argument key="$logger" type="service" id="monolog.logger.adyen_generic"/>
+            <argument key="$orderTransactionRepository" type="service" id="order_transaction.repository"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="Adyen\Shopware\Storefront\Controller\NotificationReceiverController">


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This PR adds the missing dependency injection definition for `order_transaction.repository`. This bug causes not supporting any versions below Shopware 6.4.15.0 since `EntityRepository` is not auto wirable below that version.

## Tested scenarios
<!-- Description of tested scenarios -->
- Happy/unhappy flow on Shopware 6.4.12.0 and Shopware 6.5.8.0

Fixes #461