### PR TITLE
Add null check to isManualCaptureEnabled method of AdminController

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -312,7 +312,7 @@ class AdminController
             return new JsonResponse(
                 $this->captureService->isManualCapture($paymentMethodHandlerIdentifier)
             );
-        } catch (Throwable) {
+        } catch (Throwable $t) {
             return new JsonResponse(false);
         }
     }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -51,6 +51,7 @@ use Shopware\Core\System\Currency\CurrencyFormatter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Throwable;
 
 /**
  * Class AdminController
@@ -302,12 +303,16 @@ class AdminController
     {
         try {
             $orderTransaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction($orderId);
+            if (is_null($orderTransaction)) {
+                return new JsonResponse(false);
+            }
+            
             $paymentMethodHandlerIdentifier = $orderTransaction->getPaymentMethod()->getHandlerIdentifier();
 
             return new JsonResponse(
                 $this->captureService->isManualCapture($paymentMethodHandlerIdentifier)
             );
-        } catch (Exception $e) {
+        } catch (Throwable) {
             return new JsonResponse(false);
         }
     }


### PR DESCRIPTION
## Summary
The additional null check allows the method to return early of no Adyen transaction was found instead of relying that an exception is thrown. Because the original intend of the try-catch was to catch any exception, the catch clause is changed to catch all Throwables (possible since PHP 7).

I removed the variable from the catch clause in the first place. But because this plugin has to be compatible with Shopware 6.4, it has to be PHP 7.4 compatible. Catch clauses without variable are allowed since PHP 8.

## Tested scenarios
None

**Fixed issue**:  https://github.com/Adyen/adyen-shopware6/issues/479
