### PR TITLE
[ECP-8827] Fixing shopper locale for redirect based payment methods

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -529,8 +529,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
 
         if (empty($request['shopperLocale'])) {
             $shopperLocale = $this->salesChannelRepository
-                ->getSalesChannelAssoc($salesChannelContext, ['language.locale'])
-                ->getLanguage()->getLocale()->getCode();
+                ->getSalesChannelLocale($salesChannelContext);
         } else {
             $shopperLocale = $request['shopperLocale'];
         }

--- a/src/Service/PaymentMethodsService.php
+++ b/src/Service/PaymentMethodsService.php
@@ -225,7 +225,7 @@ class PaymentMethodsService
 
         $salesChannelAssocLocale = $this->salesChannelRepository
             ->getSalesChannelAssoc($context, ['language.locale', 'country']);
-        $shopperLocale = $salesChannelAssocLocale->getLanguage()->getLocale()->getCode();
+        $shopperLocale = $this->salesChannelRepository->getSalesChannelLocale($context);
 
         if (!is_null($context->getCustomer())) {
             if ($context->getCustomer()->getActiveBillingAddress()->getCountry()->getIso()) {


### PR DESCRIPTION
Language of shopperLocal stayed to default language and did not update along with updating the language of shopware instance. This resulted in a bug where payment page still stayed to default language as the /payments call had default value in shopperLocale. 
 
## Tested scenarios
1. On mini cart page for payment methods call
2. On checkout page 

