### PR TITLE
[ECP-9184] Revert removal of gift card payment methods

### DIFF
--- a/src/Handlers/AlbelliGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/AlbelliGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class AlbelliGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'albelligiftcard';
+    }
+}

--- a/src/Handlers/BeautyGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/BeautyGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class BeautyGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'beautycadeaukaart';
+    }
+}

--- a/src/Handlers/BijenkorfGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/BijenkorfGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class BijenkorfGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'bijcadeaucard';
+    }
+}

--- a/src/Handlers/DeCadeaukaartGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/DeCadeaukaartGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class DeCadeaukaartGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'decadeaukaart';
+    }
+}

--- a/src/Handlers/FashionChequeGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/FashionChequeGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class FashionChequeGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'fashioncheque';
+    }
+}

--- a/src/Handlers/GallGallGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GallGallGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class GallGallGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'gallgall';
+    }
+}

--- a/src/Handlers/GenericGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GenericGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class GenericGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'genericgiftcard';
+    }
+}

--- a/src/Handlers/GivexGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/GivexGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class GivexGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'givex';
+    }
+}

--- a/src/Handlers/HunkemollerLingerieGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/HunkemollerLingerieGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class HunkemollerLingerieGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'hmlingerie';
+    }
+}

--- a/src/Handlers/KadowereldGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/KadowereldGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class KadowereldGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'kadowereld';
+    }
+}

--- a/src/Handlers/SVSGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/SVSGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class SVSGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'svs';
+    }
+}

--- a/src/Handlers/TCSTestGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/TCSTestGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class TCSTestGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'tcstestgiftcard';
+    }
+}

--- a/src/Handlers/VVVGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/VVVGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class VVVGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'vvvgiftcard';
+    }
+}

--- a/src/Handlers/WebshopGiftCardPaymentMethodHandler.php
+++ b/src/Handlers/WebshopGiftCardPaymentMethodHandler.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\Handlers;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class WebshopGiftCardPaymentMethodHandler extends AbstractPaymentMethodHandler
+{
+    public static $isGiftCard = true;
+
+    public static function getPaymentMethodCode()
+    {
+        return 'giftcard';
+    }
+
+    public static function getBrand(): string
+    {
+        return 'webshopgiftcard';
+    }
+}

--- a/src/PaymentMethods/AlbelliGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/AlbelliGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\AlbelliGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class AlbelliGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Albelli Giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Albelli Giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return AlbelliGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_ALBELLI_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'albelligiftcard.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/BeautyGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/BeautyGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\BeautyGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class BeautyGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Beauty Cadeaukaart';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Beauty Cadeaukaart';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return BeautyGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_BEAUTYCADEAUKAART_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'beautycadeaukaart.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/BijenkorfGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/BijenkorfGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\BijenkorfGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class BijenkorfGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Bijenkorf';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Bijenkorf Cadeaucard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return BijenkorfGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_BIJENKORF_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'bijcadeaucard.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/DeCadeaukaartGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/DeCadeaukaartGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\DeCadeaukaartGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class DeCadeaukaartGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'DeCadeaukaart';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'DeCadeaukaart giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return DeCadeaukaartGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_DECADEAUKAART_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'decadeaukaart.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/FashionChequeGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/FashionChequeGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\FashionChequeGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class FashionChequeGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'FashionCheque';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'FashionCheque giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return FashionChequeGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_FASHIONCHEQUE_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'fashioncheque.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/GallGallGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/GallGallGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\GallGallGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class GallGallGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Gall & Gall';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Gall & Gall Giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return GallGallGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_GALLGALL_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'gallgall.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/GenericGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/GenericGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\GenericGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class GenericGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Generic Giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Generic Giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return GenericGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_GENERIC_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'genericgiftcard.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/GivexGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/GivexGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\GivexGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class GivexGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Givex';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Givex Giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return GivexGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_GIVEX_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'givex.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/HunkemollerLingerieGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/HunkemollerLingerieGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\HunkemollerLingerieGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class HunkemollerLingerieGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Hunkemoller Lingerie';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Hunkemoller Lingerie Card';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return HunkemollerLingerieGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_HMLINGERIE_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'hmlingerie.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/KadowereldGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/KadowereldGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\KadowereldGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class KadowereldGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Kado Wereld';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Kado Wereld Giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return KadowereldGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_KADOWERELD_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'kadowereld.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/SVSGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/SVSGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\SVSGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class SVSGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'SVS';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'SVS Giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return SVSGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_SVS_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'svs.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/TCSTestGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/TCSTestGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\TCSTestGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class TCSTestGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'TCS Test';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'TCS Test GiftCard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return TCSTestGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_TCSTEST_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'tcstestgiftcard.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/VVVGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/VVVGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\VVVGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class VVVGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'VVV';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'VVV Giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return VVVGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_VVV_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'vvvgiftcard.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/PaymentMethods/WebshopGiftCardPaymentMethod.php
+++ b/src/PaymentMethods/WebshopGiftCardPaymentMethod.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <shopware@adyen.com>
+ */
+
+namespace Adyen\Shopware\PaymentMethods;
+
+use Adyen\Shopware\Handlers\WebshopGiftCardPaymentMethodHandler;
+
+/**
+ * @deprecated Individual gift card payment methods were deprecated and will be removed on v4.0.0.
+ * Use GiftCardPaymentMethod instead.
+ */
+class WebshopGiftCardPaymentMethod implements PaymentMethodInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Webshop';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Webshop Giftcard';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getPaymentHandler(): string
+    {
+        return WebshopGiftCardPaymentMethodHandler::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getGatewayCode(): string
+    {
+        return 'ADYEN_WEBSHOP_GIFTCARD';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getTemplate(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getLogo(): string
+    {
+        return 'webshopgiftcard.png';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+}

--- a/src/Resources/config/services/payment-handlers.xml
+++ b/src/Resources/config/services/payment-handlers.xml
@@ -195,6 +195,62 @@
                  parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
             <tag name="shopware.payment.method.async"/>
         </service>
+        <service id="Adyen\Shopware\Handlers\GivexGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\WebshopGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\KadowereldGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\TCSTestGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\AlbelliGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\BijenkorfGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\VVVGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\GenericGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\GallGallGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\HunkemollerLingerieGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\BeautyGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\SVSGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\FashionChequeGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+        <service id="Adyen\Shopware\Handlers\DeCadeaukaartGiftCardPaymentMethodHandler"
+                 parent="Adyen\Shopware\Handlers\AbstractPaymentMethodHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
     </services>
 </container>
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This PR reverts the removed gift card payment method classes and adds them `@deprecated` tag, which blocks running update script to the following version.

## Tested scenarios
<!-- Description of tested scenarios -->
- Installing and updating the plugin on Shopware 6.4 and Shopware 6.5