### PR TITLE
[ECP-9149] Remove deprecated classes of Shopware

### DIFF
--- a/src/AdyenPaymentShopware6.php
+++ b/src/AdyenPaymentShopware6.php
@@ -461,15 +461,6 @@ class AdyenPaymentShopware6 extends Plugin
         }
     }
 
-    private function safeCopyAsset($source, $destination): bool
-    {
-        try {
-            return copy($source, $destination);
-        } catch (\Exception $e) {
-            return false;
-        }
-    }
-
     /**
      * @param UpdateContext $updateContext
      * @param string $paymentMethodHandler

--- a/src/Controller/StoreApi/Payment/PaymentController.php
+++ b/src/Controller/StoreApi/Payment/PaymentController.php
@@ -315,7 +315,8 @@ class PaymentController
             function () use ($order, $initialStateId, $orderId, $paymentMethodId, $context): void {
                 if ($order->getTransactions() !== null && $order->getTransactions()->count() >= 1) {
                     foreach ($order->getTransactions() as $transaction) {
-                        if ($transaction->getStateMachineState()->getTechnicalName()
+                        $stateMachineState = $transaction->getStateMachineState();
+                        if (isset($stateMachineState) && $transaction->getStateMachineState()->getTechnicalName()
                             !== OrderTransactionStates::STATE_CANCELLED) {
                             $this->orderTransactionStateHandler->cancel(
                                 $transaction->getId(),

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -50,10 +50,7 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
-use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentFinalizeException;
-use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentProcessException;
-use Shopware\Core\Checkout\Payment\Exception\CustomerCanceledAsyncPaymentException;
-use Shopware\Core\Checkout\Payment\Exception\PaymentProcessException;
+use Shopware\Core\Checkout\Payment\PaymentException;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
@@ -308,16 +305,16 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
 
         if (empty($orderNumber)) {
             $message = 'Order number is missing';
-            throw new AsyncPaymentProcessException($transactionId, $message);
+            throw PaymentException::asyncProcessInterrupted($transactionId, $message);
         }
 
         try {
             $this->paymentResponseHandler
                 ->handleShopwareApis($transaction, $salesChannelContext, $this->paymentResults);
         } catch (PaymentCancelledException $exception) {
-            throw new CustomerCanceledAsyncPaymentException($transactionId, $exception->getMessage());
+            throw PaymentException::customerCanceled($transactionId, $exception->getMessage());
         } catch (PaymentFailedException $exception) {
-            throw new AsyncPaymentFinalizeException($transactionId, $exception->getMessage());
+            throw PaymentException::asyncFinalizeInterrupted($transactionId, $exception->getMessage());
         }
 
         /*
@@ -337,7 +334,12 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
         return new RedirectResponse($transaction->getReturnUrl());
     }
 
-    private function createAdyenOrder(SalesChannelContext $salesChannelContext, $transaction)
+    /**
+     * @param SalesChannelContext $salesChannelContext
+     * @param $transaction
+     * @return array
+     */
+    private function createAdyenOrder(SalesChannelContext $salesChannelContext, $transaction): array
     {
         $uuid = Uuid::randomHex();
         $currency = $salesChannelContext->getCurrency()->getIsoCode();
@@ -352,8 +354,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
      * @param AsyncPaymentTransactionStruct $transaction
      * @param Request $request
      * @param SalesChannelContext $salesChannelContext
-     * @throws AsyncPaymentFinalizeException
-     * @throws CustomerCanceledAsyncPaymentException
+     * @return void
      */
     public function finalize(
         AsyncPaymentTransactionStruct $transaction,
@@ -364,9 +365,9 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
         try {
             $this->resultHandler->processResult($transaction, $request, $salesChannelContext);
         } catch (PaymentCancelledException $exception) {
-            throw new CustomerCanceledAsyncPaymentException($transactionId, $exception->getMessage());
+            throw PaymentException::customerCanceled($transactionId, $exception->getMessage());
         } catch (PaymentFailedException $exception) {
-            throw new AsyncPaymentFinalizeException($transactionId, $exception->getMessage());
+            throw PaymentException::asyncFinalizeInterrupted($transactionId, $exception->getMessage());
         }
     }
 
@@ -707,7 +708,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
                 $orderRequestData
             );
             return $request;
-        } catch (AsyncPaymentProcessException $exception) {
+        } catch (PaymentException $exception) {
             $this->logger->error($exception->getMessage());
             throw $exception;
         } catch (\Exception $exception) {
@@ -717,10 +718,16 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
                 $exception->getMessage()
             );
             $this->logger->error($message);
-            throw new AsyncPaymentProcessException($transactionId, $message);
+            throw PaymentException::asyncProcessInterrupted($transactionId, $message);
         }
     }
 
+    /**
+     * @param SalesChannelContext $salesChannelContext
+     * @param PaymentRequest $request
+     * @param AsyncPaymentTransactionStruct $transaction
+     * @return void
+     */
     private function paymentsCall(
         SalesChannelContext $salesChannelContext,
         PaymentRequest $request,
@@ -750,7 +757,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
             );
             $this->displaySafeErrorMessages($exception);
             $this->logger->error($message);
-            throw new AsyncPaymentProcessException($transactionId, $message);
+            throw PaymentException::asyncProcessInterrupted($transactionId, $message);
         }
         $this->paymentResults[] = $this->paymentResponseHandler
             ->handlePaymentResponse($response, $transaction->getOrderTransaction(), false);
@@ -779,7 +786,11 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
         return $product;
     }
 
-    private function displaySafeErrorMessages(AdyenException $exception)
+    /**
+     * @param AdyenException $exception
+     * @return void
+     */
+    private function displaySafeErrorMessages(AdyenException $exception): void
     {
         if ('validation' === $exception->getErrorType()
             && in_array($exception->getAdyenErrorCode(), self::SAFE_ERROR_CODES)) {
@@ -819,7 +830,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
 
     /**
      * @param AsyncPaymentTransactionStruct $transaction
-     * @param RequestDataBag $dataBag
+     * @param $adyenOrderResponse
      * @param SalesChannelContext $salesChannelContext
      * @return void
      */
@@ -873,7 +884,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
             $this->paymentStateDataService->deletePaymentStateDataFromId($statedataArray->getId());
         }
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new AsyncPaymentProcessException(
+            throw PaymentException::asyncProcessInterrupted(
                 $transactionId,
                 'Invalid payment state data.'
             );

--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -94,77 +94,82 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
     /**
      * @var ClientService
      */
-    protected $clientService;
+    protected ClientService $clientService;
 
     /**
      * @var Currency
      */
-    protected $currency;
+    protected Currency $currency;
 
     /**
      * @var ConfigurationService
      */
-    protected $configurationService;
+    protected ConfigurationService $configurationService;
 
     /**
      * @var CheckoutStateDataValidator
      */
-    protected $checkoutStateDataValidator;
+    protected CheckoutStateDataValidator $checkoutStateDataValidator;
 
     /**
      * @var PaymentStateDataService
      */
-    protected $paymentStateDataService;
+    protected PaymentStateDataService $paymentStateDataService;
 
     /**
      * @var LoggerInterface
      */
-    protected $logger;
+    protected LoggerInterface $logger;
 
     /**
      * @var SalesChannelRepository
      */
-    protected $salesChannelRepository;
+    protected SalesChannelRepository $salesChannelRepository;
 
     /**
      * @var PaymentResponseHandler
      */
-    protected $paymentResponseHandler;
+    protected PaymentResponseHandler $paymentResponseHandler;
 
     /**
      * @var ResultHandler
      */
-    protected $resultHandler;
+    protected ResultHandler $resultHandler;
 
     /**
      * @var OrderTransactionStateHandler
      */
-    protected $orderTransactionStateHandler;
+    protected OrderTransactionStateHandler $orderTransactionStateHandler;
 
     /**
      * @var RouterInterface
      */
-    protected $symfonyRouter;
+    protected RouterInterface $symfonyRouter;
 
     /**
      * @var EntityRepository
      */
-    protected $currencyRepository;
+    protected EntityRepository $currencyRepository;
 
     /**
      * @var EntityRepository
      */
-    protected $productRepository;
+    protected EntityRepository $productRepository;
 
     /**
      * @var RequestStack
      */
-    protected $requestStack;
+    protected RequestStack $requestStack;
 
     /**
      * @var AbstractContextSwitchRoute
      */
-    private $contextSwitchRoute;
+    private AbstractContextSwitchRoute $contextSwitchRoute;
+
+    /**
+     * @var OrdersService
+     */
+    private OrdersService $ordersService;
 
     private $paymentsApiService;
 
@@ -173,8 +178,6 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
     private $orderRequestData = [];
 
     private $remainingAmount = null;
-
-    private OrdersService $ordersService;
 
     /**
      * AbstractPaymentMethodHandler constructor.
@@ -244,7 +247,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
      * @param RequestDataBag $dataBag
      * @param SalesChannelContext $salesChannelContext
      * @return RedirectResponse
-     * @throws PaymentProcessException|AdyenException
+     * @throws AdyenException
      */
     public function pay(
         AsyncPaymentTransactionStruct $transaction,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Following exception classes were deprecated on Shopware 6.5 and removed on Shopware 6.6. Those exception classes were replaced with `PaymentException`.

- `AsyncPaymentFinalizeException`
- `AsyncPaymentProcessException`
- `CustomerCanceledAsyncPaymentException`
- `PaymentProcessException`

## Tested scenario
- Redirect payment flows
- Card payments
