### PR TITLE
[ECP-9206] Adyen related tables missing for giftcard payments on admin panel

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -526,22 +526,16 @@ class AdminController
     public function isAdyenOrder(string $orderId): JsonResponse
     {
         try {
-            $adyenPluginId = $this->pluginProvider->getAdyenPluginId();
             $transaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction(
                 $orderId,
                 Context::createDefaultContext()
             );
-            $pluginId = $transaction->getPaymentMethod()->getPluginId();
 
-            if ($pluginId == $adyenPluginId) {
-                return new JsonResponse(
-                    ['status' => true]
-                );
+            if (!is_null($transaction)) {
+                return new JsonResponse(['status' => true]);
             }
 
-            return new JsonResponse(
-                ['status' => false]
-            );
+            return new JsonResponse(['status' => false]);
         } catch (Throwable $t) {
             return new JsonResponse(['message' => "Something went wrong."], 500);
         }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -538,7 +538,7 @@ class AdminController
             return new JsonResponse(['status' => false]);
         } catch (Throwable $t) {
             $this->logger->error($t->getMessage());
-            return new JsonResponse(['message' => "adyen.error"], 500);
+            return new JsonResponse(['message' => 'adyen.error'], 500);
         }
     }
 }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -526,10 +526,7 @@ class AdminController
     public function isAdyenOrder(string $orderId): JsonResponse
     {
         try {
-            $transaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction(
-                $orderId,
-                Context::createDefaultContext()
-            );
+            $transaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction($orderId);
 
             if (!is_null($transaction)) {
                 return new JsonResponse(['status' => true]);

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -537,7 +537,8 @@ class AdminController
 
             return new JsonResponse(['status' => false]);
         } catch (Throwable $t) {
-            return new JsonResponse(['message' => "Something went wrong."], 500);
+            $this->logger->error($t->getMessage());
+            return new JsonResponse(['message' => "adyen.error"], 500);
         }
     }
 }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -527,10 +527,12 @@ class AdminController
     {
         try {
             $adyenPluginId = $this->pluginProvider->getAdyenPluginId();
-            $transaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction($orderId, Context::createDefaultContext());
+            $transaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction(
+                $orderId, Context::createDefaultContext()
+            );
             $pluginId = $transaction->getPaymentMethod()->getPluginId();
 
-            if($pluginId == $adyenPluginId){
+            if ($pluginId == $adyenPluginId) {
                 return new JsonResponse(
                     ['status' => true]
                 );

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -528,21 +528,17 @@ class AdminController
         try {
             $adyenPluginId = $this->pluginProvider->getAdyenPluginId();
             $transaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction($orderId, Context::createDefaultContext());
+            $pluginId = $transaction->getPaymentMethod()->getPluginId();
 
-            if (!is_null($transaction)) {
-                $pluginId = $transaction->getPaymentMethod()->getPluginId();
-
-                if($pluginId == $adyenPluginId){
-                    return new JsonResponse(
-                        ['status' => true]
-                    );
-                }
+            if($pluginId == $adyenPluginId){
+                return new JsonResponse(
+                    ['status' => true]
+                );
             }
 
             return new JsonResponse(
                 ['status' => false]
             );
-
         } catch (Throwable $t) {
             return new JsonResponse(['message' => "Something went wrong."], 500);
         }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -515,7 +515,7 @@ class AdminController
     }
 
     /**
-     * @param string $pluginId
+     * @param string $orderId
      * @return JsonResponse
      */
     #[Route(

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -28,6 +28,7 @@ use Adyen\Service\Checkout;
 use Adyen\Shopware\Entity\AdyenPayment\AdyenPaymentEntity;
 use Adyen\Shopware\Entity\Notification\NotificationEntity;
 use Adyen\Shopware\Exception\CaptureException;
+use Adyen\Shopware\Provider\AdyenPluginProvider;
 use Adyen\Shopware\Service\AdyenPaymentService;
 use Adyen\Shopware\Service\CaptureService;
 use Adyen\Shopware\Service\ConfigurationService;
@@ -92,6 +93,9 @@ class AdminController
     /** @var OrderTransactionRepository */
     private OrderTransactionRepository $orderTransactionRepository;
 
+    /** @var AdyenPluginProvider */
+    private AdyenPluginProvider $pluginProvider;
+
     /**
      * AdminController constructor.
      *
@@ -107,6 +111,7 @@ class AdminController
      * @param ConfigurationService $configurationService
      * @param AdyenPaymentService $adyenPaymentService
      * @param OrderTransactionRepository $orderTransactionRepository
+     * @param AdyenPluginProvider $pluginProvider
      */
     public function __construct(
         LoggerInterface $logger,
@@ -120,7 +125,8 @@ class AdminController
         Currency $currencyUtil,
         ConfigurationService $configurationService,
         AdyenPaymentService $adyenPaymentService,
-        OrderTransactionRepository $orderTransactionRepository
+        OrderTransactionRepository $orderTransactionRepository,
+        AdyenPluginProvider $pluginProvider
     ) {
         $this->logger = $logger;
         $this->orderRepository = $orderRepository;
@@ -134,6 +140,7 @@ class AdminController
         $this->configurationService = $configurationService;
         $this->adyenPaymentService = $adyenPaymentService;
         $this->orderTransactionRepository = $orderTransactionRepository;
+        $this->pluginProvider = $pluginProvider;
     }
 
     /**
@@ -505,5 +512,26 @@ class AdminController
         }
 
         return new JsonResponse($notificationId);
+    }
+
+    /**
+     * @param string $pluginId
+     * @return JsonResponse
+     */
+    #[Route(
+        '/api/adyen/orders/{pluginId}/is-adyen-order',
+        name: 'api.adyen_is_adyen_order.get',
+        methods: ['GET']
+    )]
+    public function isAdyenOrder(string $pluginId): JsonResponse
+    {
+        try {
+            $adyenPluginId = $this->pluginProvider->getAdyenPluginId();
+            return new JsonResponse(
+                ['status' => $pluginId == $adyenPluginId]
+            );
+        } catch (Throwable $t) {
+            return new JsonResponse(['message' => 'Something went wrong.'], 500);
+        }
     }
 }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -519,19 +519,32 @@ class AdminController
      * @return JsonResponse
      */
     #[Route(
-        '/api/adyen/orders/{pluginId}/is-adyen-order',
+        '/api/adyen/orders/{orderId}/is-adyen-order',
         name: 'api.adyen_is_adyen_order.get',
         methods: ['GET']
     )]
-    public function isAdyenOrder(string $pluginId): JsonResponse
+    public function isAdyenOrder(string $orderId): JsonResponse
     {
         try {
             $adyenPluginId = $this->pluginProvider->getAdyenPluginId();
+            $transaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction($orderId, Context::createDefaultContext());
+
+            if (!is_null($transaction)) {
+                $pluginId = $transaction->getPaymentMethod()->getPluginId();
+
+                if($pluginId == $adyenPluginId){
+                    return new JsonResponse(
+                        ['status' => true]
+                    );
+                }
+            }
+
             return new JsonResponse(
-                ['status' => $pluginId == $adyenPluginId]
+                ['status' => false]
             );
+
         } catch (Throwable $t) {
-            return new JsonResponse(['message' => 'Something went wrong.'], 500);
+            return new JsonResponse(['message' => "Something went wrong."], 500);
         }
     }
 }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -528,7 +528,8 @@ class AdminController
         try {
             $adyenPluginId = $this->pluginProvider->getAdyenPluginId();
             $transaction = $this->orderTransactionRepository->getFirstAdyenOrderTransaction(
-                $orderId, Context::createDefaultContext()
+                $orderId,
+                Context::createDefaultContext()
             );
             $pluginId = $transaction->getPaymentMethod()->getPluginId();
 

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -273,8 +273,8 @@ class PaymentResponseHandler
             // Only store psp reference for the transaction if this is the first/original pspreference and not giftcard
             $pspReference = $result->getPspReference();
             if (empty($storedTransactionCustomFields[self::ORIGINAL_PSP_REFERENCE])
-                && !empty($pspReference)
-                && !$result->isGiftcardOrder()) {
+                && !empty($pspReference)) {
+//                && !$result->isGiftcardOrder()) {
                 $transactionCustomFields[self::ORIGINAL_PSP_REFERENCE] = $pspReference;
             }
 
@@ -285,8 +285,8 @@ class PaymentResponseHandler
             // Only store additional data for the transaction if this is the first additional data
             $additionalData = $result->getAdditionalData();
             if (empty($storedTransactionCustomFields[self::ADDITIONAL_DATA])
-                && !empty($additionalData)
-                && !$result->isGiftcardOrder()) {
+                && !empty($additionalData)) {
+//                && !$result->isGiftcardOrder()) {
                 $transactionCustomFields[self::ADDITIONAL_DATA] = $additionalData;
             }
         }

--- a/src/Handlers/PaymentResponseHandler.php
+++ b/src/Handlers/PaymentResponseHandler.php
@@ -273,8 +273,8 @@ class PaymentResponseHandler
             // Only store psp reference for the transaction if this is the first/original pspreference and not giftcard
             $pspReference = $result->getPspReference();
             if (empty($storedTransactionCustomFields[self::ORIGINAL_PSP_REFERENCE])
-                && !empty($pspReference)) {
-//                && !$result->isGiftcardOrder()) {
+                && !empty($pspReference)
+                && !$result->isGiftcardOrder()) {
                 $transactionCustomFields[self::ORIGINAL_PSP_REFERENCE] = $pspReference;
             }
 
@@ -285,8 +285,8 @@ class PaymentResponseHandler
             // Only store additional data for the transaction if this is the first additional data
             $additionalData = $result->getAdditionalData();
             if (empty($storedTransactionCustomFields[self::ADDITIONAL_DATA])
-                && !empty($additionalData)) {
-//                && !$result->isGiftcardOrder()) {
+                && !empty($additionalData)
+                && !$result->isGiftcardOrder()) {
                 $transactionCustomFields[self::ADDITIONAL_DATA] = $additionalData;
             }
         }

--- a/src/Resources/app/administration/src/component/adyen-refund/index.js
+++ b/src/Resources/app/administration/src/component/adyen-refund/index.js
@@ -118,24 +118,10 @@ Component.register('adyen-refund', {
 
             this.allowRefund = this.order.amountTotal > (refundedAmount / 100);
         },
-
-        isAdyenOrder() {
-            const orderTransactions = this.order.transactions;
-            let isAdyen = false;
-            for (let i = 0; i < orderTransactions.length; i++) {
-                if (orderTransactions[i].customFields !== undefined) {
-                    if (orderTransactions[i].customFields.originalPspReference !== undefined) {
-                        isAdyen = true;
-                    }
-                }
-            }
-
-            this.showWidget = isAdyen;
-        }
     },
 
     beforeMount() {
-        this.isAdyenOrder();
+        this.showWidget = this.adyenService.isAdyenOrder(this.order);
         if (this.showWidget) {
             this.fetchRefunds();
         }

--- a/src/Resources/app/administration/src/service/adyenService.js
+++ b/src/Resources/app/administration/src/service/adyenService.js
@@ -159,18 +159,35 @@ class ApiClient extends ApiService {
             });
     }
 
-    isAdyenOrder(order) {
+    async isAdyenOrder(order) {
         const orderTransactions = order.transactions;
         let isAdyen = false;
         for (let i = 0; i < orderTransactions.length; i++) {
-            if (orderTransactions[i].customFields !== undefined) {
-                if (orderTransactions[i].customFields.originalPspReference !== undefined) {
-                    isAdyen = true;
-                }
+            isAdyen = await this.checkAdyenOrder(orderTransactions[i].paymentMethod.pluginId).then((res) => {
+                return res.status
+            });
+
+            if (isAdyen){
+                return isAdyen;
             }
         }
 
         return isAdyen;
+    }
+
+    checkAdyenOrder(pluginId) {
+        const headers = this.getBasicHeaders({});
+        return this.httpClient
+            .get(this.getApiBasePath()  + '/orders/' + pluginId + '/is-adyen-order', {
+                headers
+            })
+            .then((response) => {
+                return ApiService.handleResponse(response);
+            })
+            .catch((error) => {
+                console.error('An error occurred: ' + error.message);
+                throw error;
+            });
     }
 
     fetchAdyenPartialPayments(orderId) {

--- a/src/Resources/app/administration/src/service/adyenService.js
+++ b/src/Resources/app/administration/src/service/adyenService.js
@@ -159,30 +159,17 @@ class ApiClient extends ApiService {
             });
     }
 
-    async isAdyenOrder(order) {
-        const orderTransactions = order.transactions;
-        let isAdyen = false;
-        for (let i = 0; i < orderTransactions.length; i++) {
-            isAdyen = await this.checkAdyenOrder(orderTransactions[i].paymentMethod.pluginId).then((res) => {
-                return res.status
-            });
-
-            if (isAdyen){
-                return isAdyen;
-            }
-        }
-
-        return isAdyen;
-    }
-
-    checkAdyenOrder(pluginId) {
+    isAdyenOrder(order){
         const headers = this.getBasicHeaders({});
         return this.httpClient
-            .get(this.getApiBasePath()  + '/orders/' + pluginId + '/is-adyen-order', {
+            .get(this.getApiBasePath()  + '/orders/' + order.id + '/is-adyen-order', {
                 headers
             })
             .then((response) => {
                 return ApiService.handleResponse(response);
+            })
+            .then((response) => {
+                return response.status
             })
             .catch((error) => {
                 console.error('An error occurred: ' + error.message);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adyen related tables notifications, refunds and captures are not showing up if the payment is completed with gift card payment. This PR contains an updated check for whether an order is an Adyen order based on orderTransaction. If the order is an Adyen-Order the tables would show up regardless of the payment method.