### PR TITLE
[ECP-9226] Update syntax for default value in alter table in migration

### DIFF
--- a/src/Migration/Migration1713255011AlterAdyenPayment.php
+++ b/src/Migration/Migration1713255011AlterAdyenPayment.php
@@ -15,7 +15,7 @@ class Migration1713255011AlterAdyenPayment extends MigrationStep
     public function update(Connection $connection): void
     {
         $connection->executeStatement(<<<SQL
-            ALTER TABLE `adyen_payment` ADD COLUMN `total_refunded` int DEFAULT(0) NOT NULL;
+            ALTER TABLE `adyen_payment` ADD COLUMN `total_refunded` int DEFAULT 0 NOT NULL;
         SQL);
     }
 


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Merchants sometimes get database syntax error on updating the plugin. This error occurs when the syntax of SQL query in alter table for providing  default value is not compatible with the MYSQL modes being used by the merchant. In this PR we update the syntax to a format that is expected to have more leniency.
