### PR TITLE
Add more detailed modal blocks

### DIFF
--- a/src/Resources/views/storefront/component/payment/payment-action-modal.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-action-modal.html.twig
@@ -7,13 +7,17 @@
     >
         <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered">
             <div class="modal-content">
-                <div class="modal-body">
-                    <div class="adyen-payment-action-container" data-adyen-payment-action-container>
-                        <div class="adyen-payment-container loader" role="status">
-                            <span class="sr-only">{{ "adyen.loading"|trans }}</span>
+                {% block adyen_payment_action_modal_head %}
+                {% endblock %}
+                {% block adyen_payment_action_modal_body %}
+                    <div class="modal-body">
+                        <div class="adyen-payment-action-container" data-adyen-payment-action-container>
+                            <div class="adyen-payment-container loader" role="status">
+                                <span class="sr-only">{{ "adyen.loading"|trans }}</span>
+                            </div>
                         </div>
                     </div>
-                </div>
+                {% endblock %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary

At the moment to override/extend the modal, for example add a header to it, you would need to override the whole `adyen_payment_action_modal` block in [src/Resources/views/storefront/component/payment/payment-action-modal.html.twig](https://github.com/Adyen/adyen-shopware6/blob/develop/src/Resources/views/storefront/component/payment/payment-action-modal.html.twig)

I propose to add two more blocks `adyen_payment_action_modal_head` & `adyen_payment_action_modal_body`

## Tested scenarios
N/A

**Fixed issue**:  N/A
