### PR TITLE
Set modal height to Adyen component height

### DIFF
--- a/src/Resources/app/storefront/src/scss/modal.scss
+++ b/src/Resources/app/storefront/src/scss/modal.scss
@@ -22,10 +22,6 @@
 
 .adyen-payment-modal .modal-dialog {
   height: calc(100% - 3.5rem);
-
-  .modal-content {
-    height: 80%;
-  }
 }
 
 .adyen-payment-container.loader {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When a QR/3DS modal is shown and the Adyen component is bigger than the modal, a scroll bar is shown. When removing the height from the modal, the modal height will automatically adapt to the height of the component.

The height on the modal was introduced when the modal had a header which has since been removed.
See: https://github.com/wannevancamp/adyen-shopware6/commit/88b622df269bce464733e9b408ae238e5e08ca55

## Tested scenarios
Mobile before
<img width="186" alt="Demostore 2024-06-12 09-56-16" src="https://github.com/Adyen/adyen-shopware6/assets/3399877/217a3665-f196-4c19-9a54-e99832b6f7b2">

Mobile after
<img width="186" alt="Demostore 2024-06-12 09-56-54" src="https://github.com/Adyen/adyen-shopware6/assets/3399877/df741da6-ac7f-4ce7-8037-19bf04e731f6">


Desktop before
<img width="406" alt="Demostore 2024-06-12 09-57-18" src="https://github.com/Adyen/adyen-shopware6/assets/3399877/c5691f74-fe60-4c29-9279-ba047af35546">


Desktop after
<img width="405" alt="Demostore 2024-06-12 09-57-30" src="https://github.com/Adyen/adyen-shopware6/assets/3399877/9e4e64ad-ab39-4c36-b7a8-ef2aa824a926">

