### PR TITLE
Fix invalid method usage for sw version < 6.4.17.0

### DIFF
--- a/src/Subscriber/ContextSubscriber.php
+++ b/src/Subscriber/ContextSubscriber.php
@@ -73,12 +73,17 @@ class ContextSubscriber implements EventSubscriberInterface
 
     public function onContextRestored(SalesChannelContextRestoredEvent $event): void
     {
+        if (!method_exists($event, 'getCurrentSalesChannelContext')) {
+            return;
+        }
+
         $token = $event->getRestoredSalesChannelContext()->getToken();
         $oldToken = $event->getCurrentSalesChannelContext()->getToken();
 
+
         $stateData = $this->paymentStateDataService->fetchRedeemedGiftCardsFromContextToken($oldToken);
-        foreach ($stateData->getElements() as $statedataArray) {
-            $this->paymentStateDataService->updateStateDataContextToken($statedataArray, $token);
+        foreach ($stateData->getElements() as $stateDataArray) {
+            $this->paymentStateDataService->updateStateDataContextToken($stateDataArray, $token);
         }
     }
 


### PR DESCRIPTION
This change resolves an error due to the usage of not available methods for older Shopware versions.

The method `getCurrentContext` was introduced with 6.4.17.0 (see [here](https://github.com/shopware/shopware/commit/c871e77688d679241fbb2ad92c8c3d922fe475f8)).

Before this there was no method like this so I added an early return instead.
This currently breaks a stage system with version 6.4.14.0.

As stated in the [Shopware store](https://store.shopware.com/de/adyen70424242359f/adyen-payments-fuer-shopware-6.html), this plugin is currently compatible with the version range: 6.3.1.1 - 6.5.8.11
