### PR TITLE
Use transaction amount instead of order amount

### DIFF
--- a/src/Handlers/AbstractPaymentMethodHandler.php
+++ b/src/Handlers/AbstractPaymentMethodHandler.php
@@ -339,7 +339,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
         $uuid = Uuid::randomHex();
         $currency = $salesChannelContext->getCurrency()->getIsoCode();
         $amount = $this->currency->sanitize(
-            $transaction->getOrder()->getPrice()->getTotalPrice(),
+            $transaction->getOrderTransaction()->getAmount()->getTotalPrice(),
             $salesChannelContext->getCurrency()->getIsoCode()
         );
         return $this->ordersService->createOrder($salesChannelContext, $uuid, $amount, $currency);
@@ -569,7 +569,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
 
         //Building payment data
         $amount = $partialAmount ?: $this->currency->sanitize(
-            $transaction->getOrder()->getPrice()->getTotalPrice(),
+            $transaction->getOrderTransaction()->getAmount()->getTotalPrice(),
             $salesChannelContext->getCurrency()->getIsoCode()
         );
 
@@ -832,7 +832,7 @@ abstract class AbstractPaymentMethodHandler implements AsynchronousPaymentHandle
 
         //New Multi-Gift-card implementation
         $remainingOrderAmount = $this->currency->sanitize(
-            $transaction->getOrder()->getPrice()->getTotalPrice(),
+            $transaction->getOrderTransaction()->getAmount()->getTotalPrice(),
             $salesChannelContext->getCurrency()->getIsoCode()
         );
 


### PR DESCRIPTION
## Summary

Currently the payment requests are made for the order amount, but this incorrect when using partial payments (which is supported in Shopware, even though it is not fully developed by core functionality). It should be the transaction amount. This is also logical in the sense that each payment is about a transaction, NOT for an order, only indirectly it is.
