### PR TITLE
Upgrading Library version to V20.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "shopware/core": "~6.6.0",
         "shopware/storefront": "~6.6.0",
-        "adyen/php-api-library": "^17.5.0",
+        "adyen/php-api-library": "^20.2.0",
         "adyen/php-webhook-module": "^1",
         "ext-json": "*"
     },


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
There is an inconsistency in [setItemCategory()](https://github.com/Adyen/adyen-php-api-library/blob/03573f5507442120838717dfdd9b2c4c8fe9fa92/src/Adyen/Model/Checkout/LineItem.php#L597) method. It looks like it excepts null parameters but fails after the is_null() check in the method.

This inconsistency has been fixed on the library on V18.2.1. Upgrading to the recent version (V20.2.0) of the library to solve the issue.
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
