### PR TITLE
[ECP-9424]Upgrading to the latest library V20.2.0 For plugin V3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,14 @@
         }
     ],
     "description": "Official Shopware 6 Plugin to connect to Payment Service Provider Adyen",
-    "version": "4.1.0",
+    "version": "3.16.1",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "require": {
-        "shopware/core": "~6.6.0",
-        "shopware/storefront": "~6.6.0",
+        "shopware/core": "~6.4.0 || ~6.5.0",
+        "shopware/storefront": "~6.4.0 || ~6.5.0",
         "adyen/php-api-library": "^20.2.0",
-        "adyen/php-webhook-module": "^1",
+        "adyen/php-webhook-module": "0.8.0",
         "ext-json": "*"
     },
     "extra": {
@@ -41,8 +41,8 @@
         }
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.7",
-        "phpunit/phpunit": "^10.4"
+        "squizlabs/php_codesniffer": "^3.5",
+        "phpunit/phpunit": "^9"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "shopware/core": "~6.6.0",
         "shopware/storefront": "~6.6.0",
-        "adyen/php-api-library": "^17.5.0",
+        "adyen/php-api-library": "^20.2.0",
         "adyen/php-webhook-module": "^1",
         "ext-json": "*"
     },


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
There is an inconsistency in [setItemCategory()](https://github.com/Adyen/adyen-php-api-library/blob/03573f5507442120838717dfdd9b2c4c8fe9fa92/src/Adyen/Model/Checkout/LineItem.php#L597) method. It looks like it excepts null parameters but fails after the is_null() check in the method.

This inconsistency has been fixed on the library on V18.2.1. Upgrading to the recent version (V20.2.0) of the library to solve the issue.
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
