### PR TITLE
[ECP 9434] Packaged ZIP not working

### DIFF
--- a/.github/workflows/scripts/prepare-release-asset.sh
+++ b/.github/workflows/scripts/prepare-release-asset.sh
@@ -25,7 +25,7 @@ zip -r AdyenPaymentShopware6.zip AdyenPaymentShopware6/
 zip -d AdyenPaymentShopware6.zip __MACOSX/\* ; zip -d AdyenPaymentShopware6.zip *.git*
 
 # Move the zip file to plugin folder (use absolute path to avoid issues)
-mv AdyenPaymentShopware6.zip adyen-shopware6/AdyenPaymentShopware6.zip
+mv AdyenPaymentShopware6.zip adyen-shopware6
 
 # Go back to workflow's root directory
 cd adyen-shopware6

--- a/.github/workflows/scripts/prepare-release-asset.sh
+++ b/.github/workflows/scripts/prepare-release-asset.sh
@@ -19,13 +19,13 @@ composer install --no-dev --working-dir=./AdyenPaymentShopware6
 cp adyen-shopware6/composer.json AdyenPaymentShopware6/.
 
 # Zip the plugin directory
-zip -r AdyenPaymentShopware6.zip AdyenPaymentShopware6/ ;
+zip -r AdyenPaymentShopware6.zip AdyenPaymentShopware6/
 
 # Cleanup the zip installation
 zip -d AdyenPaymentShopware6.zip __MACOSX/\* ; zip -d AdyenPaymentShopware6.zip *.git*
 
-# Move the zip file to plugin folder
-mv AdyenPaymentShopware6.zip adyen-shopware6
+# Move the zip file to plugin folder (use absolute path to avoid issues)
+mv AdyenPaymentShopware6.zip adyen-shopware6/AdyenPaymentShopware6.zip
 
 # Go back to workflow's root directory
 cd adyen-shopware6

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -1,5 +1,4 @@
 on:
-  push:
   release:
     types: [published]
 
@@ -24,17 +23,9 @@ jobs:
       - name: Prepare release artifact
         run: .github/workflows/scripts/prepare-release-asset.sh
 
-      # Debug step 1: Print the current directory
-      - name: Print working directory
-        run: pwd
-
-      # Debug step 2: List files in the root directory
-      - name: List files in the root directory
-        run: ls -al
-
-      # Upload the artifact
+      # Upload the artifact (from root directory)
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: AdyenPaymentShopware6
-          path: adyen-shopware6/AdyenPaymentShopware6.zip
+          path: AdyenPaymentShopware6.zip

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -15,8 +15,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2+'  # Ensures that PHP 8.2 is used
-          extensions: mbstring, xml, intl
+          php-version: '8.2+'
 
       - name: Prepare release artifact
         run: .github/workflows/scripts/prepare-release-asset.sh

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -1,4 +1,5 @@
 on:
+  push:
   release:
     types: [published]
 

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -21,8 +21,14 @@ jobs:
       - name: Prepare release artifact
         run: .github/workflows/scripts/prepare-release-asset.sh
 
-      - name:  Upload asset
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ github.ref_name }} AdyenPaymentShopware6.zip --clobber
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: AdyenPaymentShopware6
+          path: adyen-shopware6/AdyenPaymentShopware6.zip
+
+#      - name:  Upload asset
+#        env:
+#          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          gh release upload ${{ github.ref_name }} AdyenPaymentShopware6.zip --clobber

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -1,34 +1,43 @@
 on:
-  push:
   release:
     types: [published]
 
-name: Upload Shopware 6 Marketplace asset
+name: Create and Upload Shopware 6 Marketplace Artifact
 
 jobs:
   run:
-    name: Upload Release Asset
+    name: Create and Upload Artifact
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up PHP
+      - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2+'
+          php-version: '8.2'  # Use 8.3 if preferred
+
+      - name: Make script executable
+        run: chmod +x .github/workflows/scripts/prepare-release-asset.sh
 
       - name: Prepare release artifact
         run: .github/workflows/scripts/prepare-release-asset.sh
 
+      # Debug step 1: Print the current directory
+      - name: Print working directory
+        run: pwd
+
+      # Debug step 2: List files in the root directory
+      - name: List files in the root directory
+        run: ls -al
+
+      # Debug step 3: List files in adyen-shopware6 directory
+      - name: List files in adyen-shopware6 directory
+        run: ls -al adyen-shopware6
+
+      # Upload the artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: AdyenPaymentShopware6
           path: adyen-shopware6/AdyenPaymentShopware6.zip
-
-#      - name:  Upload asset
-#        env:
-#          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          gh release upload ${{ github.ref_name }} AdyenPaymentShopware6.zip --clobber

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.2+'  # Ensures that PHP 8.2 is used
           extensions: mbstring, xml, intl
 
       - name: Prepare release artifact

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -12,6 +12,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, xml, intl
+
       - name: Prepare release artifact
         run: .github/workflows/scripts/prepare-release-asset.sh
 

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'  # Use 8.3 if preferred
+          php-version: '8.2+'
 
       - name: Make script executable
         run: chmod +x .github/workflows/scripts/prepare-release-asset.sh

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -32,10 +32,6 @@ jobs:
       - name: List files in the root directory
         run: ls -al
 
-      # Debug step 3: List files in adyen-shopware6 directory
-      - name: List files in adyen-shopware6 directory
-        run: ls -al adyen-shopware6
-
       # Upload the artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -1,5 +1,4 @@
 on:
-  push:
   release:
     types: [published]
 
@@ -18,15 +17,11 @@ jobs:
         with:
           php-version: '8.2+'
 
-      - name: Make script executable
-        run: chmod +x .github/workflows/scripts/prepare-release-asset.sh
-
       - name: Prepare release artifact
         run: .github/workflows/scripts/prepare-release-asset.sh
 
-      # Upload the artifact (from root directory)
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: AdyenPaymentShopware6
-          path: AdyenPaymentShopware6.zip
+      - name: Upload asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} AdyenPaymentShopware6.zip --clobber

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "shopware/core": "~6.6.0",
         "shopware/storefront": "~6.6.0",
-        "adyen/php-api-library": "^17.5.0",
+        "adyen/php-api-library": "^20.2.0",
         "adyen/php-webhook-module": "^1",
         "ext-json": "*"
     },


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Zip file uploaded as assets were broken because of the `prepare-release-asset.yml` workflow fails, because of incorrect php version dependency.
This PR aims at having php version greater then 8.2
Example of the correct zip file can be seen here in the form of artifact
https://github.com/Adyen/adyen-shopware6/actions/runs/10898416714
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
