### PR TITLE
[ECP-9434]Making changes to release asset yml, passing php version

### DIFF
--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2+'
+
       - name: Prepare release artifact
         run: .github/workflows/scripts/prepare-release-asset.sh
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Zip file uploaded as assets was broken, as the prepare-release-assets.yml was failing due to incorrect php version constraint.
Defining the php version to the workflow.
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
