### PR TITLE
[CS-5938] Add explicit association for deliveries.stateMachineState in webhooks

### DIFF
--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -88,7 +88,10 @@ class CaptureService
         $order = $this->orderRepository->getOrderByOrderNumber(
             $orderNumber,
             $context,
-            ['transactions', 'currency', 'lineItems', 'deliveries', 'deliveries.shippingMethod']
+            [
+                'transactions', 'currency', 'lineItems', 'deliveries',
+                'deliveries.shippingMethod', 'deliveries.stateMachineState'
+            ]
         );
 
         if (is_null($order)) {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When an openInvoice AUTHORISATION webhook is received, the webhook never completes processing if the "Capture on Shipment for OpenInvoice Payment Methods" option is enabled. It always stays in processing and causes downstream issues for captures for manual captures. Order is marked as paid but not fully completed.

The issue is caused by the delivery object doesn't return `stateMachineState` object by default anymore for Shopware 6.6. The association must be included explicitly.

## Tested scenarios
OopenInvoice AUTHORISATION webhook processing with the "Capture on Shipment for OpenInvoice Payment Methods" option enabled.
