### PR TITLE
Fixed express methods in combination with MultiWarehouse and for dev environment

### DIFF
--- a/src/Resources/views/storefront/component/checkout/expresscheckout.html.twig
+++ b/src/Resources/views/storefront/component/checkout/expresscheckout.html.twig
@@ -18,7 +18,6 @@
          data-user-logged-in="{{ adyenFrontendData.userLoggedIn }}"
          data-affiliate-code="{{ adyenFrontendData.affiliateCode }}"
          data-campaign-code="{{ adyenFrontendData.campaignCode }}"
-         data-shipping-methods-response="{{ adyenFrontendData.shippingMethodsResponse|json_encode }}"
          data-google-merchant-id="{{ adyenFrontendData.googleMerchantId }}"
          data-gateway-merchant-id="{{ adyenFrontendData.gatewayMerchantId }}"
     ></div>

--- a/src/Service/ExpressCheckoutService.php
+++ b/src/Service/ExpressCheckoutService.php
@@ -780,8 +780,8 @@ class ExpressCheckoutService
 
             return [
                 'id' => $method->getId(),
-                'label' => $method->getName(),
-                'description' => $method->getDescription() ?? '',
+                'label' => $method->getTranslation('name'),
+                'description' => $method->getTranslation('description') ?? '',
                 'value' => $value,
                 'currency' => $currency,
                 'selected' => $selectedShippingMethod->getId() === $method->getId(),

--- a/src/Service/ExpressCheckoutService.php
+++ b/src/Service/ExpressCheckoutService.php
@@ -429,6 +429,7 @@ class ExpressCheckoutService
             $contextWithNewVersion
         );
         $cartFromOrder = $this->orderConverter->convertToCart($orderWithNewVersion, $contextWithNewVersion);
+        $cartFromOrder->setRuleIds($contextWithNewVersion->getRuleIds());
         $recalculatedCart = $this->cartService->recalculate($cartFromOrder, $updatedSalesChannelContext);
 
         $newOrderData = $this->orderConverter->convertToOrder(
@@ -481,6 +482,7 @@ class ExpressCheckoutService
         SalesChannelContext $salesChannelContext
     ) :array {
         $cart = $this->orderConverter->convertToCart($order, $salesChannelContext->getContext());
+        $cart->setRuleIds($salesChannelContext->getRuleIds());
 
         $shippingLocation = $salesChannelContext->getShippingLocation();
 

--- a/src/Service/Repository/ExpressCheckoutRepository.php
+++ b/src/Service/Repository/ExpressCheckoutRepository.php
@@ -312,7 +312,7 @@ class ExpressCheckoutRepository
             $salesChannelContext->getShippingLocation()->getCountry()->getIso();
         $countryId = $this->getCountryId($countryCode, $salesChannelContext);
         $stateID = null;
-        if ($newAddress['state'] && $countryCode) {
+        if (isset($newAddress['state']) && $newAddress['state'] && $countryCode) {
             $stateID = $this->getStateId($newAddress['state'], $countryCode, $salesChannelContext);
         }
         $city = $newAddress['city'] ?? 'Adyen Guest City';
@@ -514,7 +514,7 @@ class ExpressCheckoutRepository
     ): CustomerAddressEntity {
         $countryId = $this->getCountryId($newAddress['countryCode'], $salesChannelContext);
         $stateID = null;
-        if ($newAddress['state'] && $newAddress['countryCode']) {
+        if (isset($newAddress['state']) && $newAddress['state'] && $newAddress['countryCode']) {
             $stateID = $this->getStateId($newAddress['state'], $newAddress['countryCode'], $salesChannelContext);
         }
         $city = $newAddress['city'] ?? 'Adyen Guest City';
@@ -562,7 +562,7 @@ class ExpressCheckoutRepository
         // Update customer address
         $this->customerAddressRepository->update($customerAddressData, $salesChannelContext->getContext());
 
-        if ($newAddress['email']) {
+        if (isset($newAddress['email']) && $newAddress['email']) {
             $customerData = [
                 [
                     'id' => $customer->getId(),


### PR DESCRIPTION
## Summary

- Added isset()'s so that the plugin works on dev environment without throwing "undefined array key" errors
- Added RuleIds to carts created from orders to make it compatible with SwagCommercial MultiWarehouse functionality's (product stocks are based on those rules)
- Removed redundant `data-shipping-methods-response` from expresscheckout.html.twig as it's not used by javascript
- Fixed how shipping translations are passed to the widgets

## Tested scenarios
GooglePay express flow
PayPal express flow
