### PR TITLE
Fix duplicate media file handling

### DIFF
--- a/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
+++ b/src/ScheduledTask/FetchPaymentMethodLogosHandler.php
@@ -30,6 +30,7 @@ use Exception;
 use Psr\Log\LoggerAwareTrait;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Content\Media\File\MediaFile;
+use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -158,14 +159,31 @@ class FetchPaymentMethodLogosHandler extends ScheduledTaskHandler
         string $filename,
         string $paymentMethodEntityId
     ): void {
-        $mediaId = $this->mediaService->createMediaInFolder('adyen', $context, false);
-        $this->mediaService->saveMediaFile(
-            $media,
-            $filename,
-            $context,
-            'adyen',
-            $mediaId
-        );
+        try {
+            $mediaId = $this->mediaService->createMediaInFolder('adyen', $context, false);
+            $this->mediaService->saveMediaFile(
+                $media,
+                $filename,
+                $context,
+                'adyen',
+                $mediaId
+            );
+        } catch (MediaException $exception) {
+            if ($exception->getErrorCode() !== MediaException::MEDIA_DUPLICATED_FILE_NAME) {
+                throw $exception;
+            }
+
+            $mediaId = $this->mediaRepository->search(
+                (new Criteria())->addFilter(new EqualsFilter('fileName', $filename)),
+                $context
+            )->getEntities()->first()?->getId();
+
+            if (!$mediaId) {
+                $this->logger->error(sprintf('The media file with filename %s could not be found.', $filename));
+
+                return;
+            }
+        }
 
         $this->paymentMethodRepository->update([
             [


### PR DESCRIPTION
## Summary
Fixed an occuring bug where you can't run `adyen:fetch-logos` without errors if an image is unassigned but the media file exists.

This PR fixes this by catching the specific exception and using the existing mediaId
