### PR TITLE
add twig blocks around inline scripts

### DIFF
--- a/src/Resources/views/storefront/component/adyen-giving/adyen-giving-component.html.twig
+++ b/src/Resources/views/storefront/component/adyen-giving/adyen-giving-component.html.twig
@@ -15,9 +15,10 @@
         ></div>
 
         <div id='donation-container'></div>
-
-        <script>
-            var adyenGivingConfiguration = document.querySelector('#adyen-giving-configuration').dataset;
-        </script>
+        {% block adyen_giving_inline_script %}
+            <script>
+                var adyenGivingConfiguration = document.querySelector('#adyen-giving-configuration').dataset;
+            </script>
+        {% endblock %}
     </div>
 {% endif %}

--- a/src/Resources/views/storefront/component/adyencheckout.html.twig
+++ b/src/Resources/views/storefront/component/adyencheckout.html.twig
@@ -10,6 +10,8 @@
         {# Load checkout web component (Corresponding version number can be found on release notes.) #}
         <link rel="stylesheet" href="{{ asset('bundles/adyenpaymentshopware6/css/adyen.css', 'asset') }}">
         <script type="text/javascript" src="{{ asset('bundles/adyenpaymentshopware6/js/adyen.js', 'asset') }}"></script>
-        <script>var adyenCheckoutConfiguration = document.querySelector('#adyen-checkout-configuration').dataset;</script>
+        {% block adyen_checkout_inline_script %}
+            <script>var adyenCheckoutConfiguration = document.querySelector('#adyen-checkout-configuration').dataset;</script>
+        {% endblock %}
     {% endif %}
 {% endblock %}

--- a/src/Resources/views/storefront/component/checkout/cart/giftcards.html.twig
+++ b/src/Resources/views/storefront/component/checkout/cart/giftcards.html.twig
@@ -23,7 +23,9 @@
                  data-translation-adyen-giftcard-remaining-amount="{{ "adyen.giftcard.remainingAmount" | trans }}"
                  data-translation-adyen-giftcard-remove="{{ "adyen.giftcard.removeGiftcard" | trans }}"
             ></div>
-            <script>var adyenGiftcardsConfiguration = document.querySelector('#adyen-giftcards-configuration').dataset;</script>
+            {% block adyen_checkout_giftcard_inline_script %}
+                <script>var adyenGiftcardsConfiguration = document.querySelector('#adyen-giftcards-configuration').dataset;</script>
+            {% endblock %}
             {# loop through giftcards and display logo #}
             <select id="giftcardDropdown" style="display: none" aria-label="{{ 'adyen.giftcard.chooseGiftcard' | trans }}">
                 <option value="" disabled selected>{{ "adyen.giftcard.chooseGiftcard" | trans }}</option>

--- a/src/Resources/views/storefront/component/checkout/expresscheckout.html.twig
+++ b/src/Resources/views/storefront/component/checkout/expresscheckout.html.twig
@@ -29,7 +29,9 @@
                    value="{{ adyenPaymentMethodType|escape }}">
         </div>
     {% endfor %}
-    <script>
-        var adyenExpressCheckoutOptions = document.querySelector('#adyen-express-checkout-options').dataset;
-    </script>
+    {% block adyen_express_checkout_inline_script %}
+        <script>
+            var adyenExpressCheckoutOptions = document.querySelector('#adyen-express-checkout-options').dataset;
+        </script>
+    {% endblock %}
 </div>

--- a/src/Resources/views/storefront/component/payment/payment-success-action.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-success-action.html.twig
@@ -6,8 +6,10 @@
 
         <div id='success-action-container'></div>
 
-        <script>
-            var adyenSuccessActionConfiguration = document.querySelector('#adyen-success-action-configuration').dataset;
-        </script>
+        {% block adyen_payment_success_action_inline_script %}
+            <script>
+                var adyenSuccessActionConfiguration = document.querySelector('#adyen-success-action-configuration').dataset;
+            </script>
+        {% endblock %}
     </div>
 {% endif %}

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -32,11 +32,13 @@
                 data-country="{{ shippingAddress.country.iso }}"
                 data-phone-number="{{ shippingAddress.phoneNumber }}"
             ></div>
-            <script>
-                var shopperDetails = document.querySelector('#shopper-details').dataset;
-                var activeBillingAddress = document.querySelector('#active-billing-address').dataset;
-                var activeShippingAddress = document.querySelector('#active-shipping-address').dataset;
-            </script>
+            {% block adyen_confirm_payment_addresses_inline_script %}
+                <script>
+                    var shopperDetails = document.querySelector('#shopper-details').dataset;
+                    var activeBillingAddress = document.querySelector('#active-billing-address').dataset;
+                    var activeShippingAddress = document.querySelector('#active-shipping-address').dataset;
+                </script>
+            {% endblock %}
         {% endif %}
         {% if adyenFrontendData and adyenFrontendData.paymentStatusUrl and adyenFrontendData.paymentMethodsResponse %}
             <div id="adyen-checkout-options"
@@ -70,9 +72,11 @@
                  data-gateway-merchant-id="{{ adyenFrontendData.gatewayMerchantId }}"
             >
             </div>
-            <script>
-                var adyenCheckoutOptions = document.querySelector('#adyen-checkout-options').dataset;
-            </script>
+            {% block adyen_confirm_payment_checkout_options_inline_script %}
+                <script>
+                    var adyenCheckoutOptions = document.querySelector('#adyen-checkout-options').dataset;
+                </script>
+            {% endblock %}
         {% endif %}
     {% endblock %}
 {% endblock %}

--- a/src/Resources/views/storefront/page/checkout/finish/finish-details.html.twig
+++ b/src/Resources/views/storefront/page/checkout/finish/finish-details.html.twig
@@ -7,7 +7,9 @@
 
     {% sw_include '@AdyenPaymentShopware6/storefront/component/adyencheckout.html.twig' %}
     {% if adyenFrontendData %}
-        <script>window.localStorage.removeItem('confirmOrderForm.tos');</script>
+        {% block adyen_finish_details_inline_script %}
+            <script>window.localStorage.removeItem('confirmOrderForm.tos');</script>
+        {% endblock %}
         {% if adyenFrontendData.notification %}
             <h2 style="text-align: center; margin-bottom: 40px">{{ "adyen.notification.message"|trans }}</h2>
         {% endif %}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
if you set csp headers, inline scripts are no longer secure enough. 
To make the inline scripts from `<script>` to `<script nonce={{ app.request.attributes.get("_cspNonce") }}>`, you would have to copy 90% of the twig template files to adapt one line of code.

that's why i created the blocks around the inline scripts. so that you can customise exactly these places in the theme without having to duplicate the complete code.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
