### PR TITLE
Remove Giropay from README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ The plugin integrates card component (Secured Fields) using Adyen Checkout for a
  - Clearpay
  - Electronic Payment Service (EPS)
  - Gift cards
- - GiroPay
  - Google Pay
  - iDeal
  - Klarna Pay Later


### PR DESCRIPTION
## Summary
Remove Giropay from the list of supported payment methods in the Readme file, because Adyen no longer supports it.