### PR TITLE
Validate all required input fields when accessibility tweaks are active

### DIFF
--- a/src/Resources/app/storefront/src/configuration/adyen.js
+++ b/src/Resources/app/storefront/src/configuration/adyen.js
@@ -19,12 +19,25 @@
  * See the LICENSE file for more info.
  *
  */
-function validateTOS(self) {
-    const tosCheckbox = document.querySelector('#tos');
-    if(adyenCheckoutOptions?.accessibilityTweaks === '1' && tosCheckbox && !tosCheckbox.checked) {
-        tosCheckbox.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        tosCheckbox.focus();
-        return false;
+
+function validateRequired(self) {
+    if (adyenCheckoutOptions?.accessibilityTweaks === "1") {
+        const requiredFields = document.querySelectorAll("input[required]");
+
+        for (const field of requiredFields) {
+            if (!field.checkValidity()) {
+                const onScrollEnd = () => {
+                    field.focus();
+                    field.reportValidity();
+                    document.removeEventListener("scrollend", onScrollEnd);
+                };
+
+                document.addEventListener("scrollend", onScrollEnd, { once: true });
+                field.scrollIntoView({ behavior: "smooth", block: "center" });
+                return false;
+            }
+        }
+        return true;
     }
 
     return self.confirmOrderForm.checkValidity();
@@ -41,7 +54,7 @@ export default {
         'applepay': {
             extra: {},
             onClick(resolve, reject, self) {
-                if(!validateTOS(self)) {
+                if(!validateRequired(self)) {
                     reject();
                     return false;
                 }
@@ -59,7 +72,7 @@ export default {
                 buttonSizeMode: 'fill',
             },
             onClick: function (resolve, reject, self) {
-                if(!validateTOS(self)) {
+                if(!validateRequired(self)) {
                     reject();
                     return false;
                 }
@@ -84,7 +97,7 @@ export default {
         'paypal': {
             extra: {},
             onClick: function (source, event, self) {
-                return validateTOS(self);
+                return validateRequired(self);
             },
             onError: function(error, component, self) {
                 component.setStatus('ready');
@@ -134,7 +147,7 @@ export default {
             prePayRedirect: true,
             sessionKey: 'amazonCheckoutSessionId',
             onClick: function (resolve, reject, self) {
-                if(!validateTOS(self)) {
+                if(!validateRequired(self)) {
                     reject();
                     return false;
                 }


### PR DESCRIPTION
## Summary

When custom required form fields are present in the checkout, e. g. from other plugins, and the ACCESSIBILITY_TWEAKS flag is active, the validity of those fields is not reported to the user properly.

This was fixed in part with v4.3.7, but for the default TOS checkbox only. With this PR, **all** required input fields in the checkout – including the TOS box – will be validated and reported to the user.

field.reportValidity() has to be called in the event listener callback because the validation message wouldn't be shown for the field otherwise. 


## Tested scenarios
**without ACCESSIBILITY_TWEAKS, before this fix:**
- Attempted to finish checkout with TOS box unchecked – scrolls to and focuses TOS box
- Attempted to finish checkout with a required third party form field left empty – scrolls to and focuses field

**with ACCESSIBILITY_TWEAKS, before this fix:**
- Attempted to finish checkout with TOS box unchecked – scrolls to and focuses TOS box 
- Attempted to finish checkout with a required third party form field left empty – validity is not reported to the user, PayPal window opens for a short moment and closes again

**with ACCESSIBILITY_TWEAKS, after this fix:**
- Attempted to finish checkout with TOS box unchecked – scrolls to and focuses TOS box
- Attempted to finish checkout with a required third party form field left empty – scrolls to and focuses field
