### PR TITLE
Fix: Use AbstractHandlePaymentMethodRoute to support decorators

### DIFF
--- a/src/Service/PaypalPaymentService.php
+++ b/src/Service/PaypalPaymentService.php
@@ -44,11 +44,12 @@ use Shopware\Core\Checkout\Cart\SalesChannel\CartOrderRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Payment\PaymentException;
-use Shopware\Core\Checkout\Payment\SalesChannel\HandlePaymentMethodRoute;
+use Shopware\Core\Checkout\Payment\SalesChannel\AbstractHandlePaymentMethodRoute;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Class PaypalPaymentService.
@@ -63,7 +64,7 @@ readonly class PaypalPaymentService
      * @param PaymentResponseHandler $paymentResponseHandler
      * @param SalesChannelRepository $salesChannelRepository
      * @param CartOrderRoute $cartOrderRoute
-     * @param HandlePaymentMethodRoute $handlePaymentMethodRoute
+     * @param AbstractHandlePaymentMethodRoute $handlePaymentMethodRoute
      * @param ExpressCheckoutService $expressCheckoutService
      * @param CartService $cartService
      * @param PaymentRequestService $paymentRequestService
@@ -74,7 +75,8 @@ readonly class PaypalPaymentService
         private PaymentResponseHandler $paymentResponseHandler,
         private SalesChannelRepository $salesChannelRepository,
         private CartOrderRoute $cartOrderRoute,
-        private HandlePaymentMethodRoute $handlePaymentMethodRoute,
+        #[Autowire(service: 'Shopware\Core\Checkout\Payment\SalesChannel\HandlePaymentMethodRoute')]
+        private AbstractHandlePaymentMethodRoute $handlePaymentMethodRoute,
         private ExpressCheckoutService $expressCheckoutService,
         private CartService $cartService,
         private PaymentRequestService $paymentRequestService


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The strict type-hinting of `HandlePaymentMethodRoute` in `PaypalPaymentService` causes a DI container crash (500 TypeError) when a decorator is applied (e.g., by the Shopware Security Plugin for GHSA-9v5m-39wh-5chq). 

Changed the type to `AbstractHandlePaymentMethodRoute` and added Symfony's `#[Autowire]` attribute to ensure the correct default service is injected while maintaining compatibility with decorators. This aligns the file with the approach already used in other controllers like `FrontendProxyController`.

## Tested scenarios
* Tested on a Shopware 6.5.8.7 instance.
* Verified that the DI container compiles successfully **with** the Shopware Security Plugin active (the decorator is accepted).
* Verified that the DI container compiles successfully **without** the Shopware Security Plugin active (the default Shopware service is injected via Autowire).
* Verified that the checkout process completes for Adyen payment methods without throwing 500 errors.

**Fixed issue**:  #824 